### PR TITLE
Fix texture tool translation appearing to affect scaled UVs disproportionately

### DIFF
--- a/com.unity.probuilder.tests/Tests/Runtime/MeshOps/UV/ConvertManualToAutoUVTests.cs
+++ b/com.unity.probuilder.tests/Tests/Runtime/MeshOps/UV/ConvertManualToAutoUVTests.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using UObject = UnityEngine.Object;
+using NUnit.Framework;
+using UnityEngine.ProBuilder.MeshOperations;
+
+namespace UnityEngine.ProBuilder.RuntimeTests.MeshOps.UV
+{
+	public class ConvertUvUnwrappingMethodTests
+	{
+		public ProBuilderMesh mesh;
+		public ProBuilder.Face face;
+		public ProBuilder.Edge verticalEdge;
+		public ProBuilder.Edge horizontalEdge;
+
+		[SetUp]
+		public void Setup()
+		{
+			mesh = ShapeGenerator.CreateShape(ShapeType.Sprite);
+			face = mesh.faces.First();
+			verticalEdge = face.edgesInternal[0];
+			horizontalEdge = face.edgesInternal[1];
+
+			// Verify that UVs are actually rotated
+			Assume.That(face.manualUV, Is.EqualTo(false));
+
+		}
+
+		[TearDown]
+		public void Teardown()
+		{
+			UObject.DestroyImmediate(mesh.gameObject);
+		}
+
+		static Vector2[] AutoUVOffsetParameters = new[]
+		{
+			new Vector2( 0f,  0f),
+			new Vector2( 1f,  0f),
+			new Vector2( 0f,  1f),
+			new Vector2( 1f,  1f),
+			new Vector2(-1f, 0f),
+			new Vector2( 0f, -1f),
+			new Vector2(-1f, -1f),
+		};
+
+		static float[] AutoUVRotationParameters = new[]
+		{
+			0f,
+			60f,
+			180f,
+			200f,
+			359f
+		};
+
+		static Vector2[] AutoUVScaleParameters = new[]
+		{
+			new Vector2(1f, 1f),
+			new Vector2(2f, 2f),
+			new Vector2(.5f, .5f),
+			new Vector2(.2f, 1f),
+			new Vector2(1f, .2f),
+		};
+
+		static IEnumerable EnumerateTestCases()
+		{
+			foreach (var offset in AutoUVOffsetParameters)
+			{
+				foreach (var scale in AutoUVScaleParameters)
+				{
+					foreach (var rotation in AutoUVRotationParameters)
+					{
+						yield return new TestCaseData(offset, rotation, scale).SetName(
+							string.Format("({0:F2}, {1:F2}), {2:F2}, ({3:F2}, {4:F2})",
+								offset.x,
+								offset.y,
+								rotation,
+								scale.x,
+								scale.y
+							));
+					}
+				}
+			}
+		}
+
+		static float GetEdgeRotation(ProBuilderMesh mesh, ProBuilder.Edge edge)
+		{
+			var dir = mesh.texturesInternal[edge.b] - mesh.texturesInternal[edge.a];
+			var angle = Vector2.Angle(Vector2.up, dir);
+			if (Vector2.Dot(Vector2.right, dir) < 0)
+				angle = 360f - angle;
+			return angle;
+		}
+
+		static float GetEdgeScale(ProBuilderMesh mesh, ProBuilder.Edge edge)
+		{
+			return Vector2.Distance(mesh.texturesInternal[edge.b], mesh.texturesInternal[edge.a]);
+		}
+
+		[TestCaseSource(typeof(ConvertUvUnwrappingMethodTests), "EnumerateTestCases")]
+		public void SetManualFaceToAuto_MatchesOriginalUVs(Vector2 offset, float rotation, Vector2 scale)
+		{
+			var unwrap = face.uv;
+			unwrap.offset = offset;
+			unwrap.rotation = rotation;
+			unwrap.scale = scale;
+
+			face.uv = unwrap;
+
+			// Verify that UV settings have actually been applied
+			Assume.That(face.uv.offset, Is.EqualTo(offset));
+			Assume.That(face.uv.rotation, Is.EqualTo(rotation));
+			Assume.That(face.uv.scale, Is.EqualTo(scale));
+			Assume.That(face.manualUV, Is.EqualTo(false));
+
+			mesh.Refresh(RefreshMask.UV);
+
+			// Verify that the UVs are in the correct place
+			Assume.That(GetEdgeRotation(mesh, verticalEdge), Is.EqualTo(rotation).Within(.1f));
+			Assume.That(GetEdgeScale(mesh, verticalEdge), Is.EqualTo(scale.y).Within(.1f));
+			Assume.That(GetEdgeScale(mesh, horizontalEdge), Is.EqualTo(scale.x).Within(.1f));
+			// Offset is flipped in code for legacy reasons
+			var center = Bounds2D.Center(mesh.texturesInternal, face.distinctIndexesInternal);
+			Assume.That(center.x, Is.EqualTo(-offset.x).Within(.1f));
+			Assume.That(center.y, Is.EqualTo(-offset.y).Within(.1f));
+
+			face.uv = AutoUnwrapSettings.defaultAutoUnwrapSettings;
+			face.manualUV = true;
+
+			// Verify that UV settings have been reset
+			Assume.That(face.uv.offset, Is.EqualTo(new Vector2(0f, 0f)));
+			Assume.That(face.uv.rotation, Is.EqualTo(0f));
+			Assume.That(face.uv.scale, Is.EqualTo(new Vector2(1f, 1f)));
+			Assume.That(face.manualUV, Is.EqualTo(true));
+
+			// This sets the manualFlag to false, sets the AutoUnwrap settings, and rebuilds UVs
+			UVEditing.SetAutoAndAlignUnwrapParamsToUVs(mesh, new [] { face });
+
+			Assert.That(face.uv.offset.x, Is.EqualTo(offset.x).Within(.1f));
+			Assert.That(face.uv.offset.y, Is.EqualTo(offset.y).Within(.1f));
+			Assert.That(face.uv.rotation, Is.EqualTo(rotation).Within(.1f));
+			Assert.That(face.uv.scale.x, Is.EqualTo(scale.x).Within(.1f));
+			Assert.That(face.uv.scale.y, Is.EqualTo(scale.y).Within(.1f));
+			Assert.That(face.manualUV, Is.EqualTo(false));
+		}
+	}
+}

--- a/com.unity.probuilder.tests/Tests/Runtime/MeshOps/UV/ConvertManualToAutoUVTests.cs
+++ b/com.unity.probuilder.tests/Tests/Runtime/MeshOps/UV/ConvertManualToAutoUVTests.cs
@@ -64,27 +64,6 @@ namespace UnityEngine.ProBuilder.RuntimeTests.MeshOps.UV
 			new Vector2(1f, .2f),
 		};
 
-		static IEnumerable EnumerateTestCases()
-		{
-			foreach (var offset in AutoUVOffsetParameters)
-			{
-				foreach (var scale in AutoUVScaleParameters)
-				{
-					foreach (var rotation in AutoUVRotationParameters)
-					{
-						yield return new TestCaseData(offset, rotation, scale).SetName(
-							string.Format("({0:F2}, {1:F2}), {2:F2}, ({3:F2}, {4:F2})",
-								offset.x,
-								offset.y,
-								rotation,
-								scale.x,
-								scale.y
-							));
-					}
-				}
-			}
-		}
-
 		static float GetEdgeRotation(ProBuilderMesh mesh, ProBuilder.Edge edge)
 		{
 			var dir = mesh.texturesInternal[edge.b] - mesh.texturesInternal[edge.a];
@@ -100,7 +79,10 @@ namespace UnityEngine.ProBuilder.RuntimeTests.MeshOps.UV
 		}
 
 		[TestCaseSource(typeof(ConvertUvUnwrappingMethodTests), "EnumerateTestCases")]
-		public void SetManualFaceToAuto_MatchesOriginalUVs(Vector2 offset, float rotation, Vector2 scale)
+		public void SetManualFaceToAuto_MatchesOriginalUVs(
+			[ValueSource("AutoUVOffsetParameters")] Vector2 offset,
+			[ValueSource("AutoUVRotationParameters")] float rotation,
+			[ValueSource("AutoUVScaleParameters")] Vector2 scale)
 		{
 			var unwrap = face.uv;
 			unwrap.offset = offset;

--- a/com.unity.probuilder.tests/Tests/Runtime/MeshOps/UV/ConvertManualToAutoUVTests.cs.meta
+++ b/com.unity.probuilder.tests/Tests/Runtime/MeshOps/UV/ConvertManualToAutoUVTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2d62a423c655c4ecd967b29585365acd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.probuilder/Content/Resources/Materials/FacePicker.mat
+++ b/com.unity.probuilder/Content/Resources/Materials/FacePicker.mat
@@ -21,4 +21,4 @@ Material:
     m_TexEnvs: []
     m_Floats: []
     m_Colors:
-    - _Tint: {r: 0, g: 0, b: 0, a: 1}
+    - _Tint: {r: 1, g: 1, b: 1, a: 1}

--- a/com.unity.probuilder/Debug/Editor/TempMenuItems.cs
+++ b/com.unity.probuilder/Debug/Editor/TempMenuItems.cs
@@ -1,14 +1,52 @@
 using System.IO;
+using System.Linq;
 using UnityEngine;
 using UnityEditor;
 using UnityEditor.ProBuilder;
+using UnityEngine.ProBuilder;
+using UnityEngine.ProBuilder.MeshOperations;
 using UObject = UnityEngine.Object;
 
 class TempMenuItems : EditorWindow
 {
+    static float GetEdgeRotation(ProBuilderMesh mesh, Edge edge)
+    {
+        var dir = mesh.texturesInternal[edge.b] - mesh.texturesInternal[edge.a];
+        return Vector2.SignedAngle(Vector2.up, dir);
+    }
+
     [MenuItem("Tools/Temp Menu Item &d", false, 1000)]
     static void MenuInit()
     {
+        var rotation = 35f;
+
+        var mesh = ShapeGenerator.CreateShape(ShapeType.Sprite);
+        var face = mesh.faces.First();
+        var edge = face.edgesInternal.First();
+
+        // Verify that UVs are actually rotated
+//        Assume.That(face.manualUV, Is.EqualTo(false));
+
+        var unwrap = face.uv;
+        unwrap.rotation = rotation;
+        face.uv = unwrap;
+
+        mesh.Refresh(RefreshMask.UV);
+
+        Debug.Log("rotation: " + face.uv.rotation + " -> " + GetEdgeRotation(mesh, edge));
+//        Assume.That(GetEdgeRotation(mesh, edge), Is.EqualTo(rotation));
+
+        var origins = mesh.textures.ToArray();
+
+        face.uv = AutoUnwrapSettings.defaultAutoUnwrapSettings;
+        face.manualUV = true;
+
+//        Assume.That(face.uv.rotation, Is.EqualTo(0f));
+//        Assume.That(face.manualUV, Is.EqualTo(true));
+
+        UVEditing.SetAutoAndAlignUnwrapParamsToUVs(mesh, new [] { face });
+
+//        Assert.That(face.uv.rotation, Is.EqualTo(rotation));
     }
 
     [MenuItem("Tools/Recompile")]

--- a/com.unity.probuilder/Debug/Editor/TempMenuItems.cs
+++ b/com.unity.probuilder/Debug/Editor/TempMenuItems.cs
@@ -9,44 +9,15 @@ using UObject = UnityEngine.Object;
 
 class TempMenuItems : EditorWindow
 {
-    static float GetEdgeRotation(ProBuilderMesh mesh, Edge edge)
-    {
-        var dir = mesh.texturesInternal[edge.b] - mesh.texturesInternal[edge.a];
-        return Vector2.SignedAngle(Vector2.up, dir);
-    }
 
     [MenuItem("Tools/Temp Menu Item &d", false, 1000)]
     static void MenuInit()
     {
-        var rotation = 35f;
-
-        var mesh = ShapeGenerator.CreateShape(ShapeType.Sprite);
-        var face = mesh.faces.First();
-        var edge = face.edgesInternal.First();
-
-        // Verify that UVs are actually rotated
-//        Assume.That(face.manualUV, Is.EqualTo(false));
-
-        var unwrap = face.uv;
-        unwrap.rotation = rotation;
-        face.uv = unwrap;
-
-        mesh.Refresh(RefreshMask.UV);
-
-        Debug.Log("rotation: " + face.uv.rotation + " -> " + GetEdgeRotation(mesh, edge));
-//        Assume.That(GetEdgeRotation(mesh, edge), Is.EqualTo(rotation));
-
-        var origins = mesh.textures.ToArray();
-
-        face.uv = AutoUnwrapSettings.defaultAutoUnwrapSettings;
-        face.manualUV = true;
-
-//        Assume.That(face.uv.rotation, Is.EqualTo(0f));
-//        Assume.That(face.manualUV, Is.EqualTo(true));
-
-        UVEditing.SetAutoAndAlignUnwrapParamsToUVs(mesh, new [] { face });
-
-//        Assert.That(face.uv.rotation, Is.EqualTo(rotation));
+        foreach (var mesh in MeshSelection.top)
+        {
+            foreach(var face in mesh.selectedFacesInternal)
+                Debug.Log(UVEditing.GetUVTransform(mesh, face).ToString());
+        }
     }
 
     [MenuItem("Tools/Recompile")]

--- a/com.unity.probuilder/Editor/EditorCore/TextureMoveTool.cs
+++ b/com.unity.probuilder/Editor/EditorCore/TextureMoveTool.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using UnityEngine.ProBuilder;
+using UnityEngine.ProBuilder.MeshOperations;
 
 namespace UnityEditor.ProBuilder
 {
@@ -15,16 +16,25 @@ namespace UnityEditor.ProBuilder
         {
             SimpleTuple<Face, Vector2>[] m_FaceAndScale;
 
+            public SimpleTuple<Face, Vector2>[] faceAndScale
+            {
+                get { return m_FaceAndScale; }
+            }
+
             public TranslateTextureSelection(ProBuilderMesh mesh, PivotPoint pivot, HandleOrientation orientation)
                 : base(mesh, pivot, orientation)
             {
                 var faces = mesh.faces;
 
                 m_FaceAndScale = mesh.selectedFaceIndexes.Select(x =>
-                {
-                    return new SimpleTuple<Face, Vector2>(faces[x], Vector2.one);
-                }).ToArray();
+                    new SimpleTuple<Face, Vector2>(faces[x], UVEditing.GetUVTransform(mesh, faces[x]).scale))
+                        .ToArray();
             }
+        }
+
+        internal override MeshAndElementSelection GetElementSelection(ProBuilderMesh mesh, PivotPoint pivot, HandleOrientation orientation)
+        {
+            return new TranslateTextureSelection(mesh, pivot, orientation);
         }
 
         protected override void DoTool(Vector3 handlePosition, Quaternion handleRotation)
@@ -78,24 +88,45 @@ namespace UnityEditor.ProBuilder
                 // invert `y` because to users it's confusing that "up" in UV space visually moves the texture down
                 var delta = new Vector4(m_Position.x, -m_Position.y, 0f, 0f);
 
-                foreach (var mesh in elementSelection)
+                foreach (var value in elementSelection)
                 {
-                    if (!(mesh is MeshAndTextures))
+                    var selection = value as TranslateTextureSelection;
+
+                    if (selection == null)
                         continue;
 
                     // Account for object scale
-                    delta *= k_Vector3Magnitude / mesh.mesh.transform.lossyScale.magnitude;
+                    delta *= k_Vector3Magnitude / selection.mesh.transform.lossyScale.magnitude;
 
-                    var origins = ((MeshAndTextures)mesh).origins;
-                    var positions = ((MeshAndTextures)mesh).textures;
+                    var origins = selection.origins;
+                    var positions = selection.textures;
 
-                    foreach (var group in mesh.elementGroups)
+                    // Translating faces is treated as a special case because we want the textures in scene to visually
+                    // match the movement of the translation handle. When UVs are scaled, they have the appearance of
+                    // moving faster or slower (even though they are translating the correct distances). To avoid this,
+                    // we cache the UV scale of each face and modify the translation delta accordingly. This isn't perfect,
+                    // as it will not be able to find the scale for sheared or otherwise distorted face UVs. However, for
+                    // most cases it maps quite well.
+                    if (ProBuilderEditor.selectMode == SelectMode.TextureFace)
                     {
-                        foreach (var index in group.indices)
-                            positions[index] = origins[index] + delta;
+                        foreach (var face in selection.faceAndScale)
+                        {
+                            var faceDelta = new Vector4(delta.x / face.item2.x, delta.y / face.item2.y, 0f, 0f);
+
+                            foreach (var index in face.item1.distinctIndexes)
+                                positions[index] = origins[index] + faceDelta;
+                        }
+                    }
+                    else
+                    {
+                        foreach (var group in value.elementGroups)
+                        {
+                            foreach (var index in group.indices)
+                                positions[index] = origins[index] + delta;
+                        }
                     }
 
-                    mesh.mesh.mesh.SetUVs(k_TextureChannel, positions);
+                    selection.mesh.mesh.SetUVs(k_TextureChannel, positions);
                 }
             }
 

--- a/com.unity.probuilder/Editor/EditorCore/TextureMoveTool.cs
+++ b/com.unity.probuilder/Editor/EditorCore/TextureMoveTool.cs
@@ -5,6 +5,8 @@ namespace UnityEditor.ProBuilder
 {
     class TextureMoveTool : TextureTool
     {
+        static readonly float k_Vector3Magnitude = Vector3.one.magnitude;
+
         Vector3 m_Position = Vector3.zero;
 
         protected override void DoTool(Vector3 handlePosition, Quaternion handleRotation)
@@ -63,7 +65,8 @@ namespace UnityEditor.ProBuilder
                     if (!(mesh is MeshAndTextures))
                         continue;
 
-                    delta *= 1f / mesh.mesh.transform.lossyScale.magnitude;
+                    // Account for object scale
+                    delta *= k_Vector3Magnitude / mesh.mesh.transform.lossyScale.magnitude;
 
                     var origins = ((MeshAndTextures)mesh).origins;
                     var positions = ((MeshAndTextures)mesh).textures;

--- a/com.unity.probuilder/Editor/EditorCore/TextureMoveTool.cs
+++ b/com.unity.probuilder/Editor/EditorCore/TextureMoveTool.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using UnityEngine.ProBuilder;
 
@@ -8,6 +10,22 @@ namespace UnityEditor.ProBuilder
         static readonly float k_Vector3Magnitude = Vector3.one.magnitude;
 
         Vector3 m_Position = Vector3.zero;
+
+        protected class TranslateTextureSelection : MeshAndTextures
+        {
+            SimpleTuple<Face, Vector2>[] m_FaceAndScale;
+
+            public TranslateTextureSelection(ProBuilderMesh mesh, PivotPoint pivot, HandleOrientation orientation)
+                : base(mesh, pivot, orientation)
+            {
+                var faces = mesh.faces;
+
+                m_FaceAndScale = mesh.selectedFaceIndexes.Select(x =>
+                {
+                    return new SimpleTuple<Face, Vector2>(faces[x], Vector2.one);
+                }).ToArray();
+            }
+        }
 
         protected override void DoTool(Vector3 handlePosition, Quaternion handleRotation)
         {

--- a/com.unity.probuilder/Editor/EditorCore/TextureTool.cs
+++ b/com.unity.probuilder/Editor/EditorCore/TextureTool.cs
@@ -97,6 +97,11 @@ namespace UnityEditor.ProBuilder
             }
         }
 
+        protected override void OnToolEngaged()
+        {
+            MeshSelection.InvalidateElementSelection();
+        }
+
         protected override void OnToolDisengaged()
         {
             var isFaceMode = ProBuilderEditor.selectMode.ContainsFlag(SelectMode.TextureFace | SelectMode.Face);

--- a/com.unity.probuilder/Editor/EditorCore/UVEditor.cs
+++ b/com.unity.probuilder/Editor/EditorCore/UVEditor.cs
@@ -26,6 +26,17 @@ namespace UnityEditor.ProBuilder
             get { return ProBuilderEditor.instance; }
         }
 
+        public override void AddItemsToMenu(GenericMenu menu)
+        {
+            base.AddItemsToMenu(menu);
+
+#if PB_DEBUG
+            menu.AddItem(new GUIContent("Show UV Coordinate Labels"), s_DebugDrawCoordinateLabels.value, () =>
+            {
+                s_DebugDrawCoordinateLabels.SetValue(!s_DebugDrawCoordinateLabels.value, true);
+            });
+#endif
+        }
         public static UVEditor instance;
 
         const int LEFT_MOUSE_BUTTON = 0;
@@ -111,8 +122,8 @@ namespace UnityEditor.ProBuilder
         GUIContent gc_RenderUV = new GUIContent((Texture2D)null, "Renders the current UV workspace from coordinates {0,0} to {1,1} to a 256px image.");
 
         // Full grid size in pixels (-1, 1)
-        private int uvGridSize = 256;
-        private float uvGraphScale = 1f;
+        int uvGridSize = 256;
+        float uvGraphScale = 1f;
 
         enum UVMode
         {
@@ -127,7 +138,7 @@ namespace UnityEditor.ProBuilder
         string[] UV_CHANNELS_STR = new string[] { "UV 1", "UV 2 (read-only)", "UV 3 (read-only)", "UV 4 (read-only)" };
 
 #if PB_DEBUG
-        bool debug_showCoordinates = false;
+        static Pref<bool> s_DebugDrawCoordinateLabels = new Pref<bool>("uv.drawDebugCoordLabels", false, SettingsScope.User);
     #endif
 
         // what uv channel to modify
@@ -442,11 +453,6 @@ namespace UnityEditor.ProBuilder
                 Repaint();
                 needsRepaint = false;
             }
-
-#if PB_DEBUG
-            buggerRect = new Rect(this.position.width - 226, PAD, 220, 300);
-            DrawDebugInfo(buggerRect);
-        #endif
         }
 
         #endregion
@@ -535,7 +541,7 @@ namespace UnityEditor.ProBuilder
 
             if (update)
             {
-                // UpdateSelection clears handlePosition
+                /// UpdateSelection clears handlePosition
                 Vector2 storedHandlePosition = handlePosition;
                 ProBuilderEditor.Refresh();
                 SetHandlePosition(storedHandlePosition, true);
@@ -799,11 +805,7 @@ namespace UnityEditor.ProBuilder
             {
                 case EventType.MouseDown:
 
-#if PB_DEBUG
-                    if (toolbarRect.Contains(e.mousePosition) || actionWindowRect.Contains(e.mousePosition) || buggerRect.Contains(e.mousePosition))
-                #else
                     if (toolbarRect.Contains(e.mousePosition) || actionWindowRect.Contains(e.mousePosition))
-#endif
                     {
                         m_ignore = true;
                         return;
@@ -1844,20 +1846,21 @@ namespace UnityEditor.ProBuilder
                     Handles.CircleHandleCap(-1, UVToGUIPoint(lines[i]), Quaternion.identity, 8f, evt.type);
 
 #if PB_DEBUG
-            if (debug_showCoordinates)
+            if (s_DebugDrawCoordinateLabels)
             {
                 Handles.BeginGUI();
                 r.width = 256f;
                 r.height = 40f;
-                foreach (pb_Object pb in selection)
+
+                foreach (var mesh in selection)
                 {
-                    foreach (int i in pb.SelectedTriangles)
+                    foreach (int i in mesh.selectedIndexesInternal)
                     {
-                        Vector2 v = pb.uv[i];
+                        Vector2 v = mesh.texturesInternal[i];
                         Vector2 sv = UVToGUIPoint(v);
                         r.x = sv.x;
                         r.y = sv.y;
-                        GUI.Label(r, "UV:" + v.ToString("F2") + "\nScreen: " + (int)sv.x + ", " + (int)sv.y);
+                        GUI.Label(r, v.ToString("F2"));
                     }
                 }
                 Handles.EndGUI();
@@ -2072,33 +2075,6 @@ namespace UnityEditor.ProBuilder
             }
         }
 
-#if PB_DEBUG
-        void DrawDebugInfo(Rect rect)
-        {
-            Vector2 mpos = Event.current.mousePosition;
-
-            GUI.BeginGroup(rect);
-            GUILayout.BeginVertical(GUILayout.MaxWidth(rect.width - 6));
-
-            GUILayout.Label("Scale: " + uvGraphScale);
-
-            GUILayout.Label("Object: " + nearestElement.ToString());
-            GUILayout.Label(mpos + " (" + this.position.width + ", " + this.position.height + ")");
-
-            // GUILayout.Label("m_mouseDragging: " + m_mouseDragging);
-            // GUILayout.Label("m_rightMouseDrag: " + m_rightMouseDrag);
-            // GUILayout.Label("m_draggingCanvas: " + m_draggingCanvas);
-            // GUILayout.Label("modifyingUVs: " + modifyingUVs);
-
-            debug_showCoordinates = EditorGUILayout.Toggle("Show UV coordinates", debug_showCoordinates);
-
-            GUILayout.Label("Handle: " + handlePosition.ToString("F3"));
-            GUILayout.Label("Offset: " + handlePosition_offset.ToString("F3"));
-
-            GUI.EndGroup();
-        }
-
-    #endif
         #endregion
         #region UV Canvas Operations
 
@@ -2636,7 +2612,7 @@ namespace UnityEditor.ProBuilder
 
             if (GUILayout.Button(gc_ConvertToAuto, EditorStyles.miniButton))
                 Menu_SetAutoUV();
-            
+
             // Allowd scrollview to be enabled.
             // Otherwise, we won't be able to use the scrollbar without selecting a face.
             GUI.enabled = true;
@@ -2705,7 +2681,7 @@ namespace UnityEditor.ProBuilder
                 Menu_FitUVs();
 
             GUI.enabled = true;
-            
+
             EditorGUILayout.EndScrollView();
         }
 
@@ -3366,22 +3342,6 @@ namespace UnityEditor.ProBuilder
                     {
                         screenshot.ReadPixels(screenshotCanvasRect, (int)screenshotTexturePosition.x, (int)screenshotTexturePosition.y);
 
-#if PB_DEBUG
-                        Texture2D wholeScreenTexture = new Texture2D((int)ScreenRect.width, (int)ScreenRect.height);
-                        Rect wholeScreenRect;
-
-                        if ((bool)pb_Reflection.GetValue(this, this.GetType(), "docked"))
-                            wholeScreenRect = new Rect(4, 2, (int)ScreenRect.width - 4, (int)ScreenRect.height - 2);
-                        else
-                            wholeScreenRect = new Rect(0, 0, (int)ScreenRect.width, (int)ScreenRect.height);
-
-                        wholeScreenTexture.ReadPixels(wholeScreenRect,
-                            (int)(EditorGUIUtility.pixelsPerPoint / wholeScreenRect.width),
-                            (int)(EditorGUIUtility.pixelsPerPoint / wholeScreenRect.height));
-
-                        m_DebugUVRenderScreens.Add(wholeScreenTexture);
-                    #endif
-
                         screenshotTexturePosition.y += screenshotCanvasRect.height;
 
                         if (screenshotTexturePosition.y < screenshot_size)
@@ -3460,15 +3420,6 @@ namespace UnityEditor.ProBuilder
             {
                 FileUtility.SaveTexture(screenshot, screenShotPath);
                 DestroyImmediate(screenshot);
-
-#if PB_DEBUG
-                for (int n = 0; n < m_DebugUVRenderScreens.Count; n++)
-                {
-                    pb_EditorUtility.SaveTexture(m_DebugUVRenderScreens[n], "Assets/uv-render-" + n + ".png");
-                    DestroyImmediate(m_DebugUVRenderScreens[n]);
-                }
-                m_DebugUVRenderScreens.Clear();
-            #endif
             }
         }
 

--- a/com.unity.probuilder/Editor/EditorCore/UVEditor.cs
+++ b/com.unity.probuilder/Editor/EditorCore/UVEditor.cs
@@ -531,7 +531,7 @@ namespace UnityEditor.ProBuilder
 
             if (update)
             {
-                /// UpdateSelection clears handlePosition
+                // UpdateSelection clears handlePosition
                 Vector2 storedHandlePosition = handlePosition;
                 ProBuilderEditor.Refresh();
                 SetHandlePosition(storedHandlePosition, true);

--- a/com.unity.probuilder/Runtime/Core/Bounds2D.cs
+++ b/com.unity.probuilder/Runtime/Core/Bounds2D.cs
@@ -1,5 +1,4 @@
 using UnityEngine;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -71,7 +70,7 @@ namespace UnityEngine.ProBuilder
         /// </summary>
         /// <param name="points"></param>
         /// <param name="indexes"></param>
-        public Bounds2D(Vector2[] points, int[] indexes)
+        public Bounds2D(IList<Vector2> points, IList<int> indexes)
         {
             SetWithPoints(points, indexes);
         }
@@ -362,13 +361,6 @@ namespace UnityEngine.ProBuilder
             return new Vector2((xMin + xMax) / 2f, (yMin + yMax) / 2f);
         }
 
-        /// <summary>
-        /// Returns the center of the bounding box of points.  Optional parameter @length limits the bounds calculations
-        /// to only the points up to length in array.
-        /// </summary>
-        /// <param name="points"></param>
-        /// <param name="indexes"></param>
-        /// <returns></returns>
         public static Vector2 Center(IList<Vector2> points, IList<int> indexes)
         {
             float   xMin = 0f,
@@ -396,6 +388,35 @@ namespace UnityEngine.ProBuilder
             }
 
             return new Vector2((xMin + xMax) / 2f, (yMin + yMax) / 2f);
+        }
+
+        public static Vector2 Size(IList<Vector2> points, IList<int> indexes)
+        {
+            float   xMin = 0f,
+                    xMax = 0f,
+                    yMin = 0f,
+                    yMax = 0f;
+
+            int size = indexes.Count;
+
+            xMin = points[indexes[0]].x;
+            yMin = points[indexes[0]].y;
+            xMax = xMin;
+            yMax = yMin;
+
+            for (int i = 1; i < size; i++)
+            {
+                float x = points[indexes[i]].x;
+                float y = points[indexes[i]].y;
+
+                if (x < xMin) xMin = x;
+                if (x > xMax) xMax = x;
+
+                if (y < yMin) yMin = y;
+                if (y > yMax) yMax = y;
+            }
+
+            return new Vector2(xMax - xMin, yMax - yMin);
         }
 
         internal static Vector2 Center(IList<Vector4> points, IEnumerable<int> indexes)

--- a/com.unity.probuilder/Runtime/Core/Bounds2D.cs
+++ b/com.unity.probuilder/Runtime/Core/Bounds2D.cs
@@ -60,7 +60,7 @@ namespace UnityEngine.ProBuilder
         /// Create bounds from a set of 2d points.
         /// </summary>
         /// <param name="points"></param>
-        public Bounds2D(Vector2[] points)
+        public Bounds2D(IList<Vector2> points)
         {
             SetWithPoints(points);
         }
@@ -73,43 +73,6 @@ namespace UnityEngine.ProBuilder
         public Bounds2D(IList<Vector2> points, IList<int> indexes)
         {
             SetWithPoints(points, indexes);
-        }
-
-        /// <summary>
-        /// Create bounds from a set of 2d points.
-        /// </summary>
-        /// <param name="points"></param>
-        /// <param name="edges"></param>
-        public Bounds2D(Vector2[] points, Edge[] edges)
-        {
-            float   xMin = 0f,
-                                  xMax = 0f,
-                                  yMin = 0f,
-                                  yMax = 0f;
-
-            if (points.Length > 0 && edges.Length > 0)
-            {
-                xMin = points[edges[0].a].x;
-                yMin = points[edges[0].a].y;
-                xMax = xMin;
-                yMax = yMin;
-
-                for (int i = 0; i < edges.Length; i++)
-                {
-                    xMin = Mathf.Min(xMin, points[edges[i].a].x);
-                    xMin = Mathf.Min(xMin, points[edges[i].b].x);
-                    yMin = Mathf.Min(yMin, points[edges[i].a].y);
-                    yMin = Mathf.Min(yMin, points[edges[i].b].y);
-
-                    xMax = Mathf.Max(xMax, points[edges[i].a].x);
-                    xMax = Mathf.Max(xMax, points[edges[i].b].x);
-                    yMax = Mathf.Max(yMax, points[edges[i].a].y);
-                    yMax = Mathf.Max(yMax, points[edges[i].b].y);
-                }
-            }
-
-            this.center = new Vector2((xMin + xMax) / 2f, (yMin + yMax) / 2f);
-            this.size = new Vector3(xMax - xMin, yMax - yMin);
         }
 
         /// <summary>
@@ -332,14 +295,14 @@ namespace UnityEngine.ProBuilder
         /// <param name="points"></param>
         /// <param name="length"></param>
         /// <returns></returns>
-        public static Vector2 Center(Vector2[] points, int length = -1)
+        public static Vector2 Center(IList<Vector2> points)
         {
             float   xMin = 0f,
                     xMax = 0f,
                     yMin = 0f,
                     yMax = 0f;
 
-            int size = length < 1 ? points.Length : length;
+            int size = points.Count;
 
             xMin = points[0].x;
             yMin = points[0].y;

--- a/com.unity.probuilder/Runtime/Core/ProBuilderMeshFunction.cs
+++ b/com.unity.probuilder/Runtime/Core/ProBuilderMeshFunction.cs
@@ -390,7 +390,7 @@ namespace UnityEngine.ProBuilder
                 int textureGroup = face.textureGroup;
 
                 if (!IsValidTextureGroup(textureGroup))
-                    UvUnwrapping.Project(this, face);
+                    UvUnwrapping.Unwrap(this, face);
                 else if (!s_CachedHashSet.Add(textureGroup))
                     UvUnwrapping.ProjectTextureGroup(this, textureGroup, face.uv);
             }

--- a/com.unity.probuilder/Runtime/Core/Projection.cs
+++ b/com.unity.probuilder/Runtime/Core/Projection.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 using System.Linq;
 using System.Collections.Generic;
@@ -32,11 +33,24 @@ namespace UnityEngine.ProBuilder
         /// <returns>The positions array projected into 2d coordinates.</returns>
         public static Vector2[] PlanarProject(IList<Vector3> positions, IList<int> indexes, Vector3 direction)
         {
+            List<Vector2> results = new List<Vector2>(indexes != null ? indexes.Count : positions.Count);
+            PlanarProject(positions, indexes, direction, results);
+            return results.ToArray();
+        }
+
+        internal static void PlanarProject(IList<Vector3> positions, IList<int> indexes, Vector3 direction, List<Vector2> results)
+        {
+            if(positions == null)
+                throw new ArgumentNullException("positions");
+
+            if(results == null)
+                throw new ArgumentNullException("results");
+
             var nrm = direction;
             var axis = VectorToProjectionAxis(nrm);
             var prj = GetTangentToAxis(axis);
             var len = indexes == null ? positions.Count : indexes.Count;
-            var projected = new Vector2[len];
+            results.Clear();
 
             var u = Vector3.Cross(nrm, prj);
             var v = Vector3.Cross(u, nrm);
@@ -47,15 +61,13 @@ namespace UnityEngine.ProBuilder
             if (indexes != null)
             {
                 for (int i = 0, ic = len; i < ic; ++i)
-                    projected[i] = new Vector2(Vector3.Dot(u, positions[indexes[i]]), Vector3.Dot(v, positions[indexes[i]]));
+                    results.Add(new Vector2(Vector3.Dot(u, positions[indexes[i]]), Vector3.Dot(v, positions[indexes[i]])));
             }
             else
             {
                 for (int i = 0, ic = len; i < ic; ++i)
-                    projected[i] = new Vector2(Vector3.Dot(u, positions[i]), Vector3.Dot(v, positions[i]));
+                    results.Add(new Vector2(Vector3.Dot(u, positions[i]), Vector3.Dot(v, positions[i])));
             }
-
-            return projected;
         }
 
         internal static void PlanarProject(ProBuilderMesh mesh, int textureGroup, AutoUnwrapSettings unwrapSettings)

--- a/com.unity.probuilder/Runtime/MeshOperations/UV/AutoUvConversion.cs
+++ b/com.unity.probuilder/Runtime/MeshOperations/UV/AutoUvConversion.cs
@@ -38,7 +38,7 @@ namespace UnityEngine.ProBuilder.MeshOperations
         /// </remarks>
         internal static void SetAutoAndAlignUnwrapParamsToUVs(ProBuilderMesh mesh, IEnumerable<Face> facesToConvert)
         {
-            var origins = mesh.textures.ToArray();
+            var destinationTextures = mesh.textures.ToArray();
             var faces = facesToConvert as Face[] ?? facesToConvert.ToArray();
 
             foreach (var face in faces)
@@ -50,7 +50,7 @@ namespace UnityEngine.ProBuilder.MeshOperations
             }
 
 	        mesh.RefreshUV(faces);
-            var textures = mesh.texturesInternal;
+            var unmodifiedProjection = mesh.texturesInternal;
 
             foreach (var face in faces)
             {
@@ -58,20 +58,20 @@ namespace UnityEngine.ProBuilder.MeshOperations
 	            var distinct = face.distinctIndexesInternal;
 
 	            // rotate to match target points by comparing the angle between old UV and new auto projection
-	            Vector2 dstAngle = origins[indices[1]] - origins[indices[0]];
-	            Vector2 srcAngle = textures[indices[1]] - textures[indices[0]];
+	            Vector2 dstAngle = destinationTextures[indices[1]] - destinationTextures[indices[0]];
+	            Vector2 srcAngle = unmodifiedProjection[indices[1]] - unmodifiedProjection[indices[0]];
 	            float rotation = Vector2.Angle(dstAngle, srcAngle);
 	            if (Vector2.Dot(Vector2.Perpendicular(dstAngle), srcAngle) < 0)
 		            rotation = 360f - rotation;
 
 				// inverse the rotation to get an axis-aligned scale
-	            Vector2 dstCenter = Bounds2D.Center(origins, indices);
+	            Vector2 dstCenter = Bounds2D.Center(destinationTextures, indices);
 
 	            for (int i = 0, c = distinct.Length; i < c; i++)
-		            origins[distinct[i]] = origins[distinct[i]].RotateAroundPoint(dstCenter, -rotation);
+		            destinationTextures[distinct[i]] = destinationTextures[distinct[i]].RotateAroundPoint(dstCenter, -rotation);
 
-	            var dstBounds = new Bounds2D(origins, indices);
-	            var srcBounds = new Bounds2D(textures, indices);
+	            var dstBounds = new Bounds2D(destinationTextures, indices);
+	            var srcBounds = new Bounds2D(unmodifiedProjection, indices);
 
 	            Vector2 scale = dstBounds.size.DivideBy(srcBounds.size);
 	            Vector2 translation = dstCenter - srcBounds.center;
@@ -84,6 +84,78 @@ namespace UnityEngine.ProBuilder.MeshOperations
             }
 
             mesh.RefreshUV(faces);
+        }
+
+        internal struct UVTransform
+        {
+	        public Vector2 translation;
+	        public float rotation;
+	        public Vector2 scale;
+        }
+
+//        internal static UVTransform CalculateTransform(ProBuilderMesh mesh, Face face)
+//        {
+//			var unmodifiedProjection = Projection.PlanarProject(mesh.positions, face.distinctIndexesInternal, Math.Normal(mesh, face));
+//
+//	        return new UVTransform()
+//		        { };
+//        }
+
+        internal static UVTransform CalculateDelta(IList<Vector2> src, IList<Vector2> dst, IList<int> indices)
+        {
+	        // rotate to match target points by comparing the angle between old UV and new auto projection
+	        Vector2 dstAngle = dst[indices[1]] - dst[indices[0]];
+	        Vector2 srcAngle = src[indices[1]] - src[indices[0]];
+	        float rotation = Vector2.Angle(dstAngle, srcAngle);
+	        if (Vector2.Dot(Vector2.Perpendicular(dstAngle), srcAngle) < 0)
+		        rotation = 360f - rotation;
+
+	        Vector2 dstCenter = Bounds2D.Center(dst, indices);
+
+	        // inverse the rotation to get an axis-aligned scale
+	        Vector2 dstSize = GetRotatedSize(dst, indices, dstCenter, -rotation);
+
+	        var srcBounds = new Bounds2D(src, indices);
+
+			return new UVTransform()
+			{
+				translation = dstCenter - srcBounds.center,
+				rotation = rotation,
+				scale = dstSize.DivideBy(srcBounds.size)
+			};
+        }
+
+        static Vector2 GetRotatedSize(IList<Vector2> points, IList<int> indices, Vector2 center, float rotation)
+        {
+	        float xMin = 0f,
+		        xMax = 0f,
+		        yMin = 0f,
+		        yMax = 0f;
+
+	        int size = indices.Count;
+
+	        Vector2 point = points[indices[0]].RotateAroundPoint(center, rotation);
+
+	        xMin = point.x;
+	        yMin = point.y;
+	        xMax = xMin;
+	        yMax = yMin;
+
+	        for (int i = 1; i < size; i++)
+	        {
+		        point = points[indices[i]].RotateAroundPoint(center, rotation);
+
+		        float x = point.x;
+		        float y = point.y;
+
+		        if (x < xMin) xMin = x;
+		        if (x > xMax) xMax = x;
+
+		        if (y < yMin) yMin = y;
+		        if (y > yMax) yMax = y;
+	        }
+
+	        return new Vector2(xMax - xMin, yMax - yMin);
         }
 	}
 }

--- a/com.unity.probuilder/Runtime/MeshOperations/UV/AutoUvConversion.cs
+++ b/com.unity.probuilder/Runtime/MeshOperations/UV/AutoUvConversion.cs
@@ -29,93 +29,99 @@ namespace UnityEngine.ProBuilder.MeshOperations
 			}
 		}
 
-        /// <summary>
-        /// Reset the AutoUnwrapParameters of a set of faces to best match their current UV coordinates.
-        /// </summary>
-        /// <remarks>
-        /// Auto UVs do not support distortion, so this conversion process cannot be loss-less. However as long as there
-        /// is minimal skewing the results are usually very close.
-        /// </remarks>
-        internal static void SetAutoAndAlignUnwrapParamsToUVs(ProBuilderMesh mesh, IEnumerable<Face> facesToConvert)
-        {
-            var destinationTextures = mesh.textures.ToArray();
-            var faces = facesToConvert as Face[] ?? facesToConvert.ToArray();
+		/// <summary>
+		/// Reset the AutoUnwrapParameters of a set of faces to best match their current UV coordinates.
+		/// </summary>
+		/// <remarks>
+		/// Auto UVs do not support distortion, so this conversion process cannot be loss-less. However as long as there
+		/// is minimal skewing the results are usually very close.
+		/// </remarks>
+		internal static void SetAutoAndAlignUnwrapParamsToUVs(ProBuilderMesh mesh, IEnumerable<Face> facesToConvert)
+		{
+			var destinationTextures = mesh.textures.ToArray();
+			var faces = facesToConvert as Face[] ?? facesToConvert.ToArray();
 
-            foreach (var face in faces)
-            {
-	            face.uv = AutoUnwrapSettings.defaultAutoUnwrapSettings;
+			foreach (var face in faces)
+			{
+				face.uv = AutoUnwrapSettings.defaultAutoUnwrapSettings;
 				face.elementGroup = -1;
 				face.textureGroup = -1;
-	            face.manualUV = false;
-            }
+				face.manualUV = false;
+			}
 
-	        mesh.RefreshUV(faces);
-            var unmodifiedProjection = mesh.texturesInternal;
+			mesh.RefreshUV(faces);
+			var unmodifiedProjection = mesh.texturesInternal;
 
-            foreach (var face in faces)
-            {
-	            var indices = face.indexesInternal;
-	            var distinct = face.distinctIndexesInternal;
+			foreach (var face in faces)
+			{
+				var trs = CalculateDelta(unmodifiedProjection, face.indexesInternal, destinationTextures, face.indexesInternal);
+				var uv = face.uv;
 
-	            // rotate to match target points by comparing the angle between old UV and new auto projection
-	            Vector2 dstAngle = destinationTextures[indices[1]] - destinationTextures[indices[0]];
-	            Vector2 srcAngle = unmodifiedProjection[indices[1]] - unmodifiedProjection[indices[0]];
-	            float rotation = Vector2.Angle(dstAngle, srcAngle);
-	            if (Vector2.Dot(Vector2.Perpendicular(dstAngle), srcAngle) < 0)
-		            rotation = 360f - rotation;
+				// offset is flipped for legacy reasons. people were confused that positive offsets moved the texture
+				// in negative directions in the scene-view, but positive in UV window. if changed we would need to
+				// write some way of upgrading the unwrap settings to account for this.
+				uv.offset = -trs.translation;
+				uv.rotation = trs.rotation;
+				uv.scale = trs.scale;
+				face.uv = uv;
+			}
 
-				// inverse the rotation to get an axis-aligned scale
-	            Vector2 dstCenter = Bounds2D.Center(destinationTextures, indices);
+			mesh.RefreshUV(faces);
+		}
 
-	            for (int i = 0, c = distinct.Length; i < c; i++)
-		            destinationTextures[distinct[i]] = destinationTextures[distinct[i]].RotateAroundPoint(dstCenter, -rotation);
+		internal struct UVTransform
+		{
+			public Vector2 translation;
+			public float rotation;
+			public Vector2 scale;
 
-	            var dstBounds = new Bounds2D(destinationTextures, indices);
-	            var srcBounds = new Bounds2D(unmodifiedProjection, indices);
+			public override string ToString()
+			{
+				return translation.ToString("F2") + ", " + rotation + ", " + scale.ToString("F2");
+			}
+		}
 
-	            Vector2 scale = dstBounds.size.DivideBy(srcBounds.size);
-	            Vector2 translation = dstCenter - srcBounds.center;
+		static List<Vector2> s_UVTransformProjectionBuffer = new List<Vector2>(8);
 
-	            var uv = face.uv;
-	            uv.offset = -translation;
-	            uv.rotation = rotation;
-	            uv.scale = scale;
-	            face.uv = uv;
-            }
+		/// <summary>
+		/// Attempt to calculate the UV transform for a face. In cases where the face is auto unwrapped
+		/// (manualUV = false), this returns the offset, rotation, and scale from <see cref="Face.uv"/>. If the face is
+		/// manually unwrapped, a transform will be calculated by trying to match an unmodified planar projection to the
+		/// current UVs. The results
+		/// </summary>
+		/// <returns></returns>
+		internal static UVTransform GetUVTransform(ProBuilderMesh mesh, Face face)
+		{
+			Projection.PlanarProject(mesh.positionsInternal, face.indexesInternal, Math.Normal(mesh, face), s_UVTransformProjectionBuffer);
+			return CalculateDelta(mesh.texturesInternal, face.indexesInternal, s_UVTransformProjectionBuffer, null);
+		}
 
-            mesh.RefreshUV(faces);
-        }
+		// messy hack to support cases where you want to iterate a collection of values with an optional collection of
+		// indices. do not make public.
+		static int GetIndex(IList<int> collection, int index)
+		{
+			return collection == null ? index : collection[index];
+		}
 
-        internal struct UVTransform
-        {
-	        public Vector2 translation;
-	        public float rotation;
-	        public Vector2 scale;
-        }
-
-//        internal static UVTransform CalculateTransform(ProBuilderMesh mesh, Face face)
-//        {
-//			var unmodifiedProjection = Projection.PlanarProject(mesh.positions, face.distinctIndexesInternal, Math.Normal(mesh, face));
-//
-//	        return new UVTransform()
-//		        { };
-//        }
-
-        internal static UVTransform CalculateDelta(IList<Vector2> src, IList<Vector2> dst, IList<int> indices)
+		// indices arrays are optional - if null is passed the index will be 0, 1, 2... up to values array length.
+		// this is done to avoid allocating a separate array just to pass linear indices
+		internal static UVTransform CalculateDelta(IList<Vector2> src, IList<int> srcIndices, IList<Vector2> dst, IList<int> dstIndices)
         {
 	        // rotate to match target points by comparing the angle between old UV and new auto projection
-	        Vector2 dstAngle = dst[indices[1]] - dst[indices[0]];
-	        Vector2 srcAngle = src[indices[1]] - src[indices[0]];
+	        Vector2 dstAngle = dst[GetIndex(dstIndices, 1)] - dst[GetIndex(dstIndices, 0)];
+	        Vector2 srcAngle = src[GetIndex(srcIndices, 1)] - src[GetIndex(srcIndices, 0)];
+
 	        float rotation = Vector2.Angle(dstAngle, srcAngle);
+
 	        if (Vector2.Dot(Vector2.Perpendicular(dstAngle), srcAngle) < 0)
 		        rotation = 360f - rotation;
 
-	        Vector2 dstCenter = Bounds2D.Center(dst, indices);
+	        Vector2 dstCenter = dstIndices == null ? Bounds2D.Center(dst) : Bounds2D.Center(dst, dstIndices);
 
 	        // inverse the rotation to get an axis-aligned scale
-	        Vector2 dstSize = GetRotatedSize(dst, indices, dstCenter, -rotation);
+	        Vector2 dstSize = GetRotatedSize(dst, dstIndices, dstCenter, -rotation);
 
-	        var srcBounds = new Bounds2D(src, indices);
+	        var srcBounds = srcIndices == null ? new Bounds2D(src) : new Bounds2D(src, srcIndices);
 
 			return new UVTransform()
 			{
@@ -127,23 +133,18 @@ namespace UnityEngine.ProBuilder.MeshOperations
 
         static Vector2 GetRotatedSize(IList<Vector2> points, IList<int> indices, Vector2 center, float rotation)
         {
-	        float xMin = 0f,
-		        xMax = 0f,
-		        yMin = 0f,
-		        yMax = 0f;
+	        int size = indices == null ? points.Count : indices.Count;
 
-	        int size = indices.Count;
+	        Vector2 point = points[GetIndex(indices, 0)].RotateAroundPoint(center, rotation);
 
-	        Vector2 point = points[indices[0]].RotateAroundPoint(center, rotation);
-
-	        xMin = point.x;
-	        yMin = point.y;
-	        xMax = xMin;
-	        yMax = yMin;
+	        float xMin = point.x;
+	        float yMin = point.y;
+	        float xMax = xMin;
+	        float yMax = yMin;
 
 	        for (int i = 1; i < size; i++)
 	        {
-		        point = points[indices[i]].RotateAroundPoint(center, rotation);
+		        point = points[GetIndex(indices, i)].RotateAroundPoint(center, rotation);
 
 		        float x = point.x;
 		        float y = point.y;

--- a/com.unity.probuilder/Runtime/MeshOperations/UV/UvUnwrapping.cs
+++ b/com.unity.probuilder/Runtime/MeshOperations/UV/UvUnwrapping.cs
@@ -8,7 +8,7 @@ namespace UnityEngine.ProBuilder
     {
         static Vector2 s_TempVector2 = Vector2.zero;
 
-        internal static void Project(ProBuilderMesh mesh, Face face)
+        internal static void Unwrap(ProBuilderMesh mesh, Face face)
         {
             Projection.PlanarProject(mesh, face);
             ApplyUVSettings(mesh.texturesInternal, face.distinctIndexesInternal, face.uv);


### PR DESCRIPTION
Fixes an issue where translating a face's texture selection would not account for the object scale or it's projected UV scale.

https://unity3d.atlassian.net/browse/WB-120

## Before 

![uv-broken2](https://user-images.githubusercontent.com/1683036/53655450-36f19c00-3c1e-11e9-9596-8ccaebc237cf.gif)

## After

![uv-fixed](https://user-images.githubusercontent.com/1683036/53655455-3d801380-3c1e-11e9-8f43-766bd1eeec22.gif)


## Known issues

This fix only works for faces, for which in most cases a sane scale value value can be parsed. Translating vertices and edges will still have the appearance of moving out of sync with the translation handle.