### PR TITLE
Fixed toolbar tooltips closing other popup dialogs

### DIFF
--- a/com.unity.probuilder/Editor/EditorCore/TooltipEditor.cs
+++ b/com.unity.probuilder/Editor/EditorCore/TooltipEditor.cs
@@ -48,7 +48,7 @@ namespace UnityEditor.ProBuilder
                 s_Instance.minSize = Vector2.zero;
                 s_Instance.maxSize = Vector2.zero;
                 s_Instance.hideFlags = HideFlags.HideAndDontSave;
-                s_Instance.ShowPopup();
+                s_Instance.ShowTooltip();
 
                 object parent = ReflectionUtility.GetValue(s_Instance, s_Instance.GetType(), "m_Parent");
                 object window = ReflectionUtility.GetValue(parent, parent.GetType(), "window");


### PR DESCRIPTION
*Purpose of this PR*:
Fixed toolbar tooltips closing other popup dialogs

*Functional Testing status*:
Manual testing and ran existing ProBuilder tests to ensure the fix doesn't break other functionality

Technical Risk: 0

*Link to case*:
https://fogbugz.unity3d.com/f/cases/1109523/