### PR TITLE
Add option to Export just mesh asset

### DIFF
--- a/com.unity.probuilder/Editor/MenuActions/Export/ExportAsset.cs
+++ b/com.unity.probuilder/Editor/MenuActions/Export/ExportAsset.cs
@@ -1,16 +1,33 @@
+using System;
 using UnityEngine;
 using System.Linq;
 using System.Collections.Generic;
 using System.IO;
 using UnityEngine.ProBuilder;
+using Object = UnityEngine.Object;
 
 namespace UnityEditor.ProBuilder.Actions
 {
+    [Serializable]
+    struct ExportAssetOptions
+    {
+        public bool makePrefab;
+        public bool replaceOriginal;
+
+        public static readonly ExportAssetOptions defaults = new ExportAssetOptions()
+        {
+            makePrefab = false,
+            replaceOriginal = false
+        };
+    }
+
     sealed class ExportAsset : MenuAction
     {
         public override ToolbarGroup group { get { return ToolbarGroup.Export; } }
         public override Texture2D icon { get { return null; } }
         public override TooltipContent tooltip { get { return s_Tooltip; } }
+
+        internal static Pref<ExportAssetOptions> s_ExportAssetOptions =new Pref<ExportAssetOptions>("export.assetOptions", ExportAssetOptions.defaults);
 
         static readonly TooltipContent s_Tooltip = new TooltipContent
             (
@@ -30,9 +47,10 @@ namespace UnityEditor.ProBuilder.Actions
 
         public override ActionResult DoAction()
         {
-            var res = ExportWithFileDialog(MeshSelection.topInternal);
+            var opt = s_ExportAssetOptions.value;
+            var res = ExportWithFileDialog(MeshSelection.topInternal, opt);
             Export.PingExportedModel(res);
-            return new ActionResult(ActionResult.Status.Success, "Make Asset & Prefab");
+            return new ActionResult(ActionResult.Status.Success, opt.makePrefab ? "Make Prefab" : "Make Asset");
         }
 
         /// <summary>
@@ -40,7 +58,7 @@ namespace UnityEditor.ProBuilder.Actions
         /// </summary>
         /// <param name="meshes"></param>
         /// <returns></returns>
-        public static string ExportWithFileDialog(IEnumerable<ProBuilderMesh> meshes)
+        public static string ExportWithFileDialog(IList<ProBuilderMesh> meshes, ExportAssetOptions options)
         {
             if (meshes == null || !meshes.Any())
                 return "";
@@ -54,25 +72,9 @@ namespace UnityEditor.ProBuilder.Actions
                 if (first == null)
                     return null;
 
-                string name = first.name;
-                string path = UnityEditor.EditorUtility.SaveFilePanel("Export to Asset", "Assets", name, "prefab");
-
-                if (string.IsNullOrEmpty(path))
-                    return null;
-
-                string directory = Path.GetDirectoryName(path);
-                name = Path.GetFileNameWithoutExtension(path);
-                string meshPath = string.Format("{0}/{1}.asset", directory, first.mesh.name).Replace("\\", "/");
-                string prefabPath = string.Format("{0}/{1}.prefab", directory, name).Replace("\\", "/");
-
-                // If a file dialog was presented that means the user has already been asked to overwrite.
-                if (File.Exists(meshPath))
-                    AssetDatabase.DeleteAsset(meshPath.Replace(Application.dataPath, "Assets"));
-
-                if (File.Exists(prefabPath))
-                    AssetDatabase.DeleteAsset(prefabPath.Replace(Application.dataPath, "Assets"));
-
-                res = DoExport(path, first);
+                res = options.makePrefab
+                    ? ExportPrefab(first, options.replaceOriginal)
+                    : ExportMesh(first, options.replaceOriginal);
             }
             else
             {
@@ -81,14 +83,82 @@ namespace UnityEditor.ProBuilder.Actions
                 if (string.IsNullOrEmpty(path) || !Directory.Exists(path))
                     return null;
 
-                foreach (ProBuilderMesh pb in meshes)
-                    res = DoExport(string.Format("{0}/{1}.asset", path, pb.name), pb);
+                for(int i = 0, c = meshes.Count; i < c; i++)
+                {
+                    var pb = meshes[i];
+                    var assetPath = string.Format("{0}/{1}.asset", path, pb.name);
+
+
+                    if(options.makePrefab)
+                    {
+                        res = ExportPrefab(assetPath, pb, options.replaceOriginal);
+                    }
+                    else
+                    {
+                        res = ExportMesh(assetPath, pb);
+
+                        if (options.replaceOriginal)
+                        {
+                            pb.preserveMeshAssetOnDestroy = true;
+                            Undo.DestroyObjectImmediate(pb);
+                        }
+
+                    }
+                }
             }
 
             return res;
         }
 
-        static string DoExport(string path, ProBuilderMesh pb)
+        static string ExportPrefab(ProBuilderMesh mesh, bool replace)
+        {
+            string path = UnityEditor.EditorUtility.SaveFilePanel("Export to Asset", "Assets", mesh.name, "prefab");
+
+            if (string.IsNullOrEmpty(path))
+                return null;
+
+            string directory = Path.GetDirectoryName(path);
+            string name = Path.GetFileNameWithoutExtension(path);
+            string meshPath = string.Format("{0}/{1}.asset", directory, mesh.mesh.name).Replace("\\", "/");
+            string prefabPath = string.Format("{0}/{1}.prefab", directory, name).Replace("\\", "/");
+
+            if (File.Exists(meshPath))
+                AssetDatabase.DeleteAsset(meshPath.Replace(Application.dataPath, "Assets"));
+
+            if (File.Exists(prefabPath))
+                AssetDatabase.DeleteAsset(prefabPath.Replace(Application.dataPath, "Assets"));
+
+            return ExportPrefab(path, mesh, replace);
+        }
+
+        static string ExportMesh(ProBuilderMesh mesh, bool replace)
+        {
+            string path = UnityEditor.EditorUtility.SaveFilePanel("Export to Asset", "Assets", mesh.name, "asset");
+
+            if (string.IsNullOrEmpty(path))
+                return null;
+
+            // If a file dialog was presented that means the user has already been asked to overwrite.
+            if (File.Exists(path))
+                AssetDatabase.DeleteAsset(path.Replace(Application.dataPath, "Assets"));
+
+            ExportMesh(path, mesh);
+
+            if (replace)
+            {
+                mesh.preserveMeshAssetOnDestroy = true;
+                Undo.DestroyObjectImmediate(mesh);
+            }
+            else
+            {
+                mesh.mesh = null;
+                EditorUtility.SynchronizeWithMeshFilter(mesh);
+            }
+
+            return path;
+        }
+
+        static string ExportPrefab(string path, ProBuilderMesh pb, bool replace)
         {
             string directory = Path.GetDirectoryName(path).Replace("\\", "/");
             string name = Path.GetFileNameWithoutExtension(path);
@@ -102,26 +172,56 @@ namespace UnityEditor.ProBuilder.Actions
 
             AssetDatabase.CreateAsset(pb.mesh, meshPath);
 
-            pb.MakeUnique();
-
             Mesh meshAsset = (Mesh)AssetDatabase.LoadAssetAtPath(meshPath, typeof(Mesh));
 
-            var go = Object.Instantiate(pb.gameObject);
-            var dup = go.GetComponent<ProBuilderMesh>();
-            var entity = go.GetComponent<Entity>();
-            if (entity != null)
-                Object.DestroyImmediate(entity);
-            dup.preserveMeshAssetOnDestroy = true;
-            Object.DestroyImmediate(dup);
+            var go = replace ? pb.gameObject : Object.Instantiate(pb.gameObject);
+
+            var component = go.GetComponent<ProBuilderMesh>();
+            Undo.RecordObject(component, "Export ProBuilderMesh as Replacement");
+            component.preserveMeshAssetOnDestroy = true;
+            Undo.DestroyObjectImmediate(component);
+
             go.GetComponent<MeshFilter>().sharedMesh = meshAsset;
             string relativePrefabPath = string.Format("{0}/{1}.prefab", relativeDirectory, name);
             string prefabPath = AssetDatabase.GenerateUniqueAssetPath(relativePrefabPath);
+
 #if UNITY_2018_3_OR_NEWER
-            PrefabUtility.SaveAsPrefabAsset(go, prefabPath);
+            if(replace)
+                PrefabUtility.SaveAsPrefabAssetAndConnect(go, prefabPath, InteractionMode.UserAction);
+            else
+                PrefabUtility.SaveAsPrefabAsset(go, prefabPath);
 #else
             PrefabUtility.CreatePrefab(prefabPath, go, ReplacePrefabOptions.Default);
 #endif
-            Object.DestroyImmediate(go);
+            if (!replace)
+            {
+                pb.mesh = null;
+                EditorUtility.SynchronizeWithMeshFilter(pb);
+                Object.DestroyImmediate(go);
+            }
+
+            return meshPath;
+        }
+
+        static string ExportMesh(string path, ProBuilderMesh mesh)
+        {
+            var existing = AssetDatabase.GetAssetPath(mesh.mesh);
+
+            if (!string.IsNullOrEmpty(existing))
+                return existing;
+
+            string directory = Path.GetDirectoryName(path).Replace("\\", "/");
+            string name = Path.GetFileNameWithoutExtension(path);
+            string relativeDirectory = string.Format("Assets{0}", directory.Replace(Application.dataPath, ""));
+
+            mesh.ToMesh();
+            mesh.Refresh();
+            mesh.Optimize();
+            mesh.mesh.name = name;
+
+            string meshPath = AssetDatabase.GenerateUniqueAssetPath(string.Format("{0}/{1}.asset", relativeDirectory, name));
+
+            AssetDatabase.CreateAsset(mesh.mesh, meshPath);
 
             return meshPath;
         }


### PR DESCRIPTION
- splits the `Export Asset` option into two exporters, one for just the `Mesh` and one for `Mesh & Prefab` (latter is current behavior)
- adds an option to replace the original objects with the exported objects

![Screen Shot 2019-03-27 at 3 52 45 PM](https://user-images.githubusercontent.com/1683036/55107841-a5ecd400-50a8-11e9-832f-353c32e481e4.png)

![Screen Shot 2019-03-27 at 3 52 49 PM](https://user-images.githubusercontent.com/1683036/55107844-a9805b00-50a8-11e9-805c-b56234bdecdb.png)

