### PR TITLE
Fix vertex preview highlight rendering slightly offset of vertex

### DIFF
--- a/com.unity.probuilder/Content/Shader/PointBillboard.shader
+++ b/com.unity.probuilder/Content/Shader/PointBillboard.shader
@@ -85,7 +85,7 @@ Shader "Hidden/ProBuilder/PointBillboard"
                     GS_INPUT output = (GS_INPUT)0;
 
                     output.pos = float4(UnityObjectToViewPos(v.vertex.xyz), 1);
-                    output.pos.xyz *= lerp(.98, .95, ORTHO);
+                    output.pos.xyz *= lerp(.99, .95, ORTHO);
                     output.pos = mul(UNITY_MATRIX_P, output.pos);
                     // convert clip -> ndc -> screen, build billboards in geo shader, then screen -> ndc -> clip
                     output.pos = ClipToScreen(output.pos);

--- a/com.unity.probuilder/Content/Shader/VertexPicker.shader
+++ b/com.unity.probuilder/Content/Shader/VertexPicker.shader
@@ -29,6 +29,9 @@ CGPROGRAM
             #pragma fragment frag
             #include "UnityCG.cginc"
 
+            // Is the camera in orthographic mode? (1 yes, 0 no)
+            #define ORTHO (1 - UNITY_MATRIX_P[3][3])
+
             struct appdata
             {
                 float4 vertex : POSITION;
@@ -50,7 +53,7 @@ CGPROGRAM
                 v2f o;
 
                 o.pos = float4(UnityObjectToViewPos(v.vertex.xyz), 1);
-                o.pos.xyz *= .95;
+                o.pos.xyz *= lerp(.99, .95, ORTHO);
                 o.pos = mul(UNITY_MATRIX_P, o.pos);
 
                 // convert vertex to screen space, add pixel-unit xy to vertex, then transform back to clip space.

--- a/com.unity.probuilder/Editor/EditorCore/EditorMeshHandles.cs
+++ b/com.unity.probuilder/Editor/EditorCore/EditorMeshHandles.cs
@@ -107,6 +107,7 @@ namespace UnityEditor.ProBuilder
         static Color s_VertexUnselectedColor;
 
         Material m_EdgeMaterial;
+        // Can be either point geo shader or the older vertex shader
         Material m_VertMaterial;
         Material m_WireMaterial;
         Material m_LineMaterial;
@@ -115,41 +116,6 @@ namespace UnityEditor.ProBuilder
         internal static float dotCapSize
         {
             get { return s_VertexPointSize * .0125f; }
-        }
-
-        public static Color faceSelectedColor
-        {
-            get { return s_FaceSelectedColor; }
-        }
-
-        public static Color wireframeColor
-        {
-            get { return s_WireframeColor; }
-        }
-
-        public static Color preselectionColor
-        {
-            get { return s_PreselectionColor; }
-        }
-
-        public static Color edgeSelectedColor
-        {
-            get { return s_EdgeSelectedColor; }
-        }
-
-        public static Color edgeUnselectedColor
-        {
-            get { return s_EdgeUnselectedColor; }
-        }
-
-        public static Color vertexSelectedColor
-        {
-            get { return s_VertexSelectedColor; }
-        }
-
-        public static Color vertexUnselectedColor
-        {
-            get { return s_VertexUnselectedColor; }
         }
 
         EditorMeshHandles()
@@ -294,7 +260,7 @@ namespace UnityEditor.ProBuilder
             // Draw nearest edge
             if (selection.face != null)
             {
-                using (new TriangleDrawingScope(preselectionColor))
+                using (new TriangleDrawingScope(s_PreselectionColor))
                 {
                     GL.MultMatrix(mesh.transform.localToWorldMatrix);
 
@@ -304,14 +270,14 @@ namespace UnityEditor.ProBuilder
                     for (int i = 0, c = ind.Count; i < c; i += 3)
                     {
                         GL.Vertex(positions[ind[i]]);
-                        GL.Vertex(positions[ind[i + 1]]);
-                        GL.Vertex(positions[ind[i + 2]]);
+                        GL.Vertex(positions[ind[i+1]]);
+                        GL.Vertex(positions[ind[i+2]]);
                     }
                 }
             }
             else if (selection.edge != Edge.Empty)
             {
-                using (var drawingScope = new LineDrawingScope(preselectionColor, -1f, CompareFunction.Always))
+                using (var drawingScope = new LineDrawingScope(s_PreselectionColor, -1f, CompareFunction.Always))
                 {
                     GL.MultMatrix(mesh.transform.localToWorldMatrix);
                     drawingScope.DrawLine(positions[selection.edge.a], positions[selection.edge.b]);
@@ -319,12 +285,9 @@ namespace UnityEditor.ProBuilder
             }
             else if (selection.vertex > -1)
             {
-                var size = dotCapSize;
-
-                using (new Handles.DrawingScope(preselectionColor, mesh.transform.localToWorldMatrix))
+                using (var drawingScope = new PointDrawingScope(s_PreselectionColor, CompareFunction.Always) { matrix = mesh.transform.localToWorldMatrix })
                 {
-                    var pos = positions[selection.vertex];
-                    Handles.DotHandleCap(-1, pos, Quaternion.identity, HandleUtility.GetHandleSize(pos) * size, Event.current.type);
+                    drawingScope.Draw(positions[selection.vertex]);
                 }
             }
         }

--- a/com.unity.probuilder/Editor/EditorCore/StaticEditorMeshHandles.cs
+++ b/com.unity.probuilder/Editor/EditorCore/StaticEditorMeshHandles.cs
@@ -129,11 +129,12 @@ namespace UnityEditor.ProBuilder
 
                     m_Mesh.SetVertices(m_Points);
 
-#if UNITY_2019_1_OR_NEWER
-                    m_Mesh.SetIndices(NoAllocHelpers.ExtractArrayFromListT(s_Indices), MeshTopology.Points, 0, false);
-#else
+                    // NoAllocHelpers is internal API, and there is no SetIndices overload that accepts a list like
+                    // SetVertices or SetUVs.
+//#if UNITY_2019_1_OR_NEWER
+//                    m_Mesh.SetIndices(NoAllocHelpers.ExtractArrayFromListT(m_Indices), MeshTopology.Points, 0, false);
+//#else
                     m_Mesh.SetIndices(m_Indices.ToArray(), MeshTopology.Points, 0, false);
-#endif
                 }
                 else
                 {

--- a/com.unity.probuilder/Editor/EditorCore/StaticEditorMeshHandles.cs
+++ b/com.unity.probuilder/Editor/EditorCore/StaticEditorMeshHandles.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using UnityEngine;
 using UObject = UnityEngine.Object;
 using UnityEngine.ProBuilder;
@@ -53,6 +54,112 @@ namespace UnityEditor.ProBuilder
             Handles.DotHandleCap(0, p + matrix.MultiplyVector(direction) * d, Quaternion.identity, s * dotCapSize, e);
             Handles.DrawLine(p, p + matrix.MultiplyVector(direction) * d);
             Handles.color = Color.white;
+        }
+
+        internal struct PointDrawingScope : IDisposable
+        {
+            Color m_Color;
+            CompareFunction m_ZTest;
+            bool m_IsDisposed;
+            Mesh m_Mesh;
+            List<Vector3> m_Points;
+            List<int> m_Indices;
+            Matrix4x4 m_Matrix;
+
+            public Color color
+            {
+                get { return m_Color; }
+                set
+                {
+                    End();
+                    m_Color = value;
+                    Begin();
+                }
+            }
+
+            public CompareFunction zTest
+            {
+                get { return m_ZTest; }
+
+                set
+                {
+                    End();
+                    m_ZTest = value;
+                    Begin();
+                }
+            }
+
+            public Matrix4x4 matrix
+            {
+                get { return m_Matrix; }
+                set { m_Matrix = value; }
+            }
+
+            public PointDrawingScope(Color color, CompareFunction zTest = CompareFunction.LessEqual)
+            {
+                m_Color = color;
+                m_ZTest = zTest;
+                m_IsDisposed = false;
+                m_Mesh = Get().m_MeshPool.Get();
+                m_Points = new List<Vector3>(64);
+                m_Indices = new List<int>(64);
+                m_Matrix = Matrix4x4.identity;
+                Begin();
+            }
+
+            void Begin()
+            {
+                Get().m_VertMaterial.SetColor("_Color", color);
+                Get().m_VertMaterial.SetInt("_HandleZTest", (int)zTest);
+
+                if (!Get().m_VertMaterial.SetPass(0))
+                    throw new Exception("Failed initializing vertex material.");
+
+                m_Points.Clear();
+            }
+
+            void End()
+            {
+                m_Mesh.Clear();
+
+                if (BuiltinMaterials.geometryShadersSupported)
+                {
+                    for (int i = 0, c = m_Points.Count; i < c; ++i)
+                        m_Indices.Add(i);
+
+                    m_Mesh.SetVertices(m_Points);
+
+#if UNITY_2019_1_OR_NEWER
+                    m_Mesh.SetIndices(NoAllocHelpers.ExtractArrayFromListT(s_Indices), MeshTopology.Points, 0, false);
+#else
+                    m_Mesh.SetIndices(m_Indices.ToArray(), MeshTopology.Points, 0, false);
+#endif
+                }
+                else
+                {
+                    MeshHandles.CreatePointBillboardMesh(m_Points, m_Mesh);
+                }
+
+                Graphics.DrawMeshNow(m_Mesh, m_Matrix, 0);
+            }
+
+            public void Dispose()
+            {
+                if (m_IsDisposed)
+                    return;
+
+                m_IsDisposed = true;
+
+                End();
+
+                if(m_Mesh != null)
+                    Get().m_MeshPool.Put(m_Mesh);
+            }
+
+            public void Draw(Vector3 point)
+            {
+                m_Points.Add(point);
+            }
         }
 
         internal class LineDrawingScope : IDisposable


### PR DESCRIPTION
https://unity3d.atlassian.net/browse/WB-695

It is most noticeable in iso views.

This also reduces the amount of offset applied to vertex billboards when in iso mode and using geometry shaders from .98 to .99.