### PR TITLE
Fix UV groups

### DIFF
--- a/com.unity.probuilder/Editor/EditorCore/AutoUVEditor.cs
+++ b/com.unity.probuilder/Editor/EditorCore/AutoUVEditor.cs
@@ -481,7 +481,7 @@ namespace UnityEditor.ProBuilder
                     var uv = q.uv;
                     uv.rotation = rot;
                     q.uv = uv;
-                    sel[i].SetGroupUV(uv, q.textureGroup); //TODO don't do this multiple time for same group
+                    sel[i].SetGroupUV(uv, q.textureGroup);
                 }
             }
         }

--- a/com.unity.probuilder/Editor/EditorCore/AutoUVEditor.cs
+++ b/com.unity.probuilder/Editor/EditorCore/AutoUVEditor.cs
@@ -473,6 +473,7 @@ namespace UnityEditor.ProBuilder
                     var uv = q.uv;
                     uv.rotation = rot;
                     q.uv = uv;
+                    sel[i].SetGroupUV(uv, q.textureGroup); //TODO don't do this multiple time for same group
                 }
             }
         }

--- a/com.unity.probuilder/Editor/EditorCore/AutoUVEditor.cs
+++ b/com.unity.probuilder/Editor/EditorCore/AutoUVEditor.cs
@@ -351,6 +351,7 @@ namespace UnityEditor.ProBuilder
                     var uv = q.uv;
                     uv.flipU = flipU;
                     q.uv = uv;
+                    sel[i].SetGroupUV(q.uv, q.textureGroup);
                 }
             }
         }
@@ -365,6 +366,7 @@ namespace UnityEditor.ProBuilder
                     var uv = q.uv;
                     uv.flipV = flipV;
                     q.uv = uv;
+                    sel[i].SetGroupUV(q.uv, q.textureGroup);
                 }
             }
         }
@@ -379,6 +381,7 @@ namespace UnityEditor.ProBuilder
                     var uv = q.uv;
                     uv.swapUV = swapUV;
                     q.uv = uv;
+                    sel[i].SetGroupUV(q.uv, q.textureGroup);
                 }
             }
         }
@@ -393,6 +396,7 @@ namespace UnityEditor.ProBuilder
                     var uv = q.uv;
                     uv.useWorldSpace = useWorldSpace;
                     q.uv = uv;
+                    sel[i].SetGroupUV(q.uv, q.textureGroup);
                 }
             }
         }
@@ -407,6 +411,7 @@ namespace UnityEditor.ProBuilder
                     var uv = q.uv;
                     uv.fill = fill;
                     q.uv = uv;
+                    sel[i].SetGroupUV(q.uv, q.textureGroup);
                 }
             }
         }
@@ -422,6 +427,7 @@ namespace UnityEditor.ProBuilder
                     var uv = q.uv;
                     uv.anchor = anchor;
                     q.uv = uv;
+                    sel[i].SetGroupUV(q.uv, q.textureGroup);
                 }
             }
         }
@@ -458,6 +464,8 @@ namespace UnityEditor.ProBuilder
                             break;
                         }
                     }
+
+                    sel[i].SetGroupUV(q.uv, q.textureGroup);
                 }
             }
         }
@@ -510,6 +518,8 @@ namespace UnityEditor.ProBuilder
                             break;
                         }
                     }
+
+                    sel[i].SetGroupUV(q.uv, q.textureGroup);
                 }
             }
         }

--- a/com.unity.probuilder/Runtime/Core/Math.cs
+++ b/com.unity.probuilder/Runtime/Core/Math.cs
@@ -908,6 +908,18 @@ namespace UnityEngine.ProBuilder
             return l;
         }
 
+        internal static Vector2 SmallestVector2(Vector2[] v, IList<int> indexes)
+        {
+            int len = indexes.Count;
+            Vector2 l = v[indexes[0]];
+            for (int i = 0; i < len; i++)
+            {
+                if (v[indexes[i]].x < l.x) l.x = v[indexes[i]].x;
+                if (v[indexes[i]].y < l.y) l.y = v[indexes[i]].y;
+            }
+            return l;
+        }
+
         /// <summary>
         /// The largest X and Y value in an array.  May or may not belong to the same Vector2.
         /// </summary>
@@ -928,6 +940,18 @@ namespace UnityEngine.ProBuilder
         internal static Vector2 LargestVector2(Vector2[] v, int[] indexes)
         {
             int len = indexes.Length;
+            Vector2 l = v[indexes[0]];
+            for (int i = 0; i < len; i++)
+            {
+                if (v[indexes[i]].x > l.x) l.x = v[indexes[i]].x;
+                if (v[indexes[i]].y > l.y) l.y = v[indexes[i]].y;
+            }
+            return l;
+        }
+
+        internal static Vector2 LargestVector2(Vector2[] v, IList<int> indexes)
+        {
+            int len = indexes.Count;
             Vector2 l = v[indexes[0]];
             for (int i = 0; i < len; i++)
             {

--- a/com.unity.probuilder/Runtime/Core/ProBuilderMeshFunction.cs
+++ b/com.unity.probuilder/Runtime/Core/ProBuilderMeshFunction.cs
@@ -391,7 +391,7 @@ namespace UnityEngine.ProBuilder
 
                 if (!IsValidTextureGroup(textureGroup))
                     UvUnwrapping.Project(this, face);
-                else if (!s_CachedHashSet.Add(textureGroup))
+                else if (s_CachedHashSet.Add(textureGroup))
                     UvUnwrapping.ProjectTextureGroup(this, textureGroup, face.uv);
             }
 

--- a/com.unity.probuilder/Runtime/Core/ProBuilderMeshFunction.cs
+++ b/com.unity.probuilder/Runtime/Core/ProBuilderMeshFunction.cs
@@ -403,6 +403,20 @@ namespace UnityEngine.ProBuilder
                 mesh.SetUVs(3, m_Textures3);
         }
 
+        public void SetGroupUV(AutoUnwrapSettings settings, int group)
+        {
+            if (!IsValidTextureGroup(group))
+                return;
+            
+            foreach (var face in facesInternal)
+            {
+                if (face.textureGroup != group)
+                    continue;
+
+                face.uv = settings;
+            }
+        }
+
         void RefreshColors()
         {
             Mesh m = filter.sharedMesh;

--- a/com.unity.probuilder/Runtime/Core/ProBuilderMeshFunction.cs
+++ b/com.unity.probuilder/Runtime/Core/ProBuilderMeshFunction.cs
@@ -403,7 +403,7 @@ namespace UnityEngine.ProBuilder
                 mesh.SetUVs(3, m_Textures3);
         }
 
-        public void SetGroupUV(AutoUnwrapSettings settings, int group)
+        internal void SetGroupUV(AutoUnwrapSettings settings, int group)
         {
             if (!IsValidTextureGroup(group))
                 return;


### PR DESCRIPTION
[WB-1085]

**Issues Fixed:**
- Change to one member of a UV group would not replicate on all other member of the group
- The UV settings would be applied to every faces individually instead of being applied to all faces at once. For example, the face would all be rotated around their own pivot instead of being rotated around the pivot of the entire group.