### PR TITLE
Save all settings on application quit

### DIFF
--- a/com.unity.probuilder/Content/Resources/Materials/FacePicker.mat
+++ b/com.unity.probuilder/Content/Resources/Materials/FacePicker.mat
@@ -21,4 +21,4 @@ Material:
     m_TexEnvs: []
     m_Floats: []
     m_Colors:
-    - _Tint: {r: 1, g: 1, b: 1, a: 1}
+    - _Tint: {r: 0, g: 0, b: 0, a: 1}

--- a/com.unity.probuilder/Editor/EditorCore/ProBuilderEditor.cs
+++ b/com.unity.probuilder/Editor/EditorCore/ProBuilderEditor.cs
@@ -24,7 +24,7 @@ namespace UnityEditor.ProBuilder
         const float k_MouseDragThreshold = 6f;
 
         //Off pointer multiplier is a percentage of the picking distance
-        const float k_OffPointerMultiplierPercent = 0.1f;  
+        const float k_OffPointerMultiplierPercent = 0.1f;
 
         /// <value>
         /// Raised any time the ProBuilder editor refreshes the selection. This is called every frame when interacting with mesh elements, and after any mesh operation.
@@ -491,9 +491,9 @@ namespace UnityEditor.ProBuilder
 
         void Menu_ToggleIconMode()
         {
-            s_IsIconGui.value = !s_IsIconGui;
+            s_IsIconGui.value = !s_IsIconGui.value;
             if (s_EditorToolbar != null)
-                UObject.DestroyImmediate(s_EditorToolbar);
+                DestroyImmediate(s_EditorToolbar);
             s_EditorToolbar = ScriptableObject.CreateInstance<EditorToolbar>();
             s_EditorToolbar.hideFlags = HideFlags.HideAndDontSave;
             s_EditorToolbar.InitWindowProperties(this);

--- a/com.unity.probuilder/Editor/EditorCore/ProBuilderSettings.cs
+++ b/com.unity.probuilder/Editor/EditorCore/ProBuilderSettings.cs
@@ -1,9 +1,20 @@
 using UnityEditor.SettingsManagement;
+using UnityEngine.ProBuilder;
 
 namespace UnityEditor.ProBuilder
 {
     static class ProBuilderSettings
     {
+        [InitializeOnLoadMethod]
+        static void SaveSettingsOnExit()
+        {
+            EditorApplication.quitting += () =>
+            {
+                Log.Info("Saving on quit");
+                Save();
+            };
+        }
+
         internal const string k_DefaultSettingsPath = "ProjectSettings/ProBuilderSettings.json";
 
         static Settings s_Instance;


### PR DESCRIPTION
Previously it was a requirement to call `ProBuillderSettings.Save` at some point after modifying a project setting. Now settings are automatically saved when the application exits.

https://unity3d.atlassian.net/browse/WB-1358