### PR TITLE
remove menuitem shortcut conflicts

### DIFF
--- a/com.unity.probuilder/Debug/Editor/GenerateMenuItems.cs
+++ b/com.unity.probuilder/Debug/Editor/GenerateMenuItems.cs
@@ -65,7 +65,6 @@ namespace UnityEditor.ProBuilder
                 {
                     PropertyInfo hasMenuEntryProperty = typeof(MenuAction).GetProperty("hasFileMenuEntry", BindingFlags.NonPublic | BindingFlags.Instance);
                     visibleInMenu = hasMenuEntryProperty != null && (bool)hasMenuEntryProperty.GetValue(instance, null);
-
                     menuItemShortcut = instance.tooltip.shortcut;
                 }
             }
@@ -104,7 +103,8 @@ namespace UnityEditor.ProBuilder
             {
                 var data = new MenuActionData(action);
 
-//                UnityEngine.Debug.Log($"{data.visibleInMenu}\n{data.typeString}\n{data.path}\n{data.menuItemShortcut}");
+                if (!data.visibleInMenu)
+                    continue;
 
                 if (data.valid)
                 {
@@ -161,12 +161,11 @@ namespace UnityEditor.ProBuilder
 
             var category = GetActionCategory(data.path);
             var priority = GetMenuPriority(category);
-            var shortcut = GetMenuFormattedShortcut(data.menuItemShortcut);
+            var menuItemShortcut = GetMenuFormattedShortcut(data.menuItemShortcut);
 
             sb.AppendLine();
 
 #if SHORTCUT_MANAGER
-
             var shortcutInfo = data.type.GetCustomAttribute<MenuActionShortcutAttribute>();
 
             if (shortcutInfo != null)
@@ -186,7 +185,7 @@ namespace UnityEditor.ProBuilder
 #endif
 
             // Action
-            sb.AppendLine($"\t\t[MenuItem(k_MenuPrefix + \"{data.path}{shortcut}\", false, {priority})]");
+            sb.AppendLine($"\t\t[MenuItem(k_MenuPrefix + \"{data.path}{menuItemShortcut}\", false, {priority})]");
             sb.AppendLine($"\t\tstatic void MenuPerform_{data.typeString}()");
             sb.AppendLine( "\t\t{");
             sb.AppendLine($"\t\t\tvar instance = EditorToolbarLoader.GetInstance<{data.typeString}>();");

--- a/com.unity.probuilder/Editor/EditorCore/EditorToolbarMenuItems.cs
+++ b/com.unity.probuilder/Editor/EditorCore/EditorToolbarMenuItems.cs
@@ -82,21 +82,6 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Editors/Open Shape Editor ", true)]
-		static bool MenuVerify_OpenShapeEditor()
-		{
-			var instance = EditorToolbarLoader.GetInstance<OpenShapeEditor>();
-			return instance != null && instance.enabled;
-		}
-
-		[MenuItem(k_MenuPrefix + "Editors/Open Shape Editor %#k", false, PreferenceKeys.menuEditor + 1)]
-		static void MenuPerform_OpenShapeEditor()
-		{
-			var instance = EditorToolbarLoader.GetInstance<OpenShapeEditor>();
-			if(instance != null && instance.enabled)
-				EditorUtility.ShowNotification(instance.DoAction().notification);
-		}
-
 		[MenuItem(k_MenuPrefix + "Editors/Open Shape Editor Menu Item ", true)]
 		static bool MenuVerify_OpenShapeEditorMenuItem()
 		{
@@ -168,21 +153,6 @@ namespace UnityEditor.ProBuilder
 		static void MenuPerform_OpenVertexPositionEditor()
 		{
 			var instance = EditorToolbarLoader.GetInstance<OpenVertexPositionEditor>();
-			if(instance != null && instance.enabled)
-				EditorUtility.ShowNotification(instance.DoAction().notification);
-		}
-
-		[MenuItem(k_MenuPrefix + "Export/Export ", true)]
-		static bool MenuVerify_Export()
-		{
-			var instance = EditorToolbarLoader.GetInstance<Export>();
-			return instance != null && instance.enabled;
-		}
-
-		[MenuItem(k_MenuPrefix + "Export/Export", false, PreferenceKeys.menuExport + 0)]
-		static void MenuPerform_Export()
-		{
-			var instance = EditorToolbarLoader.GetInstance<Export>();
 			if(instance != null && instance.enabled)
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
@@ -322,36 +292,6 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Geometry/Connect Edges ", true)]
-		static bool MenuVerify_ConnectEdges()
-		{
-			var instance = EditorToolbarLoader.GetInstance<ConnectEdges>();
-			return instance != null && instance.enabled;
-		}
-
-		[MenuItem(k_MenuPrefix + "Geometry/Connect Edges &e", false, PreferenceKeys.menuGeometry + 3)]
-		static void MenuPerform_ConnectEdges()
-		{
-			var instance = EditorToolbarLoader.GetInstance<ConnectEdges>();
-			if(instance != null && instance.enabled)
-				EditorUtility.ShowNotification(instance.DoAction().notification);
-		}
-
-		[MenuItem(k_MenuPrefix + "Geometry/Connect Vertices ", true)]
-		static bool MenuVerify_ConnectVertices()
-		{
-			var instance = EditorToolbarLoader.GetInstance<ConnectVertices>();
-			return instance != null && instance.enabled;
-		}
-
-		[MenuItem(k_MenuPrefix + "Geometry/Connect Vertices &e", false, PreferenceKeys.menuGeometry + 3)]
-		static void MenuPerform_ConnectVertices()
-		{
-			var instance = EditorToolbarLoader.GetInstance<ConnectVertices>();
-			if(instance != null && instance.enabled)
-				EditorUtility.ShowNotification(instance.DoAction().notification);
-		}
-
 		[MenuItem(k_MenuPrefix + "Geometry/Delete Faces ", true)]
 		static bool MenuVerify_DeleteFaces()
 		{
@@ -396,36 +336,6 @@ namespace UnityEditor.ProBuilder
 		static void MenuPerform_Extrude()
 		{
 			var instance = EditorToolbarLoader.GetInstance<Extrude>();
-			if(instance != null && instance.enabled)
-				EditorUtility.ShowNotification(instance.DoAction().notification);
-		}
-
-		[MenuItem(k_MenuPrefix + "Geometry/Extrude Edges ", true)]
-		static bool MenuVerify_ExtrudeEdges()
-		{
-			var instance = EditorToolbarLoader.GetInstance<ExtrudeEdges>();
-			return instance != null && instance.enabled;
-		}
-
-		[MenuItem(k_MenuPrefix + "Geometry/Extrude Edges %e", false, PreferenceKeys.menuGeometry + 3)]
-		static void MenuPerform_ExtrudeEdges()
-		{
-			var instance = EditorToolbarLoader.GetInstance<ExtrudeEdges>();
-			if(instance != null && instance.enabled)
-				EditorUtility.ShowNotification(instance.DoAction().notification);
-		}
-
-		[MenuItem(k_MenuPrefix + "Geometry/Extrude Faces ", true)]
-		static bool MenuVerify_ExtrudeFaces()
-		{
-			var instance = EditorToolbarLoader.GetInstance<ExtrudeFaces>();
-			return instance != null && instance.enabled;
-		}
-
-		[MenuItem(k_MenuPrefix + "Geometry/Extrude Faces %e", false, PreferenceKeys.menuGeometry + 3)]
-		static void MenuPerform_ExtrudeFaces()
-		{
-			var instance = EditorToolbarLoader.GetInstance<ExtrudeFaces>();
 			if(instance != null && instance.enabled)
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
@@ -561,36 +471,6 @@ namespace UnityEditor.ProBuilder
 		static void MenuPerform_SplitVertices()
 		{
 			var instance = EditorToolbarLoader.GetInstance<SplitVertices>();
-			if(instance != null && instance.enabled)
-				EditorUtility.ShowNotification(instance.DoAction().notification);
-		}
-
-		[MenuItem(k_MenuPrefix + "Geometry/Subdivide Edges ", true)]
-		static bool MenuVerify_SubdivideEdges()
-		{
-			var instance = EditorToolbarLoader.GetInstance<SubdivideEdges>();
-			return instance != null && instance.enabled;
-		}
-
-		[MenuItem(k_MenuPrefix + "Geometry/Subdivide Edges &s", false, PreferenceKeys.menuGeometry + 3)]
-		static void MenuPerform_SubdivideEdges()
-		{
-			var instance = EditorToolbarLoader.GetInstance<SubdivideEdges>();
-			if(instance != null && instance.enabled)
-				EditorUtility.ShowNotification(instance.DoAction().notification);
-		}
-
-		[MenuItem(k_MenuPrefix + "Geometry/Subdivide Faces ", true)]
-		static bool MenuVerify_SubdivideFaces()
-		{
-			var instance = EditorToolbarLoader.GetInstance<SubdivideFaces>();
-			return instance != null && instance.enabled;
-		}
-
-		[MenuItem(k_MenuPrefix + "Geometry/Subdivide Faces &s", false, PreferenceKeys.menuGeometry + 3)]
-		static void MenuPerform_SubdivideFaces()
-		{
-			var instance = EditorToolbarLoader.GetInstance<SubdivideFaces>();
 			if(instance != null && instance.enabled)
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
@@ -748,21 +628,6 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Object/Generate U V2 ", true)]
-		static bool MenuVerify_GenerateUV2()
-		{
-			var instance = EditorToolbarLoader.GetInstance<GenerateUV2>();
-			return instance != null && instance.enabled;
-		}
-
-		[MenuItem(k_MenuPrefix + "Object/Generate U V2", false, PreferenceKeys.menuGeometry + 2)]
-		static void MenuPerform_GenerateUV2()
-		{
-			var instance = EditorToolbarLoader.GetInstance<GenerateUV2>();
-			if(instance != null && instance.enabled)
-				EditorUtility.ShowNotification(instance.DoAction().notification);
-		}
-
 		[MenuItem(k_MenuPrefix + "Object/Merge Objects ", true)]
 		static bool MenuVerify_MergeObjects()
 		{
@@ -834,7 +699,7 @@ namespace UnityEditor.ProBuilder
 		}
 
 #if SHORTCUT_MANAGER
-		[Shortcut(k_ShortcutPrefix + "Object/Set Trigger", typeof(UnityEditor.SceneView), (KeyCode) 116, (ShortcutModifiers) 0)]
+		[Shortcut(k_ShortcutPrefix + "Object/Set Trigger", typeof(UnityEditor.SceneView), (KeyCode) 0, (ShortcutModifiers) 0)]
 #endif
 		[MenuItem(k_MenuPrefix + "Object/Set Trigger", false, PreferenceKeys.menuGeometry + 2)]
 		static void MenuPerform_SetTrigger()
@@ -900,66 +765,6 @@ namespace UnityEditor.ProBuilder
 		static void MenuPerform_InvertSelection()
 		{
 			var instance = EditorToolbarLoader.GetInstance<InvertSelection>();
-			if(instance != null && instance.enabled)
-				EditorUtility.ShowNotification(instance.DoAction().notification);
-		}
-
-		[MenuItem(k_MenuPrefix + "Selection/Select Edge Loop ", true)]
-		static bool MenuVerify_SelectEdgeLoop()
-		{
-			var instance = EditorToolbarLoader.GetInstance<SelectEdgeLoop>();
-			return instance != null && instance.enabled;
-		}
-
-		[MenuItem(k_MenuPrefix + "Selection/Select Edge Loop &l", false, PreferenceKeys.menuSelection + 0)]
-		static void MenuPerform_SelectEdgeLoop()
-		{
-			var instance = EditorToolbarLoader.GetInstance<SelectEdgeLoop>();
-			if(instance != null && instance.enabled)
-				EditorUtility.ShowNotification(instance.DoAction().notification);
-		}
-
-		[MenuItem(k_MenuPrefix + "Selection/Select Edge Ring ", true)]
-		static bool MenuVerify_SelectEdgeRing()
-		{
-			var instance = EditorToolbarLoader.GetInstance<SelectEdgeRing>();
-			return instance != null && instance.enabled;
-		}
-
-		[MenuItem(k_MenuPrefix + "Selection/Select Edge Ring &r", false, PreferenceKeys.menuSelection + 0)]
-		static void MenuPerform_SelectEdgeRing()
-		{
-			var instance = EditorToolbarLoader.GetInstance<SelectEdgeRing>();
-			if(instance != null && instance.enabled)
-				EditorUtility.ShowNotification(instance.DoAction().notification);
-		}
-
-		[MenuItem(k_MenuPrefix + "Selection/Select Face Loop ", true)]
-		static bool MenuVerify_SelectFaceLoop()
-		{
-			var instance = EditorToolbarLoader.GetInstance<SelectFaceLoop>();
-			return instance != null && instance.enabled;
-		}
-
-		[MenuItem(k_MenuPrefix + "Selection/Select Face Loop", false, PreferenceKeys.menuSelection + 0)]
-		static void MenuPerform_SelectFaceLoop()
-		{
-			var instance = EditorToolbarLoader.GetInstance<SelectFaceLoop>();
-			if(instance != null && instance.enabled)
-				EditorUtility.ShowNotification(instance.DoAction().notification);
-		}
-
-		[MenuItem(k_MenuPrefix + "Selection/Select Face Ring ", true)]
-		static bool MenuVerify_SelectFaceRing()
-		{
-			var instance = EditorToolbarLoader.GetInstance<SelectFaceRing>();
-			return instance != null && instance.enabled;
-		}
-
-		[MenuItem(k_MenuPrefix + "Selection/Select Face Ring", false, PreferenceKeys.menuSelection + 0)]
-		static void MenuPerform_SelectFaceRing()
-		{
-			var instance = EditorToolbarLoader.GetInstance<SelectFaceRing>();
 			if(instance != null && instance.enabled)
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}

--- a/com.unity.probuilder/Editor/MenuActions/Object/SetTrigger.cs
+++ b/com.unity.probuilder/Editor/MenuActions/Object/SetTrigger.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 namespace UnityEditor.ProBuilder.Actions
 {
-    [MenuActionShortcut(typeof(SceneView), KeyCode.T)]
+    [MenuActionShortcut(typeof(SceneView))]
     sealed class SetTrigger : MenuAction
     {
         public override ToolbarGroup group


### PR DESCRIPTION
Fixes an issue where ShortcutManager would report conflicting shortcuts for MenuItems sharing a KeyCombination but differentiated by context.