### PR TITLE
fix vertex billboard shader not rendering correctly on metal

### DIFF
--- a/com.unity.probuilder/Content/Shader/VertexShader.shader
+++ b/com.unity.probuilder/Content/Shader/VertexShader.shader
@@ -3,6 +3,7 @@
 	Properties
 	{
 		_Scale("Scale", Range(1,7)) = 3.3
+		_Color ("Color", Color) = (1,1,1,1)
 	}
 
 	SubShader
@@ -31,6 +32,7 @@
 			#include "UnityCG.cginc"
 
 			float _Scale;
+			float4 _Color;
 
 			struct appdata
 			{
@@ -80,7 +82,7 @@
 
 			half4 frag (v2f i) : COLOR
 			{
-				return i.color;
+				return _Color * i.color;
 			}
 
 			ENDCG


### PR DESCRIPTION
fixes the vertex shader not rendering with the correct colors on graphics apis that do not support geometry shaders.