### PR TITLE
Lessen edge case where PointInPolygon would return the wrong value

### DIFF
--- a/com.unity.probuilder/Runtime/Core/Math.cs
+++ b/com.unity.probuilder/Runtime/Core/Math.cs
@@ -344,7 +344,13 @@ namespace UnityEngine.ProBuilder
 
             if (bounds.ContainsPoint(point))
             {
-                Vector2 rayStart = bounds.center + Vector2.up * (bounds.size.y + 2f);
+                //Get the direction toward the first edge of the polygon
+                Vector2 p1 = polygon[indexes != null ? indexes[0] : 0];
+                Vector2 p2 = polygon[indexes != null ? indexes[1] : 1];
+                Vector2 center = p1 + (p2 - p1) * 0.5f;
+                Vector2 dir = center - bounds.center;
+
+                Vector2 rayStart = bounds.center + dir * (bounds.size.y + bounds.size.x + 2f);
                 int collisions = 0;
 
                 for (int i = 0; i < len; i += 2)


### PR DESCRIPTION
PointInPolygon previously used Vector2.up for the point used to check if the target point intersects with any of the edges. It meant that if the target point, one point on the polygon and the center of the bounds formed by the polygon had the same Y, the function would say that the point isn't in the polygon.

This situation has a low chance to happen, but this fix lessens it even more where it's highly improbable to happen.