### PR TITLE
Editor/fix smoothing group limit

### DIFF
--- a/com.unity.probuilder/Runtime/Core/Normals.cs
+++ b/com.unity.probuilder/Runtime/Core/Normals.cs
@@ -184,6 +184,13 @@ namespace UnityEngine.ProBuilder
                         smoothGroupMax = face.smoothingGroup + 1;
                 }
             }
+            
+            // Increase buffers size if we have more smoothing groups than usual.
+            if (smoothGroupMax > s_SmoothAvg.Length)
+            {
+                s_SmoothAvg = new Vector3[smoothGroupMax];
+                s_SmoothAvgCount = new float[smoothGroupMax];
+            }
 
             // For each sharedIndexes group (individual vertex), find vertices that are in the same smoothing
             // group and average their normals.

--- a/com.unity.probuilder/Runtime/Core/Normals.cs
+++ b/com.unity.probuilder/Runtime/Core/Normals.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace UnityEngine.ProBuilder
 {
     public static class Normals
@@ -188,8 +190,8 @@ namespace UnityEngine.ProBuilder
             // Increase buffers size if we have more smoothing groups than usual.
             if (smoothGroupMax > s_SmoothAvg.Length)
             {
-                s_SmoothAvg = new Vector3[smoothGroupMax];
-                s_SmoothAvgCount = new float[smoothGroupMax];
+                Array.Resize(ref s_SmoothAvg, smoothGroupMax);
+                Array.Resize(ref s_SmoothAvgCount, smoothGroupMax);
             }
 
             // For each sharedIndexes group (individual vertex), find vertices that are in the same smoothing


### PR DESCRIPTION
**Goal of this PR:**
Fix exception when trying ProBuilderize certain meshes with Import Smoothing enabled. We use two buffers with a fixed size (smoothRangeMax = 24) when importing normals. However, in some cases, we have more smoothing groups than the length of our buffers. Now, they get resized when it's needed.

Fix this case: https://unity3d.atlassian.net/browse/WB-1233