### PR TITLE
Add missing tool info in SceneView

### DIFF
--- a/com.unity.probuilder/Editor/EditorCore/PositionMoveTool.cs
+++ b/com.unity.probuilder/Editor/EditorCore/PositionMoveTool.cs
@@ -125,7 +125,7 @@ namespace UnityEditor.ProBuilder
 
             // Draw at the end so we get the snapped value
             if(showHandleInfo && isEditing)
-                DrawDeltaInfo("Translate: " + delta.ToString("0.00"));
+                DrawDeltaInfo("Translate: " + (handleRotationOriginInverse * delta).ToString("0.00"));
         }
 
         void ApplyTranslation(Vector3 translation)

--- a/com.unity.probuilder/Editor/EditorCore/PositionMoveTool.cs
+++ b/com.unity.probuilder/Editor/EditorCore/PositionMoveTool.cs
@@ -125,7 +125,7 @@ namespace UnityEditor.ProBuilder
 
             // Draw at the end so we get the snapped value
             if(showHandleInfo && isEditing)
-                DrawDeltaInfo("Translate: " + (handleRotationOriginInverse * delta).ToString("0.00"));
+                DrawDeltaInfo(string.Format("Translate: <b>{0:F2}</b>  {1}", delta.magnitude, (handleRotationOriginInverse * delta).ToString("0.00")));
         }
 
         void ApplyTranslation(Vector3 translation)

--- a/com.unity.probuilder/Editor/EditorCore/PositionMoveTool.cs
+++ b/com.unity.probuilder/Editor/EditorCore/PositionMoveTool.cs
@@ -50,6 +50,7 @@ namespace UnityEditor.ProBuilder
             m_HandlePosition = Handles.PositionHandle(m_HandlePosition, handleRotation);
 
             m_RawHandleDelta = m_HandlePosition - handlePositionOrigin;
+
             var delta = m_RawHandleDelta;
 
             if (EditorGUI.EndChangeCheck() && delta.sqrMagnitude > k_MinTranslateDeltaSqrMagnitude)
@@ -121,6 +122,10 @@ namespace UnityEditor.ProBuilder
 
                 ApplyTranslation(handleRotationOriginInverse * delta);
             }
+
+            // Draw at the end so we get the snapped value
+            if(showHandleInfo && isEditing)
+                DrawDeltaInfo("Translate: " + delta.ToString("0.00"));
         }
 
         void ApplyTranslation(Vector3 translation)

--- a/com.unity.probuilder/Editor/EditorCore/PositionRotateTool.cs
+++ b/com.unity.probuilder/Editor/EditorCore/PositionRotateTool.cs
@@ -11,6 +11,16 @@ namespace UnityEditor.ProBuilder
         {
             base.DoTool(handlePosition, handleRotation);
 
+            if (showHandleInfo && isEditing)
+            {
+                var euler = m_Rotation.eulerAngles;
+
+                DrawDeltaInfo(string.Format("Rotate: {0,5:##0.00}, {1,5:##0.00}, {2,5:##0.00}",
+                    euler.x,
+                    euler.y,
+                    euler.z));
+            }
+
             EditorGUI.BeginChangeCheck();
 
             if (!isEditing)

--- a/com.unity.probuilder/Editor/EditorCore/PositionScaleTool.cs
+++ b/com.unity.probuilder/Editor/EditorCore/PositionScaleTool.cs
@@ -11,6 +11,9 @@ namespace UnityEditor.ProBuilder
         {
             base.DoTool(handlePosition, handleRotation);
 
+            if (showHandleInfo && isEditing)
+                DrawDeltaInfo("Scale: " + m_Scale.ToString("0.00"));
+
             if (!isEditing)
                 m_Scale = Vector3.one;
 

--- a/com.unity.probuilder/Editor/EditorCore/ProBuilderEditor.cs
+++ b/com.unity.probuilder/Editor/EditorCore/ProBuilderEditor.cs
@@ -778,28 +778,6 @@ namespace UnityEditor.ProBuilder
 
                 selectMode = UI.EditorGUIUtility.DoElementModeToolbar(m_ElementModeToolbarRect, selectMode);
 
-                // todo Move to VertexManipulationTool
-//              if (m_IsMovingElements && s_ShowSceneInfo)
-//              {
-//                  string handleTransformInfo = string.Format(
-//                      "translate: <b>{0}</b>\nrotate: <b>{1}</b>\nscale: <b>{2}</b>",
-//                      (m_ElementHandlePosition - m_TranslateOrigin).ToString(),
-//                      (m_HandleRotation.eulerAngles - m_RotateOrigin).ToString(),
-//                      (m_HandleScale - m_ScaleOrigin).ToString());
-//
-//                  var gc = UI.EditorGUIUtility.TempContent(handleTransformInfo);
-//                  // sceneview screen.height includes the tab and toolbar
-//                  var toolbarHeight = EditorStyles.toolbar.CalcHeight(gc, Screen.width);
-//                  var size = UI.EditorStyles.sceneTextBox.CalcSize(gc);
-//
-//                  Rect handleTransformInfoRect = new Rect(
-//                      sceneView.position.width - (size.x + 8), sceneView.position.height - (size.y + 8 + toolbarHeight),
-//                      size.x,
-//                      size.y);
-//
-//                  GUI.Label(handleTransformInfoRect, gc, UI.EditorStyles.sceneTextBox);
-//              }
-
                 if (s_ShowSceneInfo)
                 {
                     Vector2 size = UI.EditorStyles.sceneTextBox.CalcSize(m_SceneInfo);


### PR DESCRIPTION
Prior to 4.0.0 there was a display for scene view tool deltas. It got lost in the tools refactor, and this PR adds it back in as a part of the `PositionTool`.