### PR TITLE
Added dynamic picking distance based on current object hovered

### DIFF
--- a/com.unity.probuilder/Editor/EditorCore/EditorSceneViewPicker.cs
+++ b/com.unity.probuilder/Editor/EditorCore/EditorSceneViewPicker.cs
@@ -23,7 +23,7 @@ namespace UnityEditor.ProBuilder
         public static Pref<float> pickingDistance = new Pref<float>("picking.pickingDistance", 128f, SettingsScope.User);
 
         [UserSetting]
-        public static Pref<float> offObjectMultiplier = new Pref<float>("picking.offObjectMultiplier", 128f, SettingsScope.User);
+        public static Pref<float> offObjectMultiplier = new Pref<float>("picking.offObjectMultiplier", 10f, SettingsScope.User);
 
         public const float maxPointerDistanceFuzzy = 128f;
         public const float maxPointerDistancePrecise = 12f;

--- a/com.unity.probuilder/Editor/EditorCore/EditorSceneViewPicker.cs
+++ b/com.unity.probuilder/Editor/EditorCore/EditorSceneViewPicker.cs
@@ -12,25 +12,6 @@ namespace UnityEditor.ProBuilder
 {
     struct ScenePickerPreferences
     {
-        [UserSettingBlock("Picking")]
-        static void HandlePickingPreferences(string searchContext)
-        {
-            pickingDistance.value = Mathf.Max(0, SettingsGUILayout.SearchableFloatField("Picking Distance", pickingDistance, searchContext));
-            offObjectMultiplier.value = Mathf.Max(0, SettingsGUILayout.SearchableFloatField("Off Object Multiplier", offObjectMultiplier, searchContext));
-        }
-
-        [UserSetting]
-        public static Pref<float> pickingDistance = new Pref<float>("picking.pickingDistance", 128f, SettingsScope.User);
-
-        [UserSetting]
-        public static Pref<float> offObjectMultiplier = new Pref<float>("picking.offObjectMultiplier", 10f, SettingsScope.User);
-
-        public const float maxPointerDistanceFuzzy = 128f;
-        public const float maxPointerDistancePrecise = 12f;
-        public const CullingMode defaultCullingMode = CullingMode.Back;
-        public const SelectionModifierBehavior defaultSelectionModifierBehavior = SelectionModifierBehavior.Difference;
-        public const RectSelectMode defaultRectSelectionMode = RectSelectMode.Partial;
-
         public float maxPointerDistance;
         public float offPointerMultiplier;
         public CullingMode cullMode;

--- a/com.unity.probuilder/Editor/EditorCore/ProBuilderEditor.cs
+++ b/com.unity.probuilder/Editor/EditorCore/ProBuilderEditor.cs
@@ -374,7 +374,8 @@ namespace UnityEditor.ProBuilder
 
             m_ScenePickerPreferences = new ScenePickerPreferences()
             {
-                maxPointerDistance = ScenePickerPreferences.maxPointerDistanceFuzzy,
+                offPointerMultiplier = ScenePickerPreferences.offObjectMultiplier,
+                maxPointerDistance = ScenePickerPreferences.pickingDistance,
                 cullMode = m_BackfaceSelectEnabled ? CullingMode.None : CullingMode.Back,
                 selectionModifierBehavior = m_SelectModifierBehavior,
                 rectSelectMode = m_DragSelectRectMode

--- a/com.unity.probuilder/Editor/EditorCore/ProBuilderEditor.cs
+++ b/com.unity.probuilder/Editor/EditorCore/ProBuilderEditor.cs
@@ -63,6 +63,9 @@ namespace UnityEditor.ProBuilder
         [UserSetting("Toolbar", "Toolbar Location", "Where the Object, Face, Edge, and Vertex toolbar will be shown in the Scene View.")]
         static Pref<SceneToolbarLocation> s_SceneToolbarLocation = new Pref<SceneToolbarLocation>("editor.sceneToolbarLocation", SceneToolbarLocation.UpperCenter, SettingsScope.User);
 
+        [UserSetting()]
+        static Pref<float> s_PickingDistance = new Pref<float>("picking.pickingDistance", 128f, SettingsScope.User);
+
         static Pref<bool> s_WindowIsFloating = new Pref<bool>("UnityEngine.ProBuilder.ProBuilderEditor-isUtilityWindow", false, SettingsScope.Project);
 
         internal Pref<bool> m_BackfaceSelectEnabled = new Pref<bool>("editor.backFaceSelectEnabled", false);
@@ -213,6 +216,14 @@ namespace UnityEditor.ProBuilder
         }
 
         Stack<SelectMode> m_SelectModeHistory = new Stack<SelectMode>();
+
+        [UserSettingBlock("Picking")]
+        static void PickingPreferences(string searchContext)
+        {
+            s_PickingDistance.value = SettingsGUILayout.SearchableSlider(
+                new GUIContent("Picking Distance", "Distance to an object before it's considered hovered."),
+                s_PickingDistance.value, 1, 150, searchContext);
+        }
 
         internal static void PushSelectMode(SelectMode mode)
         {
@@ -374,8 +385,8 @@ namespace UnityEditor.ProBuilder
 
             m_ScenePickerPreferences = new ScenePickerPreferences()
             {
-                offPointerMultiplier = ScenePickerPreferences.offObjectMultiplier,
-                maxPointerDistance = ScenePickerPreferences.pickingDistance,
+                offPointerMultiplier = s_PickingDistance * 0.1f, //Multiplier is 10% of the picking distance
+                maxPointerDistance = s_PickingDistance,
                 cullMode = m_BackfaceSelectEnabled ? CullingMode.None : CullingMode.Back,
                 selectionModifierBehavior = m_SelectModifierBehavior,
                 rectSelectMode = m_DragSelectRectMode

--- a/com.unity.probuilder/Editor/EditorCore/ProBuilderEditor.cs
+++ b/com.unity.probuilder/Editor/EditorCore/ProBuilderEditor.cs
@@ -66,7 +66,7 @@ namespace UnityEditor.ProBuilder
         [UserSetting("Toolbar", "Toolbar Location", "Where the Object, Face, Edge, and Vertex toolbar will be shown in the Scene View.")]
         static Pref<SceneToolbarLocation> s_SceneToolbarLocation = new Pref<SceneToolbarLocation>("editor.sceneToolbarLocation", SceneToolbarLocation.UpperCenter, SettingsScope.User);
 
-        [UserSetting()]
+        [UserSetting]
         static Pref<float> s_PickingDistance = new Pref<float>("picking.pickingDistance", 128f, SettingsScope.User);
 
         static Pref<bool> s_WindowIsFloating = new Pref<bool>("UnityEngine.ProBuilder.ProBuilderEditor-isUtilityWindow", false, SettingsScope.Project);
@@ -220,7 +220,7 @@ namespace UnityEditor.ProBuilder
 
         Stack<SelectMode> m_SelectModeHistory = new Stack<SelectMode>();
 
-        [UserSettingBlock("Picking")]
+        [UserSettingBlock(UserSettingsProvider.developerModeCategory)]
         static void PickingPreferences(string searchContext)
         {
             s_PickingDistance.value = SettingsGUILayout.SearchableSlider(

--- a/com.unity.probuilder/Editor/EditorCore/ProBuilderEditor.cs
+++ b/com.unity.probuilder/Editor/EditorCore/ProBuilderEditor.cs
@@ -22,6 +22,9 @@ namespace UnityEditor.ProBuilder
         // Match the value set in RectSelection.cs
         const float k_MouseDragThreshold = 6f;
 
+        //Off pointer multiplier is a percentage of the picking distance
+        const float k_OffPointerMultiplierPercent = 0.1f;  
+
         /// <value>
         /// Raised any time the ProBuilder editor refreshes the selection. This is called every frame when interacting with mesh elements, and after any mesh operation.
         /// </value>
@@ -385,7 +388,7 @@ namespace UnityEditor.ProBuilder
 
             m_ScenePickerPreferences = new ScenePickerPreferences()
             {
-                offPointerMultiplier = s_PickingDistance * 0.1f, //Multiplier is 10% of the picking distance
+                offPointerMultiplier = s_PickingDistance * k_OffPointerMultiplierPercent,
                 maxPointerDistance = s_PickingDistance,
                 cullMode = m_BackfaceSelectEnabled ? CullingMode.None : CullingMode.Back,
                 selectionModifierBehavior = m_SelectModifierBehavior,


### PR DESCRIPTION
[Jira: WB-996]

**Problem:** 
With the currently high picking distance being the only option, selecting another object near your current selection can be annoying (See image bellow).

![selection](https://user-images.githubusercontent.com/44209648/53349271-c3ccea80-38ea-11e9-83fa-1f1ca50c970b.png)

**Solution:**
A modifier is now applied to the distance of a vertex/edge if the user is currently hovering another probuilder mesh. This prioritizes the hovered mesh over the selected mesh.

I also added a slider for picking distance in preferences to make it available in developer mode. (Default value stays what the constant value used to be).

![image](https://user-images.githubusercontent.com/44209648/53508683-37f0c500-3a88-11e9-8de0-61c1e0055bbc.png)

