### PR TITLE
Fix Action window in UVEditor not scrollable.

### DIFF
--- a/com.unity.probuilder/Editor/EditorCore/UVEditor.cs
+++ b/com.unity.probuilder/Editor/EditorCore/UVEditor.cs
@@ -906,11 +906,13 @@ namespace UnityEditor.ProBuilder
                     break;
 
                 case EventType.ScrollWheel:
+                    if (!actionWindowRect.Contains(e.mousePosition))
+                    {
+                        SetCanvasScale(uvGraphScale - e.delta.y * ((uvGraphScale / MAX_GRAPH_SCALE_SCROLL) * SCROLL_MODIFIER));
+                        e.Use();
+                        needsRepaint = true;
+                    }
 
-                    SetCanvasScale(uvGraphScale - e.delta.y * ((uvGraphScale / MAX_GRAPH_SCALE_SCROLL) * SCROLL_MODIFIER));
-                    e.Use();
-
-                    needsRepaint = true;
                     break;
 
                 case EventType.ContextClick:


### PR DESCRIPTION
**Goal of this PR:**
In the UV Editor, user can only scroll the UV view (grid) and not the actions window that is embedded. This PR fixes that issue by checking when we scroll if mouse is hovering the actions window. If so, we don't scroll the UV view and don't consume the event.

Fix this case: https://unity3d.atlassian.net/browse/WB-1260