### PR TITLE
Deep selection on faces shouldn't trigger when multiple faces are selected

### DIFF
--- a/com.unity.probuilder/Editor/EditorCore/EditorSceneViewPicker.cs
+++ b/com.unity.probuilder/Editor/EditorCore/EditorSceneViewPicker.cs
@@ -26,6 +26,7 @@ namespace UnityEditor.ProBuilder
     static class EditorSceneViewPicker
     {
         static int s_DeepSelectionPrevious = 0x0;
+        static bool s_AppendModifierPreviousState = false;
         static SceneSelection s_Selection = new SceneSelection();
         static List<VertexPickerEntry> s_NearestVertices = new List<VertexPickerEntry>();
         static List<GameObject> s_OverlappingGameObjects = new List<GameObject>();
@@ -295,6 +296,14 @@ namespace UnityEditor.ProBuilder
             // If any event modifiers are engaged don't cycle the deep click
             EventModifiers em = Event.current.modifiers;
 
+            // Reset cycle if we used an event modifier previously.
+            // Move state back to single selection.
+            if ((em != EventModifiers.None) != s_AppendModifierPreviousState)
+            {
+                s_AppendModifierPreviousState = (em != EventModifiers.None);
+                s_DeepSelectionPrevious = newHash;
+            }
+            
             if (isPreview || em != EventModifiers.None)
                 EditorHandleUtility.GetHovered(mousePosition, s_OverlappingGameObjects);
             else


### PR DESCRIPTION
(WIP - REQUESTING QA FIRST)

Goal of this PR:
When picking Faces, sometimes deep selection is triggered when we try to pick a face that has been already selected through Ctrl + Click action. This PR fixes this by storing the append selection state. We reset the DeepSelectionPrevious when we switch from/to append selection.

Fix this case: https://unity3d.atlassian.net/browse/WB-424
