### PR TITLE
Fix Connect Edges throwing exception with degenerate tris

### DIFF
--- a/com.unity.probuilder/Editor/EditorCore/EditorMeshUtility.cs
+++ b/com.unity.probuilder/Editor/EditorCore/EditorMeshUtility.cs
@@ -1,9 +1,11 @@
 using UnityEngine;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using UnityEditor.SettingsManagement;
 using UnityEngine.ProBuilder;
+using UnityEngine.ProBuilder.MeshOperations;
 using Math = UnityEngine.ProBuilder.Math;
 
 namespace UnityEditor.ProBuilder
@@ -51,7 +53,7 @@ namespace UnityEditor.ProBuilder
             if (!skipMeshProcessing)
             {
                 bool autoLightmap = Lightmapping.autoUnwrapLightmapUV;
-                
+
 #if UNITY_2019_2_OR_NEWER
                 bool lightmapUVs = generateLightmapUVs || (autoLightmap && mesh.gameObject.HasStaticFlag(StaticEditorFlags.ContributeGI));
 #else

--- a/com.unity.probuilder/Editor/EditorCore/RepairActions.cs
+++ b/com.unity.probuilder/Editor/EditorCore/RepairActions.cs
@@ -1,10 +1,7 @@
-using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using UnityEngine.ProBuilder;
 using UnityEngine.ProBuilder.MeshOperations;
-using UnityEditor;
 using UnityEngine;
 
 namespace UnityEditor.ProBuilder
@@ -139,17 +136,17 @@ namespace UnityEditor.ProBuilder
 
             foreach (ProBuilderMesh pb in InternalUtility.GetComponents<ProBuilderMesh>(Selection.transforms))
             {
-                pb.ToMesh();
+                var removed = MeshValidation.EnsureMeshIsValid(pb);
 
-                int[] rm = pb.RemoveDegenerateTriangles();
-                count += rm != null ? rm.Length : 0;
-
-                pb.ToMesh();
-                pb.Refresh();
-                pb.Optimize();
+                if (removed > 0)
+                {
+                    pb.Rebuild();
+                    pb.Optimize();
+                    count += removed;
+                }
             }
 
-            EditorUtility.ShowNotification("Removed " + (count / 3) + " degenerate triangles.");
+            EditorUtility.ShowNotification("Removed " + count + " vertices \nbelonging to degenerate triangles.");
         }
     }
 }

--- a/com.unity.probuilder/Editor/EditorCore/RepairActions.cs
+++ b/com.unity.probuilder/Editor/EditorCore/RepairActions.cs
@@ -136,13 +136,13 @@ namespace UnityEditor.ProBuilder
 
             foreach (ProBuilderMesh pb in InternalUtility.GetComponents<ProBuilderMesh>(Selection.transforms))
             {
-                var removed = MeshValidation.EnsureMeshIsValid(pb);
+                int removedVertexCount;
 
-                if (removed > 0)
+                if(!MeshValidation.EnsureMeshIsValid(pb, out removedVertexCount))
                 {
                     pb.Rebuild();
                     pb.Optimize();
-                    count += removed;
+                    count += removedVertexCount;
                 }
             }
 

--- a/com.unity.probuilder/Editor/MenuActions/Geometry/WeldVertices.cs
+++ b/com.unity.probuilder/Editor/MenuActions/Geometry/WeldVertices.cs
@@ -98,19 +98,22 @@ namespace UnityEditor.ProBuilder.Actions
                     {
                         var newSelection = welds ?? new int[0] { };
 
-                        var removedIndices = mesh.RemoveDegenerateTriangles();
-                        if (removedIndices != null)
+
+                        if (MeshValidation.ContainsDegenerateTriangles(mesh))
                         {
-                            if (removedIndices.Length > 0)
+                            List<int> removedIndices = new List<int>();
+
+                            if(MeshValidation.RemoveDegenerateTriangles(mesh, removedIndices))
                             {
                                 var newlySelectedVertices = new List<int>();
                                 selectedVertices.Sort();
-                                Array.Sort(removedIndices);
+                                removedIndices.Sort();
 
                                 int count = 0;
+                                
                                 for (int i = 0; i < selectedVertices.Count ; i++)
                                 {
-                                    if (count >= removedIndices.Length || selectedVertices[i] != removedIndices[count] )
+                                    if (count >= removedIndices.Count || selectedVertices[i] != removedIndices[count] )
                                     {
                                         newlySelectedVertices.Add(selectedVertices[i] - UnityEngine.ProBuilder.ArrayUtility.NearestIndexPriorToValue(removedIndices, selectedVertices[i]) - 1);
                                     }

--- a/com.unity.probuilder/Runtime/Core/ArrayUtility.cs
+++ b/com.unity.probuilder/Runtime/Core/ArrayUtility.cs
@@ -140,7 +140,7 @@ namespace UnityEngine.ProBuilder
          * Given a sorted list and value, returns the index of the greatest value in sorted_list that is
          * less than value.  Ex: List( { 0, 1, 4, 6, 7 } ) Value(5) returns 2, which is the index of value 4.
          * If value is less than sorted[0], -1 is returned.  If value is greater than sorted[end], sorted.Count-1
-         * is returned.  If an exact match is found, the index prior to that match is returned.
+         * is returned. If an exact match is found, the index prior to that match is returned.
          */
         public static int NearestIndexPriorToValue<T>(IList<T> sorted_list, T value) where T : System.IComparable<T>
         {

--- a/com.unity.probuilder/Runtime/Core/ProBuilderMeshFunction.cs
+++ b/com.unity.probuilder/Runtime/Core/ProBuilderMeshFunction.cs
@@ -194,6 +194,9 @@ namespace UnityEngine.ProBuilder
             Refresh();
         }
 
+        /// <summary>
+        /// Wraps <see cref="ToMesh"/> and <see cref="Refresh"/>.
+        /// </summary>
         internal void Rebuild()
         {
             ToMesh();
@@ -407,7 +410,7 @@ namespace UnityEngine.ProBuilder
         {
             if (!IsValidTextureGroup(group))
                 return;
-            
+
             foreach (var face in facesInternal)
             {
                 if (face.textureGroup != group)

--- a/com.unity.probuilder/Runtime/Core/ProBuilderMeshSelection.cs
+++ b/com.unity.probuilder/Runtime/Core/ProBuilderMeshSelection.cs
@@ -121,16 +121,6 @@ namespace UnityEngine.ProBuilder
             return selected;
         }
 
-        internal Face[] selectedFacesInternal
-        {
-            get { return GetSelectedFaces(); }
-        }
-
-        internal int[] selectedFaceIndicesInternal
-        {
-            get { return m_SelectedFaces; }
-        }
-
         /// <value>
         /// A collection of the currently selected faces by their index in the @"UnityEngine.ProBuilder.ProBuilderMesh.faces" array.
         /// </value>
@@ -155,14 +145,28 @@ namespace UnityEngine.ProBuilder
             get { return new ReadOnlyCollection<Edge>(m_SelectedEdges); }
         }
 
+        internal Face[] selectedFacesInternal
+        {
+            get { return GetSelectedFaces(); }
+            set { m_SelectedFaces = value.Select(x => Array.IndexOf(m_Faces, x)).ToArray(); }
+        }
+
+        internal int[] selectedFaceIndicesInternal
+        {
+            get { return m_SelectedFaces; }
+            set { m_SelectedFaces = value; }
+        }
+
         internal Edge[] selectedEdgesInternal
         {
             get { return m_SelectedEdges; }
+            set { m_SelectedEdges = value; }
         }
 
         internal int[] selectedIndexesInternal
         {
             get { return m_SelectedVertices; }
+            set { m_SelectedVertices = value; }
         }
 
         internal Face GetActiveFace()

--- a/com.unity.probuilder/Runtime/Core/SharedVertex.cs
+++ b/com.unity.probuilder/Runtime/Core/SharedVertex.cs
@@ -12,7 +12,6 @@ namespace UnityEngine.ProBuilder
     /// <summary>
     /// Defines associations between vertex positions that are coincident. The indexes stored in this collection correspond to the ProBuilderMesh.positions array.
     /// <br />
-    /// <br />
     /// Coincident vertices are vertices that despite sharing the same coordinate position, are separate entries in the vertex array.
     /// </summary>
     [Serializable]

--- a/com.unity.probuilder/Runtime/MeshOperations/MergeElements.cs
+++ b/com.unity.probuilder/Runtime/MeshOperations/MergeElements.cs
@@ -128,7 +128,7 @@ namespace UnityEngine.ProBuilder.MeshOperations
                 face.InvalidateCache();
             }
 
-            mesh.RemoveUnusedVertices();
+            MeshValidation.RemoveUnusedVertices(mesh);
         }
     }
 }

--- a/com.unity.probuilder/Runtime/MeshOperations/MeshValidation.cs
+++ b/com.unity.probuilder/Runtime/MeshOperations/MeshValidation.cs
@@ -1,0 +1,306 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UnityEngine.ProBuilder.MeshOperations
+{
+    /// <summary>
+    /// Methods for testing that mesh topology is correct.
+    /// </summary>
+	public static class MeshValidation
+	{
+	    /// <summary>
+	    /// Check if any face on a mesh contains degenerate triangles. A degenerate triangle does not have any area.
+	    /// </summary>
+	    /// <param name="mesh">The mesh to test for degenerate triangles.</param>
+	    /// <returns>True if any face contains a degenerate triangle, false if no degenerate triangles are found.</returns>
+        /// <seealso cref="RemoveDegenerateTriangles"/>
+        public static bool ContainsDegenerateTriangles(this ProBuilderMesh mesh)
+        {
+            return ContainsDegenerateTriangles(mesh, mesh.facesInternal);
+        }
+
+        /// <summary>
+        /// Check if any face contains degenerate triangles. A degenerate triangle does not have any area.
+        /// </summary>
+        /// <param name="mesh">The mesh to test for degenerate triangles.</param>
+        /// <param name="faces">The faces to test for degenerate triangles.</param>
+        /// <returns>True if any face contains a degenerate triangle, false if no degenerate triangles are found.</returns>
+        /// <seealso cref="RemoveDegenerateTriangles"/>
+        public static bool ContainsDegenerateTriangles(this ProBuilderMesh mesh, IList<Face> faces)
+        {
+            var positions = mesh.positionsInternal;
+
+            foreach (var face in faces)
+            {
+                var indices = face.indexesInternal;
+
+                for (int i = 0; i < indices.Length; i += 3)
+                {
+                    float area = Math.TriangleArea(
+                        positions[indices[i + 0]],
+                        positions[indices[i + 1]],
+                        positions[indices[i + 2]]);
+
+                    if (area <= Mathf.Epsilon)
+                        return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Check if any face contains degenerate triangles. A degenerate triangle does not have any area.
+        /// </summary>
+        /// <param name="mesh">The mesh to test for degenerate triangles.</param>
+        /// <param name="face">The face to test for degenerate triangles.</param>
+        /// <returns>True if any triangle within the face contains a degenerate triangle, false if no degenerate triangles are found.</returns>
+        /// <seealso cref="RemoveDegenerateTriangles"/>
+        public static bool ContainsDegenerateTriangles(this ProBuilderMesh mesh, Face face)
+        {
+            var positions = mesh.positionsInternal;
+            var indices = face.indexesInternal;
+
+            for (int i = 0; i < indices.Length; i += 3)
+            {
+                float area = Math.TriangleArea(
+                    positions[indices[i + 0]],
+                    positions[indices[i + 1]],
+                    positions[indices[i + 2]]);
+
+                if (area <= Mathf.Epsilon)
+                    return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Iterates through all faces in a mesh and removes triangles with an area less than float.Epsilon, or with
+        /// indexes that point to the same vertex. This function also enforces the rule that a face must contain no
+        /// coincident vertices.
+        /// </summary>
+        /// <param name="mesh">The source mesh.</param>
+        /// <param name="removed">An optional list to be populated with the removed indices. If no degenerate triangles are found, this list will contain no elements.</param>
+        /// <returns>True if degenerate triangles were found and removed, false if no degenerate triangles were found.</returns>
+        public static bool RemoveDegenerateTriangles(ProBuilderMesh mesh, List<int> removed = null)
+        {
+            if (mesh == null)
+                throw new ArgumentNullException("mesh");
+
+            Dictionary<int, int> m_Lookup = mesh.sharedVertexLookup;
+            Dictionary<int, int> m_LookupUV = mesh.sharedTextureLookup;
+            Vector3[] m_Positions = mesh.positionsInternal;
+            Dictionary<int, int> m_RebuiltLookup = new Dictionary<int, int>(m_Lookup.Count);
+            Dictionary<int, int> m_RebuiltLookupUV = new Dictionary<int, int>(m_LookupUV.Count);
+            List<Face> m_RebuiltFaces = new List<Face>(mesh.faceCount);
+            Dictionary<int, int> m_DuplicateIndexFilter = new Dictionary<int, int>(8);
+
+            foreach (Face face in mesh.facesInternal)
+            {
+                m_DuplicateIndexFilter.Clear();
+                List<int> tris = new List<int>();
+                int[] ind = face.indexesInternal;
+
+                for (int i = 0; i < ind.Length; i += 3)
+                {
+                    float area = Math.TriangleArea(m_Positions[ind[i + 0]], m_Positions[ind[i + 1]], m_Positions[ind[i + 2]]);
+
+                    if (area > Mathf.Epsilon)
+                    {
+                        // Index in the positions array
+                        int triangleIndexA = ind[i],
+                            triangleIndexB = ind[i+1],
+                            triangleIndexC = ind[i+2];
+
+                        // Common index (also called SharedIndexHandle)
+                        int sharedIndexA = m_Lookup[triangleIndexA],
+                            sharedIndexB = m_Lookup[triangleIndexB],
+                            sharedIndexC = m_Lookup[triangleIndexC];
+
+                        // test if there are any duplicates in the triangle
+                        if (!(sharedIndexA == sharedIndexB || sharedIndexA == sharedIndexC || sharedIndexB == sharedIndexC))
+                        {
+                            int index;
+
+                            // catch case where face has two distinct vertices that are in fact coincident.
+                            if (!m_DuplicateIndexFilter.TryGetValue(sharedIndexA, out index))
+                                m_DuplicateIndexFilter.Add(sharedIndexA, triangleIndexA);
+                            else
+                                triangleIndexA = index;
+
+                            if (!m_DuplicateIndexFilter.TryGetValue(sharedIndexB, out index))
+                                m_DuplicateIndexFilter.Add(sharedIndexB, triangleIndexB);
+                            else
+                                triangleIndexB = index;
+
+                            if (!m_DuplicateIndexFilter.TryGetValue(sharedIndexC, out index))
+                                m_DuplicateIndexFilter.Add(sharedIndexC, triangleIndexC);
+                            else
+                                triangleIndexC = index;
+
+                            tris.Add(triangleIndexA);
+                            tris.Add(triangleIndexB);
+                            tris.Add(triangleIndexC);
+
+                            if (!m_RebuiltLookup.ContainsKey(triangleIndexA))
+                                m_RebuiltLookup.Add(triangleIndexA, sharedIndexA);
+                            if (!m_RebuiltLookup.ContainsKey(triangleIndexB))
+                                m_RebuiltLookup.Add(triangleIndexB, sharedIndexB);
+                            if (!m_RebuiltLookup.ContainsKey(triangleIndexC))
+                                m_RebuiltLookup.Add(triangleIndexC, sharedIndexC);
+
+                            if (m_LookupUV.ContainsKey(triangleIndexA) && !m_RebuiltLookupUV.ContainsKey(triangleIndexA))
+                                m_RebuiltLookupUV.Add(triangleIndexA, m_LookupUV[triangleIndexA]);
+                            if (m_LookupUV.ContainsKey(triangleIndexB) && !m_RebuiltLookupUV.ContainsKey(triangleIndexB))
+                                m_RebuiltLookupUV.Add(triangleIndexB, m_LookupUV[triangleIndexB]);
+                            if (m_LookupUV.ContainsKey(triangleIndexC) && !m_RebuiltLookupUV.ContainsKey(triangleIndexC))
+                                m_RebuiltLookupUV.Add(triangleIndexC, m_LookupUV[triangleIndexC]);
+                        }
+                    }
+                }
+
+                if (tris.Count > 0)
+                {
+                    face.indexesInternal = tris.ToArray();
+                    m_RebuiltFaces.Add(face);
+                }
+            }
+
+            mesh.faces = m_RebuiltFaces;
+            mesh.SetSharedVertices(m_RebuiltLookup);
+            mesh.SetSharedTextures(m_RebuiltLookupUV);
+
+            return RemoveUnusedVertices(mesh, removed);
+        }
+
+        /// <summary>
+        /// Removes vertices that no face references.
+        /// </summary>
+        /// <param name="mesh">The source mesh.</param>
+        /// <param name="removed">An optional list to be populated with the removed indices. If no vertices are removed, this list will contain no elements.</param>
+        /// <returns>A list of deleted vertex indexes.</returns>
+        public static bool RemoveUnusedVertices(ProBuilderMesh mesh, List<int> removed = null)
+        {
+            if (mesh == null)
+                throw new ArgumentNullException("mesh");
+
+            bool saveRemoved = removed != null;
+
+            if(saveRemoved)
+                removed.Clear();
+
+            var del = saveRemoved ? removed : new List<int>();
+
+            var tris = new HashSet<int>(mesh.facesInternal.SelectMany(x => x.indexes));
+
+            for (int i = 0; i < mesh.positionsInternal.Length; i++)
+                if (!tris.Contains(i))
+                    del.Add(i);
+
+            mesh.DeleteVertices(del);
+
+            return del.Any();
+        }
+
+        /// <summary>
+        /// Rebuild a collection of indexes accounting for the removal of a collection of indices.
+        /// </summary>
+        /// <param name="indices">The indices to rebuild.</param>
+        /// <param name="removed">A sorted collection indices that were removed.</param>
+        /// <returns>A new list of indices pointing to the same vertex as they were prior to the removal of some entries.</returns>
+        internal static List<int> RebuildIndexes(IEnumerable<int> indices, List<int> removed)
+        {
+            var res = new List<int>();
+            var rmc = removed.Count;
+
+            foreach (var index in indices)
+            {
+                var nearestIndex = ArrayUtility.NearestIndexPriorToValue(removed, index) + 1;
+
+                // don't add back into the indices collection if the index was removed
+                if (nearestIndex > -1 && nearestIndex < rmc && removed[nearestIndex] == index)
+                    continue;
+
+                res.Add(index - nearestIndex);
+            }
+
+            return res;
+        }
+
+        /// <summary>
+        /// Rebuild a collection of indexes accounting for the removal of a collection of indices.
+        /// </summary>
+        /// <param name="edges">The indices to rebuild.</param>
+        /// <param name="removed">A sorted collection indices that were removed.</param>
+        /// <returns>A new list of indices pointing to the same vertex as they were prior to the removal of some entries.</returns>
+        internal static List<Edge> RebuildEdges(IEnumerable<Edge> edges, List<int> removed)
+        {
+            var res = new List<Edge>();
+            var rmc = removed.Count;
+
+            foreach (var edge in edges)
+            {
+                var nearestIndexA = ArrayUtility.NearestIndexPriorToValue(removed, edge.a) + 1;
+                var nearestIndexB = ArrayUtility.NearestIndexPriorToValue(removed, edge.b) + 1;
+
+                // don't add back into the indices collection if the index was removed
+                if ((nearestIndexA > -1 && nearestIndexA < rmc && removed[nearestIndexA] == edge.a) ||
+                    (nearestIndexB > -1 && nearestIndexB < rmc && removed[nearestIndexB] == edge.b))
+                    continue;
+
+                res.Add(new Edge(edge.a - nearestIndexA, edge.b - nearestIndexB));
+            }
+
+            return res;
+        }
+
+        internal static void RebuildSelectionIndexes(ProBuilderMesh mesh, ref Face[] faces, ref Edge[] edges, ref int[] indices, IEnumerable<int> removed)
+        {
+            var rm = removed.ToList();
+            rm.Sort();
+
+            if (faces != null && faces.Length > 0)
+                faces = faces.Where(x => mesh.facesInternal.Contains(x)).ToArray();
+
+            if(edges != null && edges.Length > 0)
+                edges = RebuildEdges(edges, rm).ToArray();
+
+            if(indices != null && indices.Length > 0)
+                indices = RebuildIndexes(indices, rm).ToArray();
+        }
+
+        /// <summary>
+        /// Remove any degenerate triangles on a mesh, keeping the selection intact.
+        /// </summary>
+        /// <returns>
+        /// 0 if mesh is valid, or greater than 0 if corrections were made. If this method returns greater than 0, you will need to
+        /// rebuild the mesh using <see cref="ProBuilderMesh.ToMesh"/> and <see cref="ProBuilderMesh.Refresh"/>.
+        /// </returns>
+        internal static int EnsureMeshIsValid(ProBuilderMesh mesh)
+        {
+            if (ContainsDegenerateTriangles(mesh))
+            {
+                var faces = mesh.selectedFacesInternal;
+                var edges = mesh.selectedEdgesInternal;
+                var indices = mesh.selectedIndexesInternal;
+
+                List<int> removed = new List<int>();
+
+                if (RemoveDegenerateTriangles(mesh, removed))
+                {
+                    mesh.sharedVertices = SharedVertex.GetSharedVerticesWithPositions(mesh.positionsInternal);
+                    
+                    RebuildSelectionIndexes(mesh, ref faces, ref edges, ref indices, removed);
+                    mesh.selectedFacesInternal = faces;
+                    mesh.selectedEdgesInternal = edges;
+                    mesh.selectedIndexesInternal = indices;
+                    return removed.Count;
+                }
+            }
+
+            return 0;
+        }
+	}
+}

--- a/com.unity.probuilder/Runtime/MeshOperations/MeshValidation.cs.meta
+++ b/com.unity.probuilder/Runtime/MeshOperations/MeshValidation.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 12d2df8ff0d1e417e97df69e20c4c81b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.probuilder/Runtime/MeshOperations/Triangulation.cs
+++ b/com.unity.probuilder/Runtime/MeshOperations/Triangulation.cs
@@ -70,13 +70,12 @@ namespace UnityEngine.ProBuilder.MeshOperations
                 return true;
             }
 
-            Vector3 normal = Projection.FindBestPlane(vertices).normal;
             Vector2[] points2d = Projection.PlanarProject(vertices);
 
             if (unordered)
-                return Triangulation.SortAndTriangulate(points2d, out triangles, convex);
-            else
-                return Triangulate(points2d, out triangles, convex);
+                return SortAndTriangulate(points2d, out triangles, convex);
+
+            return Triangulate(points2d, out triangles, convex);
         }
 
         /// <summary>
@@ -102,7 +101,7 @@ namespace UnityEngine.ProBuilder.MeshOperations
             }
             catch (System.Exception e)
             {
-                Log.Warning("Triangulation failed: " + e.ToString());
+                Log.Info("Triangulation failed: " + e.ToString());
                 return false;
             }
 
@@ -110,7 +109,7 @@ namespace UnityEngine.ProBuilder.MeshOperations
             {
                 if (d.Points[0].Index < 0 || d.Points[1].Index < 0 || d.Points[2].Index < 0)
                 {
-                    Log.Warning("Triangulation failed: Additional vertices were inserted.");
+                    Log.Info("Triangulation failed: Additional vertices were inserted.");
                     return false;
                 }
 

--- a/com.unity.probuilder/Runtime/MeshOperations/VertexEditing.cs
+++ b/com.unity.probuilder/Runtime/MeshOperations/VertexEditing.cs
@@ -40,7 +40,9 @@ namespace UnityEngine.ProBuilder.MeshOperations
             mesh.SetSharedVertexValues(sharedVertexHandle, cen);
 
             SharedVertex merged = mesh.sharedVerticesInternal[sharedVertexHandle];
-            int[] removedIndexes = mesh.RemoveDegenerateTriangles();
+            List<int> removedIndexes = new List<int>();
+
+            MeshValidation.RemoveDegenerateTriangles(mesh, removedIndexes);
 
             // get a non-deleted index to work with
             int ind = -1;
@@ -50,7 +52,7 @@ namespace UnityEngine.ProBuilder.MeshOperations
 
             int res = ind;
 
-            for (int i = 0; i < removedIndexes.Length; i++)
+            for (int i = 0; i < removedIndexes.Count; i++)
                 if (ind > removedIndexes[i])
                     res--;
 


### PR DESCRIPTION
Fixes fogbugz case 1077016

This also cleans up the functions to remove degenerate triangles and unused vertices, moving them to a new `MeshValidation` class. A new method is added (`MeshValidation.EnsureMeshIsValid`) which cleans up degenerate tris and unused vertices while keeping the selection intact.