### PR TITLE
Fixed deselecting vertices sometimes not working properly

### DIFF
--- a/com.unity.probuilder/Editor/EditorCore/EditorSceneViewPicker.cs
+++ b/com.unity.probuilder/Editor/EditorCore/EditorSceneViewPicker.cs
@@ -29,6 +29,7 @@ namespace UnityEditor.ProBuilder
         static SceneSelection s_Selection = new SceneSelection();
         static List<VertexPickerEntry> s_NearestVertices = new List<VertexPickerEntry>();
         static List<GameObject> s_OverlappingGameObjects = new List<GameObject>();
+        static readonly List<int> s_IndexBuffer = new List<int>(16);
 
         public static ProBuilderMesh DoMouseClick(Event evt, SelectMode selectionMode, ScenePickerPreferences pickerPreferences)
         {
@@ -106,7 +107,21 @@ namespace UnityEditor.ProBuilder
                     UndoUtility.RecordSelection(mesh, "Select Vertex");
 
                     if (ind > -1)
-                        mesh.SetSelectedVertices(mesh.selectedIndexesInternal.RemoveAt(ind));
+                    {
+                        var sharedIndex = mesh.sharedVertexLookup[s_Selection.vertex];
+                        var sharedVertex = mesh.sharedVerticesInternal[sharedIndex];
+                        s_IndexBuffer.Clear();
+                        foreach (var vertex in sharedVertex)
+                        {
+                            var index = Array.IndexOf(mesh.selectedIndexesInternal, vertex);
+                            if (index < 0)
+                                continue;
+
+                            s_IndexBuffer.Add(index);
+                        }
+                        
+                        mesh.SetSelectedVertices(mesh.selectedIndexesInternal.SortedRemoveAt(s_IndexBuffer));
+                    }
                     else
                         mesh.SetSelectedVertices(mesh.selectedIndexesInternal.Add(s_Selection.vertex));
                 }

--- a/com.unity.probuilder/Editor/EditorCore/EditorSceneViewPicker.cs
+++ b/com.unity.probuilder/Editor/EditorCore/EditorSceneViewPicker.cs
@@ -119,7 +119,8 @@ namespace UnityEditor.ProBuilder
 
                             s_IndexBuffer.Add(index);
                         }
-                        
+
+                        s_IndexBuffer.Sort();
                         mesh.SetSelectedVertices(mesh.selectedIndexesInternal.SortedRemoveAt(s_IndexBuffer));
                     }
                     else


### PR DESCRIPTION
[Jira: WB-1023]

When drag selecting, the _n_ shared vertices would get picked up instead of just one like with CTLR+left click (which is the correct behaviour). CTRL/Shift+left click now removes every vertex sharing the same shared vertex you clicked.

