### PR TITLE
Changed the workflow of preview mesh in the Shape Tool

### DIFF
--- a/com.unity.probuilder/Editor/EditorCore/ShapeEditor.cs
+++ b/com.unity.probuilder/Editor/EditorCore/ShapeEditor.cs
@@ -190,6 +190,9 @@ namespace UnityEditor.ProBuilder
                 if (!originalComponents.Contains(component))
                 {
                     var copy = target.AddComponent(component.GetType());
+                    if (copy == null)
+                        continue;
+
                     UnityEditor.EditorUtility.CopySerialized(component, copy);
                 }
             }

--- a/com.unity.probuilder/Editor/EditorCore/ShapeEditor.cs
+++ b/com.unity.probuilder/Editor/EditorCore/ShapeEditor.cs
@@ -69,7 +69,7 @@ namespace UnityEditor.ProBuilder
         {
             if (m_PreviewObject != null && m_PreviewObject.transform.childCount >= 1)
             {
-                CreateSelectedShape();
+                CreateSelectedShape(autosave: true);
             }
             else
             {
@@ -117,9 +117,10 @@ namespace UnityEditor.ProBuilder
                 CreateSelectedShape();
         }
 
-        void CreateSelectedShape(bool forceCloseWindow = false)
+        void CreateSelectedShape(bool forceCloseWindow = false, bool autosave = false)
         {
             var res = m_ShapeBuilders[s_CurrentIndex].Build();
+            if (autosave) res.name = res.name + " (autosaved)";
             EditorUtility.InitObject(res);
             ApplyPreviewTransform(res);
             CopyAddedComponents(m_PreviewObject, m_OriginalComponents, res.gameObject);

--- a/com.unity.probuilder/Editor/EditorCore/ShapeEditor.cs
+++ b/com.unity.probuilder/Editor/EditorCore/ShapeEditor.cs
@@ -153,7 +153,7 @@ namespace UnityEditor.ProBuilder
         {
             ApplyPreviewTransform(mesh);
 
-            DestroyPreviewObject();
+            DestroyPreviewObject(mesh);
 
             mesh.selectable = false;
             m_PreviewObject = mesh.gameObject;

--- a/com.unity.probuilder/Editor/EditorCore/ShapeEditor.cs
+++ b/com.unity.probuilder/Editor/EditorCore/ShapeEditor.cs
@@ -1,7 +1,5 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using UnityEngine;
 using UnityEngine.ProBuilder;
 using UnityEditor.SettingsManagement;
@@ -69,7 +67,14 @@ namespace UnityEditor.ProBuilder
 
         void OnDestroy()
         {
-            DestroyPreviewObject();
+            if (m_PreviewObject != null && m_PreviewObject.transform.childCount >= 1)
+            {
+                CreateSelectedShape();
+            }
+            else
+            {
+                DestroyPreviewObject();
+            }
         }
 
         [MenuItem("GameObject/3D Object/" + PreferenceKeys.pluginTitle + " Cube _%k")]
@@ -142,10 +147,7 @@ namespace UnityEditor.ProBuilder
             int childCount;
             if (m_PreviewObject != null && (childCount = m_PreviewObject.transform.childCount) > 0)
             {
-                Transform parent = target != null
-                    ? target.transform
-                    : new GameObject("Preview Hierarchy Backup").transform;
-
+                Transform parent = target != null ? target.transform : null;
                 for (int i = childCount - 1; i >= 0; --i)
                 {
                     var child = m_PreviewObject.transform.GetChild(i);

--- a/com.unity.probuilder/Editor/EditorCore/ShapeEditor.cs
+++ b/com.unity.probuilder/Editor/EditorCore/ShapeEditor.cs
@@ -113,20 +113,39 @@ namespace UnityEditor.ProBuilder
             var res = m_ShapeBuilders[s_CurrentIndex].Build();
             EditorUtility.InitObject(res);
             ApplyPreviewTransform(res);
-            DestroyPreviewObject();
+            DestroyPreviewObject(res);
 
             if (forceCloseWindow || s_CloseWindowAfterCreateShape)
                 Close();
         }
 
-        void DestroyPreviewObject()
+        void DestroyPreviewObject(ProBuilderMesh result = null)
         {
             if (m_PreviewObject != null)
             {
+                ReparentPreviewChildren(result);
+
                 if (m_PreviewObject.GetComponent<MeshFilter>().sharedMesh != null)
                     DestroyImmediate(m_PreviewObject.GetComponent<MeshFilter>().sharedMesh);
 
                 DestroyImmediate(m_PreviewObject);
+            }
+        }
+
+        void ReparentPreviewChildren(ProBuilderMesh target)
+        {
+            int childCount;
+            if (m_PreviewObject != null && (childCount = m_PreviewObject.transform.childCount) > 0)
+            {
+                Transform parent = target != null
+                    ? target.transform
+                    : new GameObject("Preview Hierarchy Backup").transform;
+
+                for (int i = childCount - 1; i >= 0; --i)
+                {
+                    var child = m_PreviewObject.transform.GetChild(i);
+                    child.SetParent(parent);
+                }
             }
         }
 

--- a/com.unity.probuilder/Editor/EditorCore/ShapeEditor.cs
+++ b/com.unity.probuilder/Editor/EditorCore/ShapeEditor.cs
@@ -67,6 +67,8 @@ namespace UnityEditor.ProBuilder
 
         void OnDestroy()
         {
+            //In the case where the user added children to the preview,
+            //create shape instead so the user doesn't lose what he was doing.
             if (m_PreviewObject != null && m_PreviewObject.transform.childCount >= 1)
             {
                 CreateSelectedShape(autosave: true);


### PR DESCRIPTION
[Jira: WB-306]

**Problem:**
In the Shape Tool, Creating/Canceling/Changing values regenerates the objects. This deletes every object that was parented on it and removes every added component. This is not a thing that user usually do but it is a pain point for people that make that mistake.

**Solution:**
Hierarchy and added component now stays when modifying the object and building it. In the case of a cancel, if the user has added children to the shape hierarchy, we build it instead of deleting it.