### PR TITLE
Fix Material Editor incompatibilities with SRP materials

### DIFF
--- a/com.unity.probuilder/Editor/EditorCore/EditorMaterialUtility.cs
+++ b/com.unity.probuilder/Editor/EditorCore/EditorMaterialUtility.cs
@@ -1,0 +1,61 @@
+using UnityEngine;
+
+namespace UnityEditor.ProBuilder
+{
+    static class EditorMaterialUtility
+    {
+        internal static Texture2D GetPreviewTexture(Material material)
+        {
+            if (material == null || material.shader == null)
+                return null;
+
+            Texture2D best = null;
+
+            for (int i = 0; i < ShaderUtil.GetPropertyCount(material.shader); i++)
+            {
+                if (ShaderUtil.GetPropertyType(material.shader, i) == ShaderUtil.ShaderPropertyType.TexEnv)
+                {
+                    string propertyName = ShaderUtil.GetPropertyName(material.shader, i);
+
+                    Texture2D tex = material.GetTexture(propertyName) as Texture2D;
+
+                    if (tex != null)
+                    {
+                        if (propertyName.Contains("_MainTex") || propertyName.Contains("Albedo"))
+                            return tex;
+                        else if (best == null)
+                            best = tex;
+                    }
+                }
+            }
+
+            return best;
+        }
+
+        /// <summary>
+        /// Get the material best matching the active mesh selection.
+        /// </summary>
+        internal static Material GetActiveSelection()
+        {
+            var mesh = MeshSelection.activeMesh;
+
+            if (mesh != null)
+            {
+                var face = MeshSelection.activeFace;
+
+                if (face == null)
+                    return mesh.renderer.sharedMaterial;
+
+                var sharedMaterials = mesh.renderer.sharedMaterials;
+
+                if (sharedMaterials != null)
+                {
+                    var length = sharedMaterials.Length;
+                    return sharedMaterials[System.Math.Min(face.submeshIndex, length - 1)];
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/com.unity.probuilder/Editor/EditorCore/EditorMaterialUtility.cs.meta
+++ b/com.unity.probuilder/Editor/EditorCore/EditorMaterialUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6832442ae76f440d9a8a532b98ebfc57
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.probuilder/Editor/EditorCore/MaterialEditor.cs
+++ b/com.unity.probuilder/Editor/EditorCore/MaterialEditor.cs
@@ -99,16 +99,23 @@ namespace UnityEditor.ProBuilder
 
         // The currently loaded material palette asset.
         static MaterialPalette s_CurrentPalette = null;
+
         // The user set "quick material"
-        static Material s_QueuedMaterial;
+        [SerializeField]
+        Material m_QueuedMaterial;
+
         // Custom style for material row background
         GUIStyle m_RowBackgroundStyle;
+
         // The view scroll position.
         Vector2 m_ViewScroll = Vector2.zero;
+
         // All available material palettes
         MaterialPalette[] m_AvailablePalettes = null;
+
         // List of string names for all available palettes (plus one entry for 'Add New')
         string[] m_AvailablePalettes_Str = null;
+        
         // The index of the currently loaded material palette in m_AvailablePalettes
         int m_CurrentPaletteIndex = 0;
 
@@ -189,28 +196,30 @@ namespace UnityEditor.ProBuilder
             GUILayout.BeginHorizontal(GUILayout.MaxWidth(Screen.width - 74));
             GUILayout.BeginVertical();
 
-            s_QueuedMaterial = (Material)EditorGUILayout.ObjectField(s_QueuedMaterial, typeof(Material), true);
+            m_QueuedMaterial = (Material)EditorGUILayout.ObjectField(m_QueuedMaterial, typeof(Material), true);
 
             GUILayout.Space(2);
 
             if (GUILayout.Button("Apply (Ctrl+Shift+Click)"))
-                ApplyMaterial(MeshSelection.topInternal, s_QueuedMaterial);
+                ApplyMaterial(MeshSelection.topInternal, m_QueuedMaterial);
 
             GUI.enabled = editor != null && MeshSelection.selectedFaceCount > 0;
             if (GUILayout.Button("Match Selection"))
             {
-                ProBuilderMesh tp;
-                Face tf;
-                if (editor.GetFirstSelectedFace(out tp, out tf))
-                    s_QueuedMaterial = tf.material;
+                m_QueuedMaterial = EditorMaterialUtility.GetActiveSelection();
             }
             GUI.enabled = true;
 
             GUILayout.EndVertical();
 
             GUI.Box(new Rect(left, r.y + r.height + 2, 64, 64), "");
-            if (s_QueuedMaterial != null && s_QueuedMaterial.mainTexture != null)
-                EditorGUI.DrawPreviewTexture(new Rect(left + 2, r.y + r.height + 4, 60, 60), s_QueuedMaterial.mainTexture, s_QueuedMaterial, ScaleMode.StretchToFill, 0);
+
+            var previewTexture = EditorMaterialUtility.GetPreviewTexture(m_QueuedMaterial);
+
+            if (previewTexture != null)
+            {
+                GUI.Label(new Rect(left + 2, r.y + r.height + 4, 60, 60), previewTexture);
+            }
             else
             {
                 GUI.Box(new Rect(left + 2, r.y + r.height + 4, 60, 60), "");
@@ -329,7 +338,7 @@ namespace UnityEditor.ProBuilder
                 if (em == (EventModifiers.Control | EventModifiers.Shift))
                 {
                     UndoUtility.RecordObject(pb, "Quick Apply");
-                    quad.material = s_QueuedMaterial;
+                    quad.material = m_QueuedMaterial;
                     pb.ToMesh();
                     pb.Refresh();
                     pb.Optimize();

--- a/com.unity.probuilder/Editor/EditorCore/MeshSelection.cs
+++ b/com.unity.probuilder/Editor/EditorCore/MeshSelection.cs
@@ -112,6 +112,11 @@ namespace UnityEditor.ProBuilder
             get { return s_ActiveMesh; }
         }
 
+        internal static Face activeFace
+        {
+            get { return activeMesh != null ? activeMesh.selectedFacesInternal.LastOrDefault() : null; }
+        }
+
         /// <value>
         /// Receive notifications when the object selection changes.
         /// </value>

--- a/com.unity.probuilder/Editor/EditorCore/Model.cs
+++ b/com.unity.probuilder/Editor/EditorCore/Model.cs
@@ -78,7 +78,7 @@ namespace UnityEditor.ProBuilder
             mesh.Refresh(RefreshMask.UV | RefreshMask.Colors | RefreshMask.Normals | RefreshMask.Tangents);
             this.name = name;
             vertices = mesh.GetVertices();
-            submeshes = Submesh.GetSubmeshes(mesh.facesInternal, UnityEngine.ProBuilder.MeshUtility.GetMaterialCount(mesh.renderer), quads ? MeshTopology.Quads : MeshTopology.Triangles);
+            submeshes = Submesh.GetSubmeshes(mesh.facesInternal, MaterialUtility.GetMaterialCount(mesh.renderer), quads ? MeshTopology.Quads : MeshTopology.Triangles);
             materials = new Material[submeshCount];
 
             for (int i = 0; i < submeshCount; ++i)

--- a/com.unity.probuilder/Editor/EditorCore/ProBuilderEditor.cs
+++ b/com.unity.probuilder/Editor/EditorCore/ProBuilderEditor.cs
@@ -1186,28 +1186,5 @@ namespace UnityEditor.ProBuilder
 
             return true;
         }
-
-        /// <summary>
-        /// Returns the first selected pb_Object and pb_Face, or false if not found.
-        /// </summary>
-        /// <param name="mat"></param>
-        /// <returns></returns>
-        internal Material GetFirstSelectedMaterial()
-        {
-            for (int i = 0; i < selection.Length; i++)
-            {
-                var mesh = selection[i];
-
-                for (int n = 0; n < mesh.selectedFaceCount; n++)
-                {
-                    var face = mesh.selectedFacesInternal[i];
-                    var mat = UnityEngine.ProBuilder.MeshUtility.GetSharedMaterial(selection[i].renderer, face.submeshIndex);
-                    if (mat != null)
-                        return mat;
-                }
-            }
-
-            return null;
-        }
     }
 }

--- a/com.unity.probuilder/Editor/EditorCore/SceneDragAndDropListener.cs
+++ b/com.unity.probuilder/Editor/EditorCore/SceneDragAndDropListener.cs
@@ -179,11 +179,11 @@ namespace UnityEditor.ProBuilder
 
                     s_CurrentPreview.SetMaterial(s_CurrentPreview.selectedFacesInternal, s_PreviewMaterial);
 
+                    InternalMeshUtility.FilterUnusedSubmeshIndexes(s_CurrentPreview);
+
                     s_CurrentPreview.ToMesh();
                     s_CurrentPreview.Refresh();
                     s_CurrentPreview.Optimize();
-
-                    InternalMeshUtility.FilterUnusedSubmeshIndexes(s_CurrentPreview);
 
                     evt.Use();
                 }

--- a/com.unity.probuilder/Editor/EditorCore/UVEditor.cs
+++ b/com.unity.probuilder/Editor/EditorCore/UVEditor.cs
@@ -1766,34 +1766,6 @@ namespace UnityEditor.ProBuilder
         // re-usable rect for drawing graphs
         Rect r = new Rect(0, 0, 0, 0);
 
-        internal static Texture2D GetMainTexture(Material material)
-        {
-            if (material == null || material.shader == null)
-                return null;
-
-            Texture2D best = null;
-
-            for (int i = 0; i < ShaderUtil.GetPropertyCount(material.shader); i++)
-            {
-                if (ShaderUtil.GetPropertyType(material.shader, i) == ShaderUtil.ShaderPropertyType.TexEnv)
-                {
-                    string propertyName = ShaderUtil.GetPropertyName(material.shader, i);
-
-                    Texture2D tex = material.GetTexture(propertyName) as Texture2D;
-
-                    if (tex != null)
-                    {
-                        if (propertyName.Contains("_MainTex") || propertyName.Contains("Albedo"))
-                            return tex;
-                        else if (best == null)
-                            best = tex;
-                    }
-                }
-            }
-
-            return best;
-        }
-
         private void DrawUVGraph(Rect rect)
         {
             var evt = Event.current;
@@ -1806,7 +1778,7 @@ namespace UnityEditor.ProBuilder
             UVRectIdentity.x = UVGraphCenter.x + uvGraphOffset.x;
             UVRectIdentity.y = UVGraphCenter.y + uvGraphOffset.y - UVRectIdentity.height;
 
-            var texture = GetMainTexture(m_PreviewMaterial);
+            var texture = EditorMaterialUtility.GetPreviewTexture(m_PreviewMaterial);
 
             if (m_ShowPreviewMaterial && m_PreviewMaterial && texture != null)
                 EditorGUI.DrawPreviewTexture(UVRectIdentity, texture, null, ScaleMode.StretchToFill, 0);
@@ -2442,7 +2414,7 @@ namespace UnityEditor.ProBuilder
                 mode = UVMode.Manual;
             }
 
-            m_PreviewMaterial = editor.GetFirstSelectedMaterial();
+            m_PreviewMaterial = EditorMaterialUtility.GetActiveSelection();
 
             handlePosition = UVSelectionBounds().center - handlePosition_offset;
         }

--- a/com.unity.probuilder/Runtime/Core/MaterialUtility.cs
+++ b/com.unity.probuilder/Runtime/Core/MaterialUtility.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace UnityEngine.ProBuilder
+{
+    static class MaterialUtility
+    {
+#if UNITY_2018_2_OR_NEWER
+        static List<Material> s_MaterialArray = new List<Material>();
+#endif
+
+        internal static int GetMaterialCount(Renderer renderer)
+        {
+#if UNITY_2018_2_OR_NEWER
+            s_MaterialArray.Clear();
+            renderer.GetSharedMaterials(s_MaterialArray);
+            return s_MaterialArray.Count;
+#else
+            return renderer.sharedMaterials.Length;
+#endif
+        }
+
+        internal static Material GetSharedMaterial(Renderer renderer, int index)
+        {
+#if UNITY_2018_2_OR_NEWER
+            s_MaterialArray.Clear();
+            renderer.GetSharedMaterials(s_MaterialArray);
+            var count = s_MaterialArray.Count;
+            if (count < 1)
+                return null;
+            return s_MaterialArray[Math.Clamp(index, 0, count - 1)];
+#else
+            var array = renderer.sharedMaterials;
+            var count = array == null ? 0 : array.Length;
+            if (count < 1)
+                return null;
+            return array[Math.Clamp(index, 0, count - 1)];
+#endif
+        }
+    }
+}

--- a/com.unity.probuilder/Runtime/Core/MaterialUtility.cs.meta
+++ b/com.unity.probuilder/Runtime/Core/MaterialUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a419cef8f67fa48b8a2420ecc4ea4936
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.probuilder/Runtime/Core/MeshUtility.cs
+++ b/com.unity.probuilder/Runtime/Core/MeshUtility.cs
@@ -12,38 +12,6 @@ namespace UnityEngine.ProBuilder
     /// </summary>
     public static class MeshUtility
     {
-#if UNITY_2018_2_OR_NEWER
-        static List<Material> s_MaterialArray = new List<Material>();
-#endif
-
-        internal static int GetMaterialCount(Renderer renderer)
-        {
-#if UNITY_2018_2_OR_NEWER
-            s_MaterialArray.Clear();
-            renderer.GetSharedMaterials(s_MaterialArray);
-            return s_MaterialArray.Count;
-#else
-            return renderer.sharedMaterials.Length;
-#endif
-        }
-
-        internal static Material GetSharedMaterial(Renderer renderer, int index)
-        {
-#if UNITY_2018_2_OR_NEWER
-            s_MaterialArray.Clear();
-            renderer.GetSharedMaterials(s_MaterialArray);
-            var count = s_MaterialArray.Count;
-            if (count < 1)
-                return null;
-            return s_MaterialArray[Math.Clamp(index, 0, count - 1)];
-#else
-            var array = renderer.sharedMaterials;
-            var count = array == null ? 0 : array.Length;
-            if (count < 1)
-                return null;
-            return array[Math.Clamp(index, 0, count - 1)];
-#endif
-        }
 
         /// <summary>
         /// Create an array of @"UnityEngine.ProBuilder.Vertex" values that are ordered as individual triangles. This modifies the source mesh to match the new individual triangles format.

--- a/com.unity.probuilder/Runtime/Core/ProBuilderMeshFunction.cs
+++ b/com.unity.probuilder/Runtime/Core/ProBuilderMeshFunction.cs
@@ -229,7 +229,7 @@ namespace UnityEngine.ProBuilder
 
             m_MeshFormatVersion = k_MeshFormatVersion;
 
-            int materialCount = MeshUtility.GetMaterialCount(renderer);
+            int materialCount = MaterialUtility.GetMaterialCount(renderer);
 
             Submesh[] submeshes = Submesh.GetSubmeshes(facesInternal, materialCount, preferredTopology);
 


### PR DESCRIPTION
- Fix an error where the Material Editor window would turn completely black when an SRP material is assigned to the "Quick Material" field
- Fix "Match Selection" button not taking the active face selection (previously it took the first selected face, now it matches the active selection, or last selected 👈  @gabrielw-us )

https://fogbugz.unity3d.com/f/cases/1125118/