### PR TITLE
Fix inconsistencies in handle and actions when `SelectMode` is changed

### DIFF
--- a/com.unity.probuilder/Debug/Editor/SelectionDebug.cs
+++ b/com.unity.probuilder/Debug/Editor/SelectionDebug.cs
@@ -1,0 +1,78 @@
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.ProBuilder;
+
+namespace UnityEditor.ProBuilder
+{
+	class SelectionDebug : ConfigurableWindow
+	{
+		static class Styles
+		{
+			static bool s_RowToggle;
+			static readonly Color RowOddColor = new Color(.45f, .45f, .45f, .2f);
+			static readonly Color RowEvenColor = new Color(.30f, .30f, .30f, .2f);
+
+			public static void BeginRow(int index = -1)
+			{
+				if (index > -1)
+					s_RowToggle = index % 2 == 0;
+
+				var bg = GUI.backgroundColor;
+				GUI.backgroundColor = s_RowToggle ? RowEvenColor : RowOddColor;
+				GUILayout.BeginHorizontal(UI.EditorStyles.rowStyle);
+				s_RowToggle = !s_RowToggle;
+				GUI.backgroundColor = bg;
+			}
+
+			public static void EndRow()
+			{
+				GUILayout.EndHorizontal();
+			}
+		}
+
+		[MenuItem("Tools/ProBuilder/Debug/Selection Editor")]
+		static void Init()
+		{
+			GetWindow<SelectionDebug>();
+		}
+
+		static bool s_DisplayElementGroups = true;
+
+		void OnEnable()
+		{
+			MeshSelection.objectSelectionChanged += Repaint;
+			ProBuilderMesh.elementSelectionChanged += Repaint;
+		}
+
+		void OnDisable()
+		{
+			MeshSelection.objectSelectionChanged -= Repaint;
+			ProBuilderMesh.elementSelectionChanged -= Repaint;
+		}
+
+		void Repaint(ProBuilderMesh mesh)
+		{
+			Repaint();
+		}
+
+		void OnGUI()
+		{
+			s_DisplayElementGroups = EditorGUILayout.Foldout(s_DisplayElementGroups, "Element Groups");
+
+			if (s_DisplayElementGroups)
+			{
+				foreach (var group in MeshSelection.elementSelection)
+				{
+					GUILayout.Label(group.mesh.name);
+
+					foreach (var element in group.elementGroups)
+					{
+						Styles.BeginRow();
+						GUILayout.Label(element.indices.ToString(","));
+						Styles.EndRow();
+					}
+				}
+			}
+		}
+	}
+}

--- a/com.unity.probuilder/Debug/Editor/SelectionDebug.cs.meta
+++ b/com.unity.probuilder/Debug/Editor/SelectionDebug.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c3388d99d4fd94f9d8d46d06e0d02407
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.probuilder/Editor/EditorCore/DimensionsEditor.cs
+++ b/com.unity.probuilder/Editor/EditorCore/DimensionsEditor.cs
@@ -1,13 +1,23 @@
+#if UNITY_2019_1_OR_NEWER
+#define SHORTCUT_MANAGER
+#endif
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using UnityEditor.SettingsManagement;
+using UnityEditor.ShortcutManagement;
 using UnityEngine;
 using UnityEngine.ProBuilder;
+using Object = UnityEngine.Object;
 
 namespace UnityEditor.ProBuilder
 {
     sealed class DimensionsEditor : ScriptableObject
     {
         static DimensionsEditor s_Instance;
+        bool m_HasBounds;
+        Bounds m_Bounds;
 
         [MenuItem("Tools/" + PreferenceKeys.pluginTitle + "/Dimensions Overlay/Hide", true, PreferenceKeys.menuEditor + 30)]
         static bool HideVerify()
@@ -34,6 +44,24 @@ namespace UnityEditor.ProBuilder
             CreateInstance<DimensionsEditor>();
         }
 
+        [UserSetting("Dimensions Overlay", "Always use Object Bounds", "When disabled, the dimensions will be " +
+            "calculated using the current face, edge, or vertex selection. When enabled, the object bounds are used.")]
+        static Pref<bool> s_AlwaysUseObjectBounds = new Pref<bool>("s_AlwaysUseObjectBounds", false, SettingsScope.User);
+
+#if SHORTCUT_MANAGER
+        [Shortcut("ProBuilder/Dimensions Overlay/Toggle Object, Element Bounds", typeof(SceneView))]
+        static void ToggleUseElementBounds()
+        {
+            s_AlwaysUseObjectBounds.SetValue(!s_AlwaysUseObjectBounds.value, true);
+
+            if (s_Instance != null)
+            {
+                s_Instance.RebuildBounds();
+                EditorUtility.ShowNotification("Dimensions Overlay\n" + (s_AlwaysUseObjectBounds.value ? "Object" : "Element"));
+            }
+        }
+#endif
+
         void OnEnable()
         {
             s_Instance = this;
@@ -46,10 +74,17 @@ namespace UnityEditor.ProBuilder
 #else
             SceneView.onSceneGUIDelegate += OnSceneGUI;
 #endif
+            MeshSelection.objectSelectionChanged += OnObjectSelectionChanged;
+            ProBuilderMesh.elementSelectionChanged += OnElementSelectionChanged;
+            ProBuilderEditor.selectionUpdated += EditingMeshSelection;
         }
 
         void OnDisable()
         {
+            MeshSelection.objectSelectionChanged -= OnObjectSelectionChanged;
+            ProBuilderMesh.elementSelectionChanged -= OnElementSelectionChanged;
+            ProBuilderEditor.selectionUpdated -= EditingMeshSelection;
+
 #if UNITY_2019_1_OR_NEWER
             SceneView.duringSceneGui -= OnSceneGUI;
 #else
@@ -59,33 +94,107 @@ namespace UnityEditor.ProBuilder
             DestroyImmediate(material);
         }
 
-        bool GetSelectedBounds(out Bounds bounds)
+        static bool GetElementBounds(IEnumerable<ProBuilderMesh> meshes, SelectMode mode, out Bounds bounds)
         {
-            IEnumerable<MeshRenderer> renderers = Selection.transforms.Where(x => x.GetComponent<MeshRenderer>() != null).Select(x => x.GetComponent<MeshRenderer>());
+            bool initialized = false;
+            bounds = new Bounds();
+
+            foreach (var mesh in meshes)
+            {
+                var positions = mesh.positionsInternal;
+                var trs = mesh.transform;
+
+                switch (mode)
+                {
+                    case SelectMode.Face:
+                    case SelectMode.TextureFace:
+                    {
+                        var faces = mesh.facesInternal;
+
+                        foreach (var face in mesh.selectedFaceIndicesInternal)
+                        {
+                            foreach (var index in faces[face].distinctIndexesInternal)
+                            {
+                                var position = trs.TransformPoint(positions[index]);
+
+                                if (!initialized)
+                                {
+                                    bounds = new Bounds(position, Vector3.zero);
+                                    initialized = true;
+                                }
+                                else
+                                {
+                                    bounds.Encapsulate(position);
+                                }
+                            }
+                        }
+                        break;
+                    }
+
+                    case SelectMode.Edge:
+                    case SelectMode.TextureEdge:
+                    {
+                        foreach (var edge in mesh.selectedEdgesInternal)
+                        {
+                            var a = trs.TransformPoint(positions[edge.a]);
+                            var b = trs.TransformPoint(positions[edge.b]);
+
+                            if (!initialized)
+                            {
+                                bounds = new Bounds(a, Vector3.zero);
+                                initialized = true;
+                            }
+                            else
+                            {
+                                bounds.Encapsulate(a);
+                            }
+
+                            bounds.Encapsulate(b);
+                        }
+
+                        break;
+                    }
+
+                    case SelectMode.Vertex:
+                    case SelectMode.TextureVertex:
+                    {
+                        foreach (var index in mesh.selectedIndexesInternal)
+                        {
+                            var position = trs.TransformPoint(positions[index]);
+
+                            if (!initialized)
+                            {
+                                bounds = new Bounds(position, Vector3.zero);
+                                initialized = true;
+                            }
+                            else
+                            {
+                                bounds.Encapsulate(position);
+                            }
+                        }
+                        break;
+                    }
+                }
+            }
+
+            return initialized;
+        }
+
+        static bool GetSelectedBounds(out Bounds bounds)
+        {
+            var selectMode = ProBuilderEditor.selectMode;
+
+            if (selectMode.IsMeshElementMode() && !s_AlwaysUseObjectBounds.value)
+                return GetElementBounds(MeshSelection.topInternal, selectMode, out bounds);
+
+            var renderers = Selection.transforms
+                .Where(x => x.GetComponent<MeshRenderer>() != null)
+                .Select(x => x.GetComponent<MeshRenderer>());
 
             if (!renderers.Any())
             {
                 bounds = new Bounds();
                 return false;
-            }
-
-            if (ProBuilderEditor.instance != null)
-            {
-                Vector3[] positions = MeshSelection.topInternal.SelectMany(x =>
-                    {
-                        var p = x.positions.ToArray();
-
-                        return x.selectedVertices.Select(y =>
-                        {
-                            return x.transform.TransformPoint(p[y]);
-                        });
-                    }).ToArray();
-
-                if (positions.Length > 0)
-                {
-                    bounds = Math.GetBounds(positions);
-                    return true;
-                }
             }
 
             bounds = renderers.First().bounds;
@@ -96,11 +205,31 @@ namespace UnityEditor.ProBuilder
             return true;
         }
 
+        void OnObjectSelectionChanged()
+        {
+            RebuildBounds();
+        }
+
+        void OnElementSelectionChanged(ProBuilderMesh mesh)
+        {
+            RebuildBounds();
+        }
+
+        void EditingMeshSelection(IEnumerable<ProBuilderMesh> meshes)
+        {
+            RebuildBounds();
+        }
+
+        void RebuildBounds()
+        {
+            m_HasBounds = GetSelectedBounds(out m_Bounds);
+            SceneView.RepaintAll();
+        }
+
         void OnSceneGUI(SceneView scnview)
         {
-            Bounds bounds;
-            if (GetSelectedBounds(out bounds))
-                RenderBounds(bounds);
+            if(Selection.count > 0 && m_HasBounds)
+                RenderBounds(m_Bounds);
         }
 
         Mesh mesh;
@@ -126,7 +255,7 @@ namespace UnityEditor.ProBuilder
 
         const float DISTANCE_LINE_OFFSET = .2f;
 
-        float LineDistance()
+        static float LineDistance()
         {
             return HandleUtility.GetHandleSize(Selection.activeTransform.position) * DISTANCE_LINE_OFFSET;
         }

--- a/com.unity.probuilder/Editor/EditorCore/DimensionsEditor.cs
+++ b/com.unity.probuilder/Editor/EditorCore/DimensionsEditor.cs
@@ -76,14 +76,14 @@ namespace UnityEditor.ProBuilder
 #endif
             MeshSelection.objectSelectionChanged += OnObjectSelectionChanged;
             ProBuilderMesh.elementSelectionChanged += OnElementSelectionChanged;
-            ProBuilderEditor.selectionUpdated += EditingMeshSelection;
+            ProBuilderEditor.selectionUpdated += OnEditingMeshSelection;
         }
 
         void OnDisable()
         {
             MeshSelection.objectSelectionChanged -= OnObjectSelectionChanged;
             ProBuilderMesh.elementSelectionChanged -= OnElementSelectionChanged;
-            ProBuilderEditor.selectionUpdated -= EditingMeshSelection;
+            ProBuilderEditor.selectionUpdated -= OnEditingMeshSelection;
 
 #if UNITY_2019_1_OR_NEWER
             SceneView.duringSceneGui -= OnSceneGUI;
@@ -215,7 +215,7 @@ namespace UnityEditor.ProBuilder
             RebuildBounds();
         }
 
-        void EditingMeshSelection(IEnumerable<ProBuilderMesh> meshes)
+        void OnEditingMeshSelection(IEnumerable<ProBuilderMesh> meshes)
         {
             RebuildBounds();
         }

--- a/com.unity.probuilder/Editor/EditorCore/MaterialEditor.cs
+++ b/com.unity.probuilder/Editor/EditorCore/MaterialEditor.cs
@@ -31,7 +31,7 @@ namespace UnityEditor.ProBuilder
         [MenuItem("Tools/" + PreferenceKeys.pluginTitle + "/Materials/Apply Material Preset 10 &0", true, PreferenceKeys.menuMaterialColors)]
         public static bool VerifyMaterialAction()
         {
-            return ProBuilderEditor.instance != null && ProBuilderEditor.instance.selection.Length > 0;
+            return ProBuilderEditor.instance != null && MeshSelection.selectedObjectCount > 0;
         }
 
         [MenuItem("Tools/" + PreferenceKeys.pluginTitle + "/Materials/Apply Material Preset 1 &1", false, PreferenceKeys.menuMaterialColors)]

--- a/com.unity.probuilder/Editor/EditorCore/MaterialEditor.cs
+++ b/com.unity.probuilder/Editor/EditorCore/MaterialEditor.cs
@@ -116,7 +116,7 @@ namespace UnityEditor.ProBuilder
 
         // List of string names for all available palettes (plus one entry for 'Add New')
         string[] m_AvailablePalettes_Str = null;
-        
+
         // The index of the currently loaded material palette in m_AvailablePalettes
         int m_CurrentPaletteIndex = 0;
 
@@ -360,7 +360,8 @@ namespace UnityEditor.ProBuilder
 
             foreach (var mesh in selection)
             {
-                mesh.SetMaterial(mesh.selectedFaceCount > 0 ? mesh.GetSelectedFaces() : mesh.facesInternal, mat);
+                var applyPerFace = ProBuilderEditor.selectMode.ContainsFlag(SelectMode.Face) && mesh.faceCount > 0;
+                mesh.SetMaterial(applyPerFace ? mesh.GetSelectedFaces() : mesh.facesInternal, mat);
                 InternalMeshUtility.FilterUnusedSubmeshIndexes(mesh);
                 mesh.Rebuild();
                 mesh.Optimize();

--- a/com.unity.probuilder/Editor/EditorCore/MeshAndElementSelection.cs
+++ b/com.unity.probuilder/Editor/EditorCore/MeshAndElementSelection.cs
@@ -66,6 +66,36 @@ namespace UnityEditor.ProBuilder
             m_Rotation = rotation;
         }
 
+        internal static List<int> GetSelectedIndicesForSelectMode(ProBuilderMesh mesh, SelectMode mode, bool collectCoincident)
+        {
+            if (mode.ContainsFlag(SelectMode.Face | SelectMode.TextureFace))
+            {
+                List<int> indices = new List<int>();
+
+                if (collectCoincident)
+                    mesh.GetCoincidentVertices(mesh.selectedFacesInternal, indices);
+                else
+                    Face.GetDistinctIndices(mesh.selectedFacesInternal, indices);
+
+                return indices;
+            }
+            else if(mode.ContainsFlag(SelectMode.Edge | SelectMode.TextureEdge))
+            {
+                List<int> indices = new List<int>();
+
+                if (collectCoincident)
+                    mesh.GetCoincidentVertices(mesh.selectedEdgesInternal, indices);
+                else
+                    Edge.GetIndices(mesh.selectedEdgesInternal, indices);
+
+                return indices;
+            }
+
+            return collectCoincident
+                ? mesh.GetCoincidentVertices(mesh.selectedIndexesInternal)
+                : new List<int>(mesh.selectedIndexesInternal);
+        }
+
         public static List<ElementGroup> GetElementGroups(ProBuilderMesh mesh, PivotPoint pivot, HandleOrientation orientation, bool collectCoincident)
         {
             var groups = new List<ElementGroup>();
@@ -133,10 +163,7 @@ namespace UnityEditor.ProBuilder
 
                 case PivotPoint.ActiveElement:
                 {
-                    var indices = collectCoincident
-                        ? mesh.GetCoincidentVertices(mesh.selectedIndexesInternal)
-                        : new List<int>(mesh.selectedIndexesInternal);
-
+                    var indices = GetSelectedIndicesForSelectMode(mesh, selectMode, collectCoincident);
                     var position = mesh.transform.position;
                     var rotation = mesh.transform.rotation;
 
@@ -177,9 +204,7 @@ namespace UnityEditor.ProBuilder
 
                 default:
                 {
-                    var indices = collectCoincident
-                        ? mesh.GetCoincidentVertices(mesh.selectedIndexesInternal)
-                        : new List<int>(mesh.selectedIndexesInternal);
+                    var indices = GetSelectedIndicesForSelectMode(mesh, selectMode, collectCoincident);
                     var position = MeshSelection.bounds.center;
                     var rotation = Quaternion.identity;
 

--- a/com.unity.probuilder/Editor/EditorCore/MeshSelection.cs
+++ b/com.unity.probuilder/Editor/EditorCore/MeshSelection.cs
@@ -72,16 +72,6 @@ namespace UnityEditor.ProBuilder
         // Faces that need to be refreshed when moving or modifying the actual selection
         internal static Dictionary<ProBuilderMesh, List<Face>> selectedFacesInEditZone { get; private set; }
 
-        static ProBuilderMesh[] selection
-        {
-            get
-            {
-                return ProBuilderEditor.instance != null
-                    ? ProBuilderEditor.instance.selection
-                    : InternalUtility.GetComponents<ProBuilderMesh>(Selection.transforms);
-            }
-        }
-
         internal static void InvalidateElementSelection()
         {
             s_SelectedElementGroupsDirty = true;
@@ -199,9 +189,9 @@ namespace UnityEditor.ProBuilder
 
         internal static void RecalculateSelectedComponentCounts()
         {
-            for (var i = 0; i < selection.Length; i++)
+            for (var i = 0; i < topInternal.Count; i++)
             {
-                var mesh = selection[i];
+                var mesh = topInternal[i];
 
                 selectedFaceCount += mesh.selectedFaceCount;
                 selectedEdgeCount += mesh.selectedEdgeCount;
@@ -220,9 +210,9 @@ namespace UnityEditor.ProBuilder
             s_SelectionBounds = new Bounds();
             var boundsInitialized = false;
 
-            for (var i = 0; i < selection.Length; i++)
+            for (int i = 0, c = topInternal.Count; i < c; i++)
             {
-                var mesh = selection[i];
+                var mesh = topInternal[i];
 
                 // Undo causes this state
                 if (mesh == null)
@@ -251,7 +241,7 @@ namespace UnityEditor.ProBuilder
             else
                 selectedFacesInEditZone = new Dictionary<ProBuilderMesh, List<Face>>();
 
-            foreach (var mesh in selection)
+            foreach (var mesh in topInternal)
             {
                 selectedFacesInEditZone.Add(mesh, ElementSelection.GetNeighborFaces(mesh, mesh.selectedIndexesInternal));
             }
@@ -377,7 +367,7 @@ namespace UnityEditor.ProBuilder
 
         internal static void SetSelection(IList<GameObject> newSelection)
         {
-            UndoUtility.RecordSelection(selection, "Change Selection");
+            UndoUtility.RecordSelection(topInternal.ToArray(), "Change Selection");
             ClearElementAndObjectSelection();
 
             // if the previous tool was set to none, use Tool.Move
@@ -399,7 +389,7 @@ namespace UnityEditor.ProBuilder
 
         internal static void SetSelection(GameObject go)
         {
-            UndoUtility.RecordSelection(selection, "Change Selection");
+            UndoUtility.RecordSelection(topInternal.ToArray(), "Change Selection");
             ClearElementAndObjectSelection();
             AddToSelection(go);
         }

--- a/com.unity.probuilder/Editor/EditorCore/PositionMoveTool.cs
+++ b/com.unity.probuilder/Editor/EditorCore/PositionMoveTool.cs
@@ -189,7 +189,7 @@ namespace UnityEditor.ProBuilder
                 mesh.Refresh(RefreshMask.Normals);
             }
 
-            ProBuilderEditor.UpdateMeshHandles(false);
+            ProBuilderEditor.Refresh(false);
         }
 
 #if PROBUILDER_ENABLE_TRANSFORM_ORIGIN_GIZMO

--- a/com.unity.probuilder/Editor/EditorCore/PositionRotateTool.cs
+++ b/com.unity.probuilder/Editor/EditorCore/PositionRotateTool.cs
@@ -71,7 +71,7 @@ namespace UnityEditor.ProBuilder
                 mesh.Refresh(RefreshMask.Normals);
             }
 
-            ProBuilderEditor.UpdateMeshHandles(false);
+            ProBuilderEditor.Refresh(false);
         }
     }
 }

--- a/com.unity.probuilder/Editor/EditorCore/PositionTool.cs
+++ b/com.unity.probuilder/Editor/EditorCore/PositionTool.cs
@@ -159,7 +159,7 @@ namespace UnityEditor.ProBuilder
                 mesh.Refresh(RefreshMask.Normals);
             }
 
-            ProBuilderEditor.UpdateMeshHandles(false);
+            ProBuilderEditor.Refresh(false);
         }
     }
 }

--- a/com.unity.probuilder/Editor/EditorCore/ProBuilderEditor.cs
+++ b/com.unity.probuilder/Editor/EditorCore/ProBuilderEditor.cs
@@ -1019,13 +1019,11 @@ namespace UnityEditor.ProBuilder
         internal void ToggleSelectionMode()
         {
             if (m_SelectMode == SelectMode.Vertex)
-                m_SelectMode.SetValue(SelectMode.Edge, true);
+                selectMode = SelectMode.Edge;
             else if (m_SelectMode == SelectMode.Edge)
-                m_SelectMode.SetValue(SelectMode.Face, true);
+                selectMode = SelectMode.Face;
             else if (m_SelectMode == SelectMode.Face)
-                m_SelectMode.SetValue(SelectMode.Vertex, true);
-
-            Repaint();
+                selectMode = SelectMode.Vertex;
         }
 
         void UpdateSelection(bool selectionChanged = true)

--- a/com.unity.probuilder/Editor/EditorCore/ProBuilderEditor.cs
+++ b/com.unity.probuilder/Editor/EditorCore/ProBuilderEditor.cs
@@ -161,7 +161,10 @@ namespace UnityEditor.ProBuilder
 #endif
 
         // All selected pb_Objects
-        internal ProBuilderMesh[] selection = new ProBuilderMesh[0];
+        internal List<ProBuilderMesh> selection
+        {
+            get { return MeshSelection.topInternal; }
+        }
 
         Event m_CurrentEvent;
 
@@ -742,7 +745,7 @@ namespace UnityEditor.ProBuilder
                 {
                     if ((e.modifiers & (EventModifiers.Control | EventModifiers.Shift)) ==
                         (EventModifiers.Control | EventModifiers.Shift))
-                        Actions.SelectFaceRing.MenuRingAndLoopFaces(selection);
+                        Actions.SelectFaceRing.MenuRingAndLoopFaces(MeshSelection.topInternal);
                     else if (e.control)
                         EditorUtility.ShowNotification(EditorToolbarLoader.GetInstance<Actions.SelectFaceRing>().DoAction());
                     else if (e.shift)
@@ -1027,9 +1030,6 @@ namespace UnityEditor.ProBuilder
 
         void UpdateSelection(bool selectionChanged = true)
         {
-            // todo remove selection property
-            selection = MeshSelection.topInternal.ToArray();
-
             UpdateMeshHandles(selectionChanged);
 
             if (selectionChanged)
@@ -1155,12 +1155,12 @@ namespace UnityEditor.ProBuilder
         /// <param name="snapVal"></param>
         void PushToGrid(float snapVal)
         {
-            UndoUtility.RecordSelection(selection, "Push elements to Grid");
+            UndoUtility.RecordSelection(selection.ToArray(), "Push elements to Grid");
 
             if (selectMode == SelectMode.Object || selectMode == SelectMode.None)
                 return;
 
-            for (int i = 0; i < selection.Length; i++)
+            for (int i = 0, c = MeshSelection.selectedObjectCount; i < c; i++)
             {
                 ProBuilderMesh mesh = selection[i];
                 if (mesh.selectedVertexCount < 1)
@@ -1203,7 +1203,8 @@ namespace UnityEditor.ProBuilder
             pb = null;
             face = null;
 
-            if (selection.Length < 1) return false;
+            if (selection.Count < 1)
+                return false;
 
             pb = selection.FirstOrDefault(x => x.selectedFaceCount > 0);
 

--- a/com.unity.probuilder/Editor/EditorCore/ProBuilderMeshEditor.cs
+++ b/com.unity.probuilder/Editor/EditorCore/ProBuilderMeshEditor.cs
@@ -234,6 +234,9 @@ namespace UnityEditor.ProBuilder
 
         Bounds OnGetFrameBounds()
         {
+            if (!ProBuilderEditor.selectMode.IsMeshElementMode())
+                return m_MeshRenderer != null ? m_MeshRenderer.bounds : default(Bounds);
+
             if (onGetFrameBoundsEvent != null)
                 onGetFrameBoundsEvent();
 

--- a/com.unity.probuilder/Editor/EditorCore/UVRenderOptions.cs
+++ b/com.unity.probuilder/Editor/EditorCore/UVRenderOptions.cs
@@ -51,7 +51,7 @@ namespace UnityEditor.ProBuilder
 
             if (GUILayout.Button("Save UV Template"))
             {
-                if (ProBuilderEditor.instance == null || ProBuilderEditor.instance.selection.Length < 1)
+                if (ProBuilderEditor.instance == null || MeshSelection.selectedObjectCount < 1)
                 {
                     Debug.LogWarning("Abandoning UV render because no ProBuilder objects are selected.");
                     Close();

--- a/com.unity.probuilder/Editor/EditorCore/VertexManipulationTool.cs
+++ b/com.unity.probuilder/Editor/EditorCore/VertexManipulationTool.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using UnityEngine;
 using UnityEngine.ProBuilder;
@@ -229,11 +230,32 @@ namespace UnityEditor.ProBuilder
             if (evt.type == EventType.MouseUp || evt.type == EventType.Ignore)
                 FinishEdit();
 
+            switch (ProBuilderEditor.selectMode)
+            {
+                case SelectMode.Face:
+                case SelectMode.TextureFace:
+                    if (MeshSelection.selectedFaceCount < 1)
+                        return;
+                    break;
+
+                case SelectMode.Edge:
+                case SelectMode.TextureEdge:
+                    if (MeshSelection.selectedEdgeCount < 1)
+                        return;
+                    break;
+
+                case SelectMode.Vertex:
+                case SelectMode.TextureVertex:
+                    if (MeshSelection.selectedVertexCount < 1)
+                        return;
+                    break;
+            }
+
             if (!m_IsEditing)
             {
                 m_HandlePosition = MeshSelection.GetHandlePosition();
                 m_HandleRotation = MeshSelection.GetHandleRotation();
-                
+
                 m_HandlePositionOrigin = m_HandlePosition;
                 m_HandleRotationOrigin = m_HandleRotation;
                 handleRotationOriginInverse = Quaternion.Inverse(m_HandleRotation);

--- a/com.unity.probuilder/Editor/MenuActions/Selection/SelectFaceRing.cs
+++ b/com.unity.probuilder/Editor/MenuActions/Selection/SelectFaceRing.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using UnityEngine.ProBuilder;
 using UnityEngine.ProBuilder.MeshOperations;
@@ -65,9 +66,9 @@ namespace UnityEditor.ProBuilder.Actions
             return new ActionResult(ActionResult.Status.Success, "Select Face Ring");
         }
 
-        public static ActionResult MenuRingAndLoopFaces(ProBuilderMesh[] selection)
+        public static ActionResult MenuRingAndLoopFaces(IEnumerable<ProBuilderMesh> selection)
         {
-            UndoUtility.RecordSelection(selection, "Select Face Ring and Loop");
+            UndoUtility.RecordSelection(selection.ToArray(), "Select Face Ring and Loop");
 
             foreach (ProBuilderMesh pb in selection)
             {

--- a/com.unity.probuilder/Runtime/Core/Edge.cs
+++ b/com.unity.probuilder/Runtime/Core/Edge.cs
@@ -172,5 +172,16 @@ namespace UnityEngine.ProBuilder
             var common = lookup[index];
             return lookup[a] == common || lookup[b] == common;
         }
+
+        internal static void GetIndices(IEnumerable<Edge> edges, List<int> indices)
+        {
+            indices.Clear();
+
+            foreach (var edge in edges)
+            {
+                indices.Add(edge.a);
+                indices.Add(edge.b);
+            }
+        }
     }
 }

--- a/com.unity.probuilder/Runtime/Core/Face.cs
+++ b/com.unity.probuilder/Runtime/Core/Face.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine.Serialization;

--- a/com.unity.probuilder/Runtime/Core/Face.cs
+++ b/com.unity.probuilder/Runtime/Core/Face.cs
@@ -454,5 +454,27 @@ namespace UnityEngine.ProBuilder
             Array.Reverse(m_Indexes);
             InvalidateCache();
         }
+
+        internal static void GetIndices(IEnumerable<Face> faces, List<int> indices)
+        {
+            indices.Clear();
+
+            foreach (var face in faces)
+            {
+                for (int i = 0, c = face.indexesInternal.Length; i < c; ++i)
+                    indices.Add(face.indexesInternal[i]);
+            }
+        }
+
+        internal static void GetDistinctIndices(IEnumerable<Face> faces, List<int> indices)
+        {
+            indices.Clear();
+
+            foreach (var face in faces)
+            {
+                for (int i = 0, c = face.distinctIndexesInternal.Length; i < c; ++i)
+                    indices.Add(face.distinctIndexesInternal[i]);
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes the following issues related to `ProBuilderMesh` retaining distinct element selection caches.

- [x] Frame bounds focuses on element selection when in Object mode
- [x] Apply material incorrectly applies to face selection when in Object mode
- [x] Dimension overlay displays element bounds when in Object mode
- [x] Handle position when switching select modes does not update