### PR TITLE
Fix SelectMode shortcuts not working

### DIFF
--- a/com.unity.probuilder/Editor/EditorCore/ProBuilderEditor.cs
+++ b/com.unity.probuilder/Editor/EditorCore/ProBuilderEditor.cs
@@ -579,8 +579,17 @@ namespace UnityEditor.ProBuilder
 
             DrawHandleGUI(sceneView);
 
-#if !SHORTCUT_MANAGER
-
+#if SHORTCUT_MANAGER
+            // Escape isn't assignable as a shortcut
+            if (m_CurrentEvent.type == EventType.KeyDown)
+            {
+                if (m_CurrentEvent.keyCode == KeyCode.Escape && selectMode != SelectMode.Object)
+                {
+                    selectMode = SelectMode.Object;
+                    m_CurrentEvent.Use();
+                }
+            }
+#else
             if (m_CurrentEvent.type == EventType.MouseDown && m_CurrentEvent.button == 1)
                 m_IsRightMouseDown = true;
 

--- a/com.unity.probuilder/Editor/EditorCore/ProBuilderEditor.cs
+++ b/com.unity.probuilder/Editor/EditorCore/ProBuilderEditor.cs
@@ -221,8 +221,7 @@ namespace UnityEditor.ProBuilder
                 if (selectModeChanged != null)
                     selectModeChanged(value);
 
-                UpdateMeshHandles(true);
-                s_Instance.Repaint();
+                Refresh();
             }
         }
 

--- a/com.unity.probuilder/Editor/EditorCore/ProBuilderEditorShortcuts.cs
+++ b/com.unity.probuilder/Editor/EditorCore/ProBuilderEditorShortcuts.cs
@@ -15,28 +15,28 @@ namespace UnityEditor.ProBuilder
 	/// </summary>
 	static class ProBuilderEditorShortcuts
 	{
-		[Shortcut("ProBuilder/Editor/Edit Objects", typeof(SceneView))] //, KeyCode.G)]
+		[Shortcut("ProBuilder/Editor/Edit Objects", typeof(SceneView))]
 		static void SetSelectMode_Object()
 		{
 			ProBuilderEditor.selectMode = SelectMode.Object;
 		}
 
-		[Shortcut("ProBuilder/Editor/Edit Vertices", typeof(SceneView))] //, KeyCode.H)]
+		[Shortcut("ProBuilder/Editor/Edit Vertices", typeof(SceneView))]
 		static void SetSelectMode_Vertex()
 		{
-			ProBuilderEditor.selectMode = SelectMode.Object;
+			ProBuilderEditor.selectMode = SelectMode.Vertex;
 		}
 
-		[Shortcut("ProBuilder/Editor/Edit Edges", typeof(SceneView))] //, KeyCode.J)]
+		[Shortcut("ProBuilder/Editor/Edit Edges", typeof(SceneView))]
 		static void SetSelectMode_Edge()
 		{
-			ProBuilderEditor.selectMode = SelectMode.Object;
+			ProBuilderEditor.selectMode = SelectMode.Edge;
 		}
 
-		[Shortcut("ProBuilder/Editor/Edit Faces", typeof(SceneView))] //, KeyCode.K)]
+		[Shortcut("ProBuilder/Editor/Edit Faces", typeof(SceneView))]
 		static void SetSelectMode_Faces()
 		{
-			ProBuilderEditor.selectMode = SelectMode.Object;
+			ProBuilderEditor.selectMode = SelectMode.Face;
 		}
 
 		[Shortcut("ProBuilder/Editor/Toggle Geometry Mode", typeof(SceneView), KeyCode.G)]


### PR DESCRIPTION
- `Escape` now sets `SelectMode.Object`
- `Edit {Edges, Faces, Vertices}` now enters the select mode