### PR TITLE
Fixed edge hover goes through selected mesh

### DIFF
--- a/com.unity.probuilder/Editor/EditorCore/EditorSceneViewPicker.cs
+++ b/com.unity.probuilder/Editor/EditorCore/EditorSceneViewPicker.cs
@@ -552,7 +552,7 @@ namespace UnityEditor.ProBuilder
         {
             var camPos = SceneView.lastActiveSceneView.camera.transform.position;
             var closestDistToScreen = Mathf.Infinity;
-            Edge closest = default;
+            Edge closest = default(Edge);
 
             foreach (var edge in edges)
             {


### PR DESCRIPTION
[Jira: WB-1217]

**Problem:**
If the vertex is the closest point to the mouse, one of the 3 edges that connect that vertex will be hovered, even if it's behind the mesh.
![image](https://user-images.githubusercontent.com/44209648/53371938-951d3700-391f-11e9-9a75-ddb759f2964f.png)

**Solution:**
Check the distance to the camera when multiple edge have the closest distance to the mouse to determine which one is closer.