### PR TITLE
Fixed Shape Tool create not being added to the undo stack

### DIFF
--- a/com.unity.probuilder/Editor/EditorCore/ShapeEditor.cs
+++ b/com.unity.probuilder/Editor/EditorCore/ShapeEditor.cs
@@ -115,6 +115,8 @@ namespace UnityEditor.ProBuilder
             ApplyPreviewTransform(res);
             DestroyPreviewObject();
 
+            Undo.RegisterCreatedObjectUndo(res.gameObject, "Create Shape");
+
             if (forceCloseWindow || s_CloseWindowAfterCreateShape)
                 Close();
         }


### PR DESCRIPTION
Using the shape tool to build an object should now dirty the scene and the action should be undoable.