### PR TITLE
Polyshape edition

### DIFF
--- a/com.unity.probuilder/Editor/EditorCore/PolyShapeEditor.cs
+++ b/com.unity.probuilder/Editor/EditorCore/PolyShapeEditor.cs
@@ -312,7 +312,7 @@ namespace UnityEditor.ProBuilder
 
 			if(polygon == null || Tools.current != Tool.None)
 			{
-				polygon.polyEditMode = PolyShape.PolyEditMode.None;
+                SetPolyEditMode(PolyShape.PolyEditMode.None);
 				return;
 			}
 
@@ -716,10 +716,13 @@ namespace UnityEditor.ProBuilder
 		void OnSelectModeChanged(SelectMode selectMode)
 		{
 			// User changed select mode manually, remove InputTool flag
-			if( polygon != null
-				&& polygon.polyEditMode != PolyShape.PolyEditMode.None
-				&& !selectMode.ContainsFlag(SelectMode.InputTool))
-				polygon.polyEditMode = PolyShape.PolyEditMode.None;
+		    if (polygon != null
+		        && polygon.polyEditMode != PolyShape.PolyEditMode.None
+		        && !selectMode.ContainsFlag(SelectMode.InputTool))
+		    {
+		        SetPolyEditMode(PolyShape.PolyEditMode.None);
+
+		    }
 		}
 
 		void OnBeginVertexMovement()


### PR DESCRIPTION
Fix: If a Polyshape is de-selected while "Edit Polyshape" is active, auto-exit the polyshape editing.
Jira: https://unity3d.atlassian.net/browse/WB-866

Fix: If a Polyshape is de-selected and has no points yet, delete it
Jira: https://unity3d.atlassian.net/browse/WB-865