### PR TITLE
Fix MaterialEditor not filtering out unused submesh index when applying new material.

### DIFF
--- a/com.unity.probuilder/Editor/EditorCore/MaterialEditor.cs
+++ b/com.unity.probuilder/Editor/EditorCore/MaterialEditor.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine.ProBuilder;
+using UnityEngine.ProBuilder.MeshOperations;
 
 namespace UnityEditor.ProBuilder
 {
@@ -360,6 +361,7 @@ namespace UnityEditor.ProBuilder
             foreach (var mesh in selection)
             {
                 mesh.SetMaterial(mesh.selectedFaceCount > 0 ? mesh.GetSelectedFaces() : mesh.facesInternal, mat);
+                InternalMeshUtility.FilterUnusedSubmeshIndexes(mesh);
                 mesh.Rebuild();
                 mesh.Optimize();
             }


### PR DESCRIPTION
Fix this case: https://unity3d.atlassian.net/browse/WB-1193