### PR TITLE
ProBuilderize replaces all materials on object with default PB material

### DIFF
--- a/com.unity.probuilder/Runtime/Core/Submesh.cs
+++ b/com.unity.probuilder/Runtime/Core/Submesh.cs
@@ -197,6 +197,8 @@ namespace UnityEngine.ProBuilder
             foreach (var face in mesh.facesInternal)
             {
 #pragma warning disable 618
+                if (face.material == null)
+                    continue;
                 var index = Array.IndexOf(materials, face.material);
                 face.submeshIndex = Math.Clamp(index, 0, submeshCount - 1);
                 face.material = null;

--- a/com.unity.probuilder/Runtime/MeshOperations/MeshImporter.cs
+++ b/com.unity.probuilder/Runtime/MeshOperations/MeshImporter.cs
@@ -1,9 +1,7 @@
 using UnityEngine;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using UnityEngine.ProBuilder;
 
 namespace UnityEngine.ProBuilder.MeshOperations
 {
@@ -149,7 +147,7 @@ namespace UnityEngine.ProBuilder.MeshOperations
             {
                 switch (originalMesh.GetTopology(submeshIndex))
                 {
-                    case UnityEngine.MeshTopology.Triangles:
+                    case MeshTopology.Triangles:
                     {
                         int[] indexes = originalMesh.GetIndices(submeshIndex);
 
@@ -173,22 +171,23 @@ namespace UnityEngine.ProBuilder.MeshOperations
                     }
                     break;
 
-                    case UnityEngine.MeshTopology.Quads:
+                    case MeshTopology.Quads:
                     {
                         int[] indexes = originalMesh.GetIndices(submeshIndex);
 
                         for (int quad = 0; quad < indexes.Length; quad += 4)
                         {
-                            faces.Add(new Face(new int[] {
-                                vertexIndex    , vertexIndex + 1, vertexIndex + 2,
-                                vertexIndex + 2, vertexIndex + 3, vertexIndex + 0
-                            },
-                                    Math.Clamp(submeshIndex, 0, materialCount - 1),
-                                    AutoUnwrapSettings.tile,
-                                    Smoothing.smoothingGroupNone,
-                                    -1,
-                                    -1,
-                                    true));
+                            faces.Add(new Face(new int[]
+                                {
+                                    vertexIndex, vertexIndex + 1, vertexIndex + 2,
+                                    vertexIndex + 2, vertexIndex + 3, vertexIndex + 0
+                                },
+                                Math.Clamp(submeshIndex, 0, materialCount - 1),
+                                AutoUnwrapSettings.tile,
+                                Smoothing.smoothingGroupNone,
+                                -1,
+                                -1,
+                                true));
 
                             splitVertices.Add(sourceVertices[indexes[quad]]);
                             splitVertices.Add(sourceVertices[indexes[quad + 1]]);


### PR DESCRIPTION
Fix `MeshImporter.Import` resulting in all faces having a `submeshIndex` value of `0`. The problem was that `Import` adds the `ProBuilderMesh` component with `AddComponent` and does not initialize the `m_MeshFormatVersion` correctly. This PR introduces a null check in `Submesh.MapFaceMaterialsToSubmeshIndex` to prevent it from overwriting the submesh index in faces with null materials.