### PR TITLE
Fix obj exporting separate faces

### DIFF
--- a/com.unity.probuilder.tests/Tests/Runtime/Type/TestVector.cs
+++ b/com.unity.probuilder.tests/Tests/Runtime/Type/TestVector.cs
@@ -83,7 +83,7 @@ namespace UnityEngine.ProBuilder.RuntimeTests.Type
         public static void TestComparison_IVEC3()
         {
             IntVec3 a = (IntVec3)RandVec3();
-            IntVec3 b = (IntVec3)(a.vec * 2.3f);
+            IntVec3 b = (IntVec3)(a.value * 2.3f);
             IntVec3 c = (IntVec3) new Vector3(a.x, a.y + .001f, a.z);
             IntVec3 d = (IntVec3) new Vector3(a.x, a.y, a.z);
 

--- a/com.unity.probuilder/Debug/Editor/GenerateMenuItems.cs
+++ b/com.unity.probuilder/Debug/Editor/GenerateMenuItems.cs
@@ -85,7 +85,7 @@ namespace UnityEditor.ProBuilder
             { "Export", "PreferenceKeys.menuExport + 0" }
         };
 
-        [MenuItem("Tools/Debug/ProBuilder/Rebuild Menu Items &d", false, 800)]
+        [MenuItem("Tools/Debug/ProBuilder/Rebuild Menu Items", false, 800)]
         static void GenerateMenuItemsForActions()
         {
             if (File.Exists(k_GeneratedFilePath))

--- a/com.unity.probuilder/Debug/Editor/TempMenuItems.cs
+++ b/com.unity.probuilder/Debug/Editor/TempMenuItems.cs
@@ -1,18 +1,25 @@
-using System.IO;
+using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using UnityEditor;
 using UnityEditor.ProBuilder;
-using UnityEngine.ProBuilder;
-using UnityEngine.ProBuilder.MeshOperations;
 using UObject = UnityEngine.Object;
 
 class TempMenuItems : EditorWindow
 {
-
     [MenuItem("Tools/Temp Menu Item &d", false, 1000)]
     static void MenuInit()
     {
+        List<string> textures;
+        string obj, mat;
+
+        ObjOptions options = new ObjOptions()
+        {
+            applyTransforms = false
+        };
+
+        if (ObjExporter.Export("probuilder cube", MeshSelection.top.Select(x => new Model("Cube", x)), out obj, out mat, out textures, options))
+            System.IO.File.WriteAllText("/Users/karlh/Desktop/cube.obj", obj);
     }
 
     [MenuItem("Tools/Recompile")]

--- a/com.unity.probuilder/Editor/EditorCore/ObjExporter.cs
+++ b/com.unity.probuilder/Editor/EditorCore/ObjExporter.cs
@@ -184,7 +184,7 @@ namespace UnityEditor.ProBuilder
 
                 sb.AppendLine();
 
-                var normalIndexMap = AppendNormals(sb, normals, "vn", true);
+                var normalIndexMap = AppendArrayVec3(sb, normals, "vn", true);
 
                 sb.AppendLine();
 
@@ -400,6 +400,7 @@ namespace UnityEditor.ProBuilder
             }
         }
 
+        // AppendPositions separately from AppendArrayVec3 to support the non-spec color extension that some DCCs can read
         static Dictionary<int, int> AppendPositions(StringBuilder sb, Vector3[] positions, Color[] colors, bool mergeCoincident, bool includeColors)
         {
             var writeColors = includeColors && colors != null && colors.Length == positions.Length;
@@ -503,7 +504,7 @@ namespace UnityEditor.ProBuilder
             return map;
         }
 
-        static Dictionary<int, int> AppendNormals(StringBuilder sb, Vector3[] array, string prefix, bool mergeCoincident)
+        static Dictionary<int, int> AppendArrayVec3(StringBuilder sb, Vector3[] array, string prefix, bool mergeCoincident)
         {
             Dictionary<IntVec3, int> common = new Dictionary<IntVec3, int>();
             Dictionary<int, int> map = new Dictionary<int, int>();

--- a/com.unity.probuilder/Editor/EditorCore/ObjExporter.cs
+++ b/com.unity.probuilder/Editor/EditorCore/ObjExporter.cs
@@ -115,15 +115,18 @@ namespace UnityEditor.ProBuilder
 
             StringBuilder sb = new StringBuilder();
 
-            sb.AppendLine("# Exported from ProBuilder");
-            sb.AppendLine("# http://www.procore3d.com/probuilder");
+            sb.AppendLine("# ProBuilder " + Version.currentInfo.MajorMinorPatch);
+            sb.AppendLine("# https://unity3d.com/unity/features/worldbuilding/probuilder");
             sb.AppendLine(string.Format("# {0}", System.DateTime.Now));
             sb.AppendLine();
             sb.AppendLine(string.Format("mtllib ./{0}.mtl", name.Replace(" ", "_")));
             sb.AppendLine(string.Format("o {0}", name));
             sb.AppendLine();
 
-            int triangleOffset = 1;
+            // obj orders indices 1 indexed
+            int positionOffset = 1;
+            int normalOffset = 1;
+            int textureOffset = 1;
 
             bool reverseWinding = options.handedness == ObjOptions.Handedness.Right;
             float handedness = options.handedness == ObjOptions.Handedness.Left ? 1f : -1f;
@@ -145,8 +148,10 @@ namespace UnityEditor.ProBuilder
                 List<Vector4> uv4;
 
                 MeshArrays attribs = MeshArrays.Position | MeshArrays.Normal | MeshArrays.Texture0;
+
                 if (options.vertexColors)
                     attribs = attribs | MeshArrays.Color;
+
                 Vertex.GetArrays(model.vertices, out positions, out colors, out textures0, out normals, out tangent, out uv2, out uv3, out uv4, attribs);
 
                 // Can skip this entirely if handedness matches Unity & not applying transforms.
@@ -171,28 +176,15 @@ namespace UnityEditor.ProBuilder
 
                 sb.AppendLine(string.Format("g {0}", model.name));
 
-                if (options.vertexColors && colors != null && colors.Length == vertexCount)
-                {
-                    for (int i = 0; i < vertexCount; i++)
-                        sb.AppendLine(string.Format(CultureInfo.InvariantCulture, "v {0} {1} {2} {3} {4} {5}",
-                                positions[i].x, positions[i].y, positions[i].z,
-                                colors[i].r, colors[i].g, colors[i].b));
-                }
-                else
-                {
-                    for (int i = 0; i < vertexCount; i++)
-                        sb.AppendLine(string.Format(CultureInfo.InvariantCulture, "v {0} {1} {2}", positions[i].x, positions[i].y, positions[i].z));
-                }
+                var positionIndexMap = AppendPositions(sb, positions, colors, true, options.vertexColors);
 
                 sb.AppendLine();
 
-                for (int i = 0; normals != null && i < vertexCount; i++)
-                    sb.AppendLine(string.Format(CultureInfo.InvariantCulture, "vn {0} {1} {2}", normals[i].x, normals[i].y, normals[i].z));
+                var textureIndexMap = AppendArrayVec2(sb, textures0, "vt", true);
 
                 sb.AppendLine();
 
-                for (int i = 0; textures0 != null && i < vertexCount; i++)
-                    sb.AppendLine(string.Format(CultureInfo.InvariantCulture, "vt {0} {1}", textures0[i].x, textures0[i].y));
+                var normalIndexMap = AppendNormals(sb, normals, "vn", true);
 
                 sb.AppendLine();
 
@@ -215,51 +207,58 @@ namespace UnityEditor.ProBuilder
 
                     int[] indexes = submesh.m_Indexes;
                     int inc = submesh.m_Topology == MeshTopology.Quads ? 4 : 3;
+                    int inc1 = inc - 1;
+
+                    int o0 = reverseWinding ? inc1 : 0;
+                    int o1 = reverseWinding ? inc1 - 1 : 1;
+                    int o2 = reverseWinding ? inc1 - 2 : 2;
+                    int o3 = reverseWinding ? inc1 - 3 : 3;
 
                     for (int ff = 0; ff < indexes.Length; ff += inc)
                     {
+                        int p0 = positionIndexMap[indexes[ff + o0]] + positionOffset;
+                        int p1 = positionIndexMap[indexes[ff + o1]] + positionOffset;
+                        int p2 = positionIndexMap[indexes[ff + o2]] + positionOffset;
+
+                        int t0 = textureIndexMap[indexes[ff + o0]] + textureOffset;
+                        int t1 = textureIndexMap[indexes[ff + o1]] + textureOffset;
+                        int t2 = textureIndexMap[indexes[ff + o2]] + textureOffset;
+
+                        int n0 = normalIndexMap[indexes[ff + o0]] + normalOffset;
+                        int n1 = normalIndexMap[indexes[ff + o1]] + normalOffset;
+                        int n2 = normalIndexMap[indexes[ff + o2]] + normalOffset;
+
                         if (inc == 4)
                         {
-                            if (reverseWinding)
-                            {
-                                sb.AppendLine(string.Format(CultureInfo.InvariantCulture, "f {0}/{0}/{0} {1}/{1}/{1} {2}/{2}/{2} {3}/{3}/{3}",
-                                        indexes[ff + 3] + triangleOffset,
-                                        indexes[ff + 2] + triangleOffset,
-                                        indexes[ff + 1] + triangleOffset,
-                                        indexes[ff + 0] + triangleOffset));
-                            }
-                            else
-                            {
-                                sb.AppendLine(string.Format(CultureInfo.InvariantCulture, "f {0}/{0}/{0} {1}/{1}/{1} {2}/{2}/{2} {3}/{3}/{3}",
-                                        indexes[ff + 0] + triangleOffset,
-                                        indexes[ff + 1] + triangleOffset,
-                                        indexes[ff + 2] + triangleOffset,
-                                        indexes[ff + 3] + triangleOffset));
-                            }
+                            int p3 = positionIndexMap[indexes[ff + o3]] + positionOffset;
+                            int n3 = normalIndexMap[indexes[ff + o3]] + normalOffset;
+                            int t3 = textureIndexMap[indexes[ff + o3]] + textureOffset;
+
+                            sb.AppendLine(string.Format(CultureInfo.InvariantCulture,
+                                "f {0}/{4}/{8} {1}/{5}/{9} {2}/{6}/{10} {3}/{7}/{11}",
+                                    p0, p1, p2, p3,
+                                    t0, t1, t2, t3,
+                                    n0, n1, n2, n3
+                                    ));
                         }
                         else
                         {
-                            if (reverseWinding)
-                            {
-                                sb.AppendLine(string.Format(CultureInfo.InvariantCulture, "f {0}/{0}/{0} {1}/{1}/{1} {2}/{2}/{2}",
-                                        indexes[ff + 2] + triangleOffset,
-                                        indexes[ff + 1] + triangleOffset,
-                                        indexes[ff + 0] + triangleOffset));
-                            }
-                            else
-                            {
-                                sb.AppendLine(string.Format(CultureInfo.InvariantCulture, "f {0}/{0}/{0} {1}/{1}/{1} {2}/{2}/{2}",
-                                        indexes[ff + 0] + triangleOffset,
-                                        indexes[ff + 1] + triangleOffset,
-                                        indexes[ff + 2] + triangleOffset));
-                            }
+                            sb.AppendLine(string.Format(CultureInfo.InvariantCulture,
+                                "f {0}/{3}/{6} {1}/{4}/{7} {2}/{5}/{8}",
+                                p0, p1, p2,
+                                t0, t1, t2,
+                                n0, n1, n2
+                                ));
+
                         }
                     }
 
                     sb.AppendLine();
                 }
 
-                triangleOffset += vertexCount;
+                positionOffset += positionIndexMap.Count;
+                normalOffset += normalIndexMap.Count;
+                textureOffset += textureIndexMap.Count;
             }
 
             return sb.ToString();
@@ -368,6 +367,182 @@ namespace UnityEditor.ProBuilder
             }
 
             return sb.ToString();
+        }
+
+        struct PositionColorKey : System.IEquatable<PositionColorKey>
+        {
+            public IntVec3 position;
+            public IntVec4 color;
+
+            public PositionColorKey(Vector3 p, Color c)
+            {
+                position = new IntVec3(p);
+                color = new IntVec4(c);
+            }
+
+            public bool Equals(PositionColorKey other)
+            {
+                return position.Equals(other.position) && color.Equals(other.color);
+            }
+
+            public override bool Equals(object obj)
+            {
+                if (ReferenceEquals(null, obj)) return false;
+                return obj is PositionColorKey other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    return (position.GetHashCode() * 397) ^ color.GetHashCode();
+                }
+            }
+        }
+
+        static Dictionary<int, int> AppendPositions(StringBuilder sb, Vector3[] positions, Color[] colors, bool mergeCoincident, bool includeColors)
+        {
+            var writeColors = includeColors && colors != null && colors.Length == positions.Length;
+
+            Dictionary<PositionColorKey, int> common = new Dictionary<PositionColorKey, int>();
+            Dictionary<int, int> map = new Dictionary<int, int>();
+
+            int index = 0;
+
+            for (int i = 0, c = positions.Length; i < c; i++)
+            {
+                var position = positions[i];
+                var color = includeColors ? colors[i] : Color.white;
+
+                var key = new PositionColorKey(position, color);
+                int vertexIndex;
+
+                if (mergeCoincident)
+                {
+                    if (!common.TryGetValue(key, out vertexIndex))
+                    {
+                        vertexIndex = index++;
+                        common.Add(key, vertexIndex);
+                    }
+                    else
+                    {
+                        map.Add(i, vertexIndex);
+                        continue;
+                    }
+                }
+                else
+                {
+                    vertexIndex = i;
+                }
+
+                map.Add(i, vertexIndex);
+
+                if (writeColors)
+                {
+                    sb.AppendLine(string.Format(CultureInfo.InvariantCulture, "v {0} {1} {2} {3} {4} {5}",
+                        position.x,
+                        position.y,
+                        position.z,
+                        color.r,
+                        color.g,
+                        color.b));
+                }
+                else
+                {
+                    sb.AppendLine(string.Format(CultureInfo.InvariantCulture, "v {0} {1} {2}",
+                        position.x,
+                        position.y,
+                        position.z));
+                }
+            }
+
+            return map;
+        }
+
+        static Dictionary<int, int> AppendArrayVec2(StringBuilder sb, Vector2[] array, string prefix, bool mergeCoincident)
+        {
+            if (array == null)
+                return null;
+
+            Dictionary<IntVec2, int> common = new Dictionary<IntVec2, int>();
+            Dictionary<int, int> map = new Dictionary<int, int>();
+            int index = 0;
+
+            for (int i = 0, c = array.Length; i < c; i++)
+            {
+                var texture = array[i];
+                var key = new IntVec2(texture);
+                int vertexIndex;
+
+                if (mergeCoincident)
+                {
+                    if (!common.TryGetValue(key, out vertexIndex))
+                    {
+                        vertexIndex = index++;
+                        common.Add(key, vertexIndex);
+                    }
+                    else
+                    {
+                        map.Add(i, vertexIndex);
+                        continue;
+                    }
+                }
+                else
+                {
+                    vertexIndex = i;
+                }
+
+                map.Add(i, vertexIndex);
+
+                sb.AppendLine(string.Format(CultureInfo.InvariantCulture, "{0} {1} {2}",
+                    prefix,
+                    texture.x,
+                    texture.y));
+            }
+
+            return map;
+        }
+
+        static Dictionary<int, int> AppendNormals(StringBuilder sb, Vector3[] array, string prefix, bool mergeCoincident)
+        {
+            Dictionary<IntVec3, int> common = new Dictionary<IntVec3, int>();
+            Dictionary<int, int> map = new Dictionary<int, int>();
+            int index = 0;
+
+            for (int i = 0, c = array.Length; i < c; i++)
+            {
+                var value = array[i];
+                var key = new IntVec3(value);
+                int vertexIndex;
+
+                if (mergeCoincident)
+                {
+                    if (!common.TryGetValue(key, out vertexIndex))
+                    {
+                        vertexIndex = index++;
+                        common.Add(key, vertexIndex);
+                    }
+                    else
+                    {
+                        map.Add(i, vertexIndex);
+                        continue;
+                    }
+                }
+                else
+                {
+                    vertexIndex = i;
+                }
+
+                map.Add(i, vertexIndex);
+
+                sb.AppendLine(string.Format(CultureInfo.InvariantCulture, "{0} {1} {2} {3}",
+                    prefix,
+                    value.x,
+                    value.y,
+                    value.z));
+            }
+
+            return map;
         }
     }
 }

--- a/com.unity.probuilder/Editor/MenuActions/Export/ExportObj.cs
+++ b/com.unity.probuilder/Editor/MenuActions/Export/ExportObj.cs
@@ -96,9 +96,9 @@ namespace UnityEditor.ProBuilder.Actions
             {
                 try
                 {
-                    CopyTextures(textures, directory);
                     FileUtility.WriteAllText(string.Format("{0}/{1}.obj", directory, name), obj);
                     FileUtility.WriteAllText(string.Format("{0}/{1}.mtl", directory, name.Replace(" ", "_")), mat);
+                    CopyTextures(textures, directory);
                 }
                 catch (System.Exception e)
                 {
@@ -115,14 +115,18 @@ namespace UnityEditor.ProBuilder.Actions
             return path;
         }
 
-        /**
-         *  Copy files from their path to a destination directory.
-         */
-        private static void CopyTextures(List<string> textures, string destination)
+        // Copy files from their path to a destination directory.
+        static void CopyTextures(List<string> textures, string destination)
         {
             foreach (string path in textures)
             {
                 string dest = string.Format("{0}/{1}", destination, Path.GetFileName(path));
+
+                if (!File.Exists(path))
+                {
+                    Log.Warning("OBJ Export: Could not find texture \"" + path + ",\" it will not be copied.");
+                    continue;
+                }
 
                 if (!File.Exists(dest))
                     File.Copy(path, dest);

--- a/com.unity.probuilder/Runtime/Core/IntVec2.cs
+++ b/com.unity.probuilder/Runtime/Core/IntVec2.cs
@@ -1,0 +1,75 @@
+using UnityEngine;
+
+namespace UnityEngine.ProBuilder
+{
+	/// <summary>
+	/// Vertex positions are sorted as integers to avoid floating point precision errors.
+	/// </summary>
+	struct IntVec2 : System.IEquatable<IntVec2>
+	{
+		public Vector2 vec;
+
+		public float x { get { return vec.x; } }
+		public float y { get { return vec.y; } }
+
+		public const float RESOLUTION = VectorHash.FLT_COMPARE_RESOLUTION;
+
+		public IntVec2(Vector2 vector)
+		{
+			this.vec = vector;
+		}
+
+		public override string ToString()
+		{
+			return string.Format("({0:F2}, {1:F2})", x, y);
+		}
+
+		public static bool operator==(IntVec2 a, IntVec2 b)
+		{
+			return a.Equals(b);
+		}
+
+		public static bool operator!=(IntVec2 a, IntVec2 b)
+		{
+			return !(a == b);
+		}
+
+		public bool Equals(IntVec2 p)
+		{
+			return round(x) == round(p.x) &&
+				round(y) == round(p.y);
+		}
+
+		public bool Equals(Vector2 p)
+		{
+			return round(x) == round(p.x) &&
+				round(y) == round(p.y);
+		}
+
+		public override bool Equals(System.Object b)
+		{
+			return (b is IntVec2 && (this.Equals((IntVec2)b))) ||
+				(b is Vector2 && this.Equals((Vector2)b));
+		}
+
+		public override int GetHashCode()
+		{
+			return VectorHash.GetHashCode(vec);
+		}
+
+		private static int round(float v)
+		{
+			return System.Convert.ToInt32(v * RESOLUTION);
+		}
+
+		public static implicit operator Vector2(IntVec2 p)
+		{
+			return p.vec;
+		}
+
+		public static implicit operator IntVec2(Vector2 p)
+		{
+			return new IntVec2(p);
+		}
+	}
+}

--- a/com.unity.probuilder/Runtime/Core/IntVec2.cs
+++ b/com.unity.probuilder/Runtime/Core/IntVec2.cs
@@ -7,16 +7,14 @@ namespace UnityEngine.ProBuilder
 	/// </summary>
 	struct IntVec2 : System.IEquatable<IntVec2>
 	{
-		public Vector2 vec;
+		public Vector2 value;
 
-		public float x { get { return vec.x; } }
-		public float y { get { return vec.y; } }
-
-		public const float RESOLUTION = VectorHash.FLT_COMPARE_RESOLUTION;
+		public float x { get { return value.x; } }
+		public float y { get { return value.y; } }
 
 		public IntVec2(Vector2 vector)
 		{
-			this.vec = vector;
+			this.value = vector;
 		}
 
 		public override string ToString()
@@ -54,17 +52,17 @@ namespace UnityEngine.ProBuilder
 
 		public override int GetHashCode()
 		{
-			return VectorHash.GetHashCode(vec);
+			return VectorHash.GetHashCode(value);
 		}
 
 		private static int round(float v)
 		{
-			return System.Convert.ToInt32(v * RESOLUTION);
+			return System.Convert.ToInt32(v * VectorHash.FltCompareResolution);
 		}
 
 		public static implicit operator Vector2(IntVec2 p)
 		{
-			return p.vec;
+			return p.value;
 		}
 
 		public static implicit operator IntVec2(Vector2 p)

--- a/com.unity.probuilder/Runtime/Core/IntVec2.cs.meta
+++ b/com.unity.probuilder/Runtime/Core/IntVec2.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9f21d9e5e308b409f9173967b37d19be
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.probuilder/Runtime/Core/IntVec3.cs
+++ b/com.unity.probuilder/Runtime/Core/IntVec3.cs
@@ -7,17 +7,15 @@ namespace UnityEngine.ProBuilder
     /// </summary>
     struct IntVec3 : System.IEquatable<IntVec3>
     {
-        public Vector3 vec;
+        public Vector3 value;
 
-        public float x { get { return vec.x; } }
-        public float y { get { return vec.y; } }
-        public float z { get { return vec.z; } }
-
-        public const float RESOLUTION = VectorHash.FLT_COMPARE_RESOLUTION;
+        public float x { get { return value.x; } }
+        public float y { get { return value.y; } }
+        public float z { get { return value.z; } }
 
         public IntVec3(Vector3 vector)
         {
-            this.vec = vector;
+            this.value = vector;
         }
 
         public override string ToString()
@@ -57,17 +55,17 @@ namespace UnityEngine.ProBuilder
 
         public override int GetHashCode()
         {
-            return VectorHash.GetHashCode(vec);
+            return VectorHash.GetHashCode(value);
         }
 
         private static int round(float v)
         {
-            return System.Convert.ToInt32(v * RESOLUTION);
+            return System.Convert.ToInt32(v * VectorHash.FltCompareResolution);
         }
 
         public static implicit operator Vector3(IntVec3 p)
         {
-            return p.vec;
+            return p.value;
         }
 
         public static implicit operator IntVec3(Vector3 p)

--- a/com.unity.probuilder/Runtime/Core/IntVec4.cs
+++ b/com.unity.probuilder/Runtime/Core/IntVec4.cs
@@ -1,0 +1,81 @@
+using UnityEngine;
+
+namespace UnityEngine.ProBuilder
+{
+	/// <summary>
+	/// Vertex positions are sorted as integers to avoid floating point precision errors.
+	/// </summary>
+	struct IntVec4 : System.IEquatable<IntVec4>
+	{
+		public Vector4 vec;
+
+		public float x { get { return vec.x; } }
+		public float y { get { return vec.y; } }
+		public float z { get { return vec.z; } }
+		public float w { get { return vec.w; } }
+
+		public const float k_Resolution = VectorHash.FLT_COMPARE_RESOLUTION;
+
+		public IntVec4(Vector4 vector)
+		{
+			this.vec = vector;
+		}
+
+		public override string ToString()
+		{
+			return string.Format("({0:F2}, {1:F2}, {2:F2}, {3:F2})", x, y, z, w);
+		}
+
+		public static bool operator==(IntVec4 a, IntVec4 b)
+		{
+			return a.Equals(b);
+		}
+
+		public static bool operator!=(IntVec4 a, IntVec4 b)
+		{
+			return !(a == b);
+		}
+
+		public bool Equals(IntVec4 p)
+		{
+			return round(x) == round(p.x) &&
+				round(y) == round(p.y) &&
+				round(z) == round(p.z) &&
+				round(w) == round(p.w);
+		}
+
+		public bool Equals(Vector4 p)
+		{
+			return round(x) == round(p.x) &&
+				round(y) == round(p.y) &&
+				round(z) == round(p.z) &&
+				round(w) == round(p.w);
+		}
+
+		public override bool Equals(System.Object b)
+		{
+			return (b is IntVec4 && (this.Equals((IntVec4)b))) ||
+				(b is Vector4 && this.Equals((Vector4)b));
+		}
+
+		public override int GetHashCode()
+		{
+			return VectorHash.GetHashCode(vec);
+		}
+
+		private static int round(float v)
+		{
+			return System.Convert.ToInt32(v * k_Resolution);
+		}
+
+		public static implicit operator Vector4(IntVec4 p)
+		{
+			return p.vec;
+		}
+
+		public static implicit operator IntVec4(Vector4 p)
+		{
+			return new IntVec4(p);
+		}
+	}
+}

--- a/com.unity.probuilder/Runtime/Core/IntVec4.cs
+++ b/com.unity.probuilder/Runtime/Core/IntVec4.cs
@@ -7,18 +7,16 @@ namespace UnityEngine.ProBuilder
 	/// </summary>
 	struct IntVec4 : System.IEquatable<IntVec4>
 	{
-		public Vector4 vec;
+		public Vector4 value;
 
-		public float x { get { return vec.x; } }
-		public float y { get { return vec.y; } }
-		public float z { get { return vec.z; } }
-		public float w { get { return vec.w; } }
-
-		public const float k_Resolution = VectorHash.FLT_COMPARE_RESOLUTION;
+		public float x { get { return value.x; } }
+		public float y { get { return value.y; } }
+		public float z { get { return value.z; } }
+		public float w { get { return value.w; } }
 
 		public IntVec4(Vector4 vector)
 		{
-			this.vec = vector;
+			this.value = vector;
 		}
 
 		public override string ToString()
@@ -60,17 +58,17 @@ namespace UnityEngine.ProBuilder
 
 		public override int GetHashCode()
 		{
-			return VectorHash.GetHashCode(vec);
+			return VectorHash.GetHashCode(value);
 		}
 
 		private static int round(float v)
 		{
-			return System.Convert.ToInt32(v * k_Resolution);
+			return System.Convert.ToInt32(v * VectorHash.FltCompareResolution);
 		}
 
 		public static implicit operator Vector4(IntVec4 p)
 		{
-			return p.vec;
+			return p.value;
 		}
 
 		public static implicit operator IntVec4(Vector4 p)

--- a/com.unity.probuilder/Runtime/Core/IntVec4.cs.meta
+++ b/com.unity.probuilder/Runtime/Core/IntVec4.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 36dfd625ac38b4b62a04264b3819dc42
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.probuilder/Runtime/Core/Submesh.cs
+++ b/com.unity.probuilder/Runtime/Core/Submesh.cs
@@ -100,7 +100,6 @@ namespace UnityEngine.ProBuilder
         /// <param name="preferredTopology">Should the resulting submeshes be in quads or triangles. Note that quads are not guaranteed; ie, some faces may not be able to be represented in quad format and will fall back on triangles.</param>
         /// <returns>An array of Submeshes.</returns>
         /// <exception cref="NotImplementedException">Thrown in the event that a MeshTopology other than Quads or Triangles is passed.</exception>
-        /// <see cref="MeshUtility.GetMaterialCount"/>
         public static Submesh[] GetSubmeshes(IEnumerable<Face> faces, int submeshCount, MeshTopology preferredTopology = MeshTopology.Triangles)
         {
             if (preferredTopology != MeshTopology.Triangles && preferredTopology != MeshTopology.Quads)

--- a/com.unity.probuilder/Runtime/Core/VectorHash.cs
+++ b/com.unity.probuilder/Runtime/Core/VectorHash.cs
@@ -9,11 +9,11 @@ namespace UnityEngine.ProBuilder
     /// </summary>
     static class VectorHash
     {
-        public const float FLT_COMPARE_RESOLUTION = 1000f;
+        public const float FltCompareResolution = 1000f;
 
         static int HashFloat(float f)
         {
-            ulong u = (ulong)(f * FLT_COMPARE_RESOLUTION);
+            ulong u = (ulong)(f * FltCompareResolution);
             return (int)(u % int.MaxValue);
         }
 


### PR DESCRIPTION
This change enables the obj exporter to share vertex positions, normals, and textures. It reduces file sizes, as well as translates coincident vertices to other DCCs.

This also fixes an issue when attempting to copy a built-in texture resource.