### PR TITLE
Minor fixes

### DIFF
--- a/com.unity.probuilder/Runtime/Core/ShapeGenerator.cs
+++ b/com.unity.probuilder/Runtime/Core/ShapeGenerator.cs
@@ -195,6 +195,7 @@ namespace UnityEngine.ProBuilder
             }
 
             pb.gameObject.name = shape.ToString();
+            pb.renderer.sharedMaterial = BuiltinMaterials.defaultMaterial;
 
             return pb;
         }

--- a/com.unity.probuilder/Settings/Editor/SettingsDictionary.cs
+++ b/com.unity.probuilder/Settings/Editor/SettingsDictionary.cs
@@ -120,7 +120,9 @@ namespace UnityEditor.SettingsManagement
 
                 if (type == null)
                 {
-                    Debug.LogWarning("Could not instantiate type \"" + entry.type + "\". Skipping key: " + entry.key + ".");
+#if PROBUILDER_DEBUG
+	                Debug.LogWarning("Could not instantiate type \"" + entry.type + "\". Skipping key: " + entry.key + ".");
+#endif
                     continue;
                 }
 


### PR DESCRIPTION
- In the `CreateShape(ShapeType)` function initialize shapes with a default material.
- Minor refactoring in lightmapping tests
- Hide a warning that served no purpose to the user (there's nothing they can or need to do in the case where it is triggered)
