### PR TITLE
Editor/fix picking prefab mode

### DIFF
--- a/com.unity.probuilder/Runtime/Core/InternalUtility.cs
+++ b/com.unity.probuilder/Runtime/Core/InternalUtility.cs
@@ -2,8 +2,11 @@ using UnityEngine;
 using System;
 using System.Linq;
 using System.Collections.Generic;
-using UnityEditor.SceneManagement;
 using UnityEngine.Assertions;
+
+#if UNITY_EDITOR
+using UnityEditor.SceneManagement;
+#endif
 
 namespace UnityEngine.ProBuilder
 {
@@ -44,7 +47,10 @@ namespace UnityEngine.ProBuilder
             go.transform.localRotation      = t.localRotation;
             go.transform.localScale         = t.localScale;
             
+            #if UNITY_EDITOR
             StageUtility.PlaceGameObjectInCurrentStage(go);
+            #endif
+            
             return go;
         }
 

--- a/com.unity.probuilder/Runtime/Core/InternalUtility.cs
+++ b/com.unity.probuilder/Runtime/Core/InternalUtility.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using UnityEditor.SceneManagement;
 using UnityEngine.Assertions;
 
 namespace UnityEngine.ProBuilder
@@ -42,6 +43,8 @@ namespace UnityEngine.ProBuilder
             go.transform.position           = t.position;
             go.transform.localRotation      = t.localRotation;
             go.transform.localScale         = t.localScale;
+            
+            StageUtility.PlaceGameObjectInCurrentStage(go);
             return go;
         }
 


### PR DESCRIPTION
**Goal of this PR:**
PB picking doesn't work in Prefab mode. PB spawns temporary objects in its picking system then use the active camera to know what the user has selected. However, Prefab mode uses a different scene. Even if this different scene is active, each newly created GameObject go to the main scene (the active scene in hierachy). We need to call StageUtility.PlaceGameObjectInCurrentStage(...) to make sure GameObjects are being instantiated in the proper scene. In "normal" mode, this shouldn't affect the picking behaviour as it would simply let the GameObject in the main scene.

**Note 1**: Jira indicates the issue occurs with Vertex selection, but it also affect Edges and Faces selection in Prefab mode.

**Note 2**: Unfortunately, using SceneManager doesn't seem to work fine. It started to create some unexpected behaviour due to how SceneViews cameras are being handled. It's probably best to stay directly connected to the Stage Utility/Prefab mode. If dev changes the way stages/prefab mode work, they will be less impact.

Fix this case: https://unity3d.atlassian.net/browse/WB-1206