### PR TITLE
Fix a null ref when maximizing then minizing the toolbar window

### DIFF
--- a/com.unity.probuilder/Editor/EditorCore/ProBuilderEditor.cs
+++ b/com.unity.probuilder/Editor/EditorCore/ProBuilderEditor.cs
@@ -73,38 +73,44 @@ namespace UnityEditor.ProBuilder
         static Pref<float> s_PickingDistance = new Pref<float>("picking.pickingDistance", 128f, SettingsScope.User);
 
         static Pref<bool> s_WindowIsFloating = new Pref<bool>("UnityEngine.ProBuilder.ProBuilderEditor-isUtilityWindow", false, SettingsScope.Project);
+        static Pref<bool> m_BackfaceSelectEnabled = new Pref<bool>("editor.backFaceSelectEnabled", false);
+        static Pref<RectSelectMode> m_DragSelectRectMode = new Pref<RectSelectMode>("editor.dragSelectRectMode", RectSelectMode.Partial);
+        static Pref<SelectionModifierBehavior> m_SelectModifierBehavior = new Pref<SelectionModifierBehavior>("editor.rectSelectModifier", SelectionModifierBehavior.Difference);
+        static Pref<SelectMode> s_SelectMode = new Pref<SelectMode>("editor.selectMode", SelectMode.Object);
 
-        internal Pref<bool> m_BackfaceSelectEnabled = new Pref<bool>("editor.backFaceSelectEnabled", false);
-        internal Pref<RectSelectMode> m_DragSelectRectMode = new Pref<RectSelectMode>("editor.dragSelectRectMode", RectSelectMode.Partial);
-        internal Pref<SelectionModifierBehavior> m_SelectModifierBehavior = new Pref<SelectionModifierBehavior>("editor.rectSelectModifier", SelectionModifierBehavior.Difference);
-        Pref<SelectMode> m_SelectMode = new Pref<SelectMode>("editor.selectMode", SelectMode.Object);
-
-        internal RectSelectMode rectSelectMode
+        internal static RectSelectMode rectSelectMode
         {
             get { return m_DragSelectRectMode.value; }
+
             set
             {
                 if (m_DragSelectRectMode.value == value)
                     return;
+
                 m_DragSelectRectMode.SetValue(value, true);
-                m_ScenePickerPreferences.rectSelectMode = value;
+
+                if (s_Instance != null)
+                    s_Instance.m_ScenePickerPreferences.rectSelectMode = value;
             }
         }
 
-        internal SelectionModifierBehavior selectionModifierBehavior
+        internal static SelectionModifierBehavior selectionModifierBehavior
         {
             get { return m_SelectModifierBehavior.value; }
 
             set
             {
-                if (m_SelectModifierBehavior.value == value)
+                if (s_Instance == null || m_SelectModifierBehavior.value == value)
                     return;
+
                 m_SelectModifierBehavior.SetValue(value, true);
-                m_ScenePickerPreferences.selectionModifierBehavior = value;
+
+                if (s_Instance != null)
+                    s_Instance.m_ScenePickerPreferences.selectionModifierBehavior = value;
             }
         }
 
-        internal bool backfaceSelectionEnabled
+        internal static bool backfaceSelectionEnabled
         {
             get { return m_BackfaceSelectEnabled.value; }
 
@@ -114,7 +120,9 @@ namespace UnityEditor.ProBuilder
                     return;
 
                 m_BackfaceSelectEnabled.SetValue(value, true);
-                m_ScenePickerPreferences.cullMode = value ? CullingMode.None : CullingMode.Back;
+
+                if(s_Instance != null)
+                    s_Instance.m_ScenePickerPreferences.cullMode = value ? CullingMode.None : CullingMode.Back;
             }
         }
 
@@ -176,7 +184,7 @@ namespace UnityEditor.ProBuilder
         [Obsolete]
         internal static EditLevel editLevel
         {
-            get { return s_Instance != null ? EditorUtility.GetEditLevel(instance.m_SelectMode) : EditLevel.Top; }
+            get { return s_Instance != null ? EditorUtility.GetEditLevel(s_SelectMode) : EditLevel.Top; }
         }
 
         /// <summary>
@@ -186,7 +194,7 @@ namespace UnityEditor.ProBuilder
         [Obsolete]
         internal static ComponentMode componentMode
         {
-            get { return s_Instance != null ? EditorUtility.GetComponentMode(instance.m_SelectMode) : ComponentMode.Face; }
+            get { return s_Instance != null ? EditorUtility.GetComponentMode(s_SelectMode) : ComponentMode.Face; }
         }
 
         /// <value>
@@ -197,7 +205,7 @@ namespace UnityEditor.ProBuilder
             get
             {
                 if (s_Instance != null)
-                    return s_Instance.m_SelectMode;
+                    return s_SelectMode;
 
                 // for backwards compatibility reasons `Object` is returned when editor is closed
                 return SelectMode.Object;
@@ -208,12 +216,12 @@ namespace UnityEditor.ProBuilder
                 if (s_Instance == null)
                     return;
 
-                var previous = s_Instance.m_SelectMode.value;
+                var previous = s_SelectMode.value;
 
                 if (previous == value)
                     return;
 
-                s_Instance.m_SelectMode.SetValue(value, true);
+                s_SelectMode.SetValue(value, true);
 
                 if (previous == SelectMode.Edge || previous == SelectMode.Vertex || previous == SelectMode.Face)
                     s_Instance.m_LastComponentMode = previous;
@@ -530,7 +538,7 @@ namespace UnityEditor.ProBuilder
             {
                 return s_Instance == null
                     ? null
-                    : s_Instance.GetToolForSelectMode(s_Instance.m_CurrentTool, s_Instance.m_SelectMode);
+                    : s_Instance.GetToolForSelectMode(s_Instance.m_CurrentTool, s_SelectMode);
             }
         }
 
@@ -644,7 +652,7 @@ namespace UnityEditor.ProBuilder
 
             if (selectMode.IsMeshElementMode() && MeshSelection.selectedVertexCount > 0)
             {
-                var tool = GetToolForSelectMode(m_CurrentTool, m_SelectMode);
+                var tool = GetToolForSelectMode(m_CurrentTool, s_SelectMode);
 
                 if (tool != null)
                     tool.OnSceneGUI(m_CurrentEvent);
@@ -1018,11 +1026,11 @@ namespace UnityEditor.ProBuilder
         /// </summary>
         internal void ToggleSelectionMode()
         {
-            if (m_SelectMode == SelectMode.Vertex)
+            if (s_SelectMode == SelectMode.Vertex)
                 selectMode = SelectMode.Edge;
-            else if (m_SelectMode == SelectMode.Edge)
+            else if (s_SelectMode == SelectMode.Edge)
                 selectMode = SelectMode.Face;
-            else if (m_SelectMode == SelectMode.Face)
+            else if (s_SelectMode == SelectMode.Face)
                 selectMode = SelectMode.Vertex;
         }
 

--- a/com.unity.probuilder/Editor/MenuActions/Interaction/ToggleDragRectMode.cs
+++ b/com.unity.probuilder/Editor/MenuActions/Interaction/ToggleDragRectMode.cs
@@ -7,8 +7,8 @@ namespace UnityEditor.ProBuilder.Actions
     {
         RectSelectMode mode
         {
-            get { return ProBuilderEditor.instance.rectSelectMode; }
-            set { ProBuilderEditor.instance.rectSelectMode = value; }
+            get { return ProBuilderEditor.rectSelectMode; }
+            set { ProBuilderEditor.rectSelectMode = value; }
         }
 
         public override ToolbarGroup group

--- a/com.unity.probuilder/Editor/MenuActions/Interaction/ToggleDragSelectionMode.cs
+++ b/com.unity.probuilder/Editor/MenuActions/Interaction/ToggleDragSelectionMode.cs
@@ -7,8 +7,8 @@ namespace UnityEditor.ProBuilder.Actions
     {
         SelectionModifierBehavior modifier
         {
-            get { return ProBuilderEditor.instance.selectionModifierBehavior; }
-            set { ProBuilderEditor.instance.selectionModifierBehavior = value; }
+            get { return ProBuilderEditor.selectionModifierBehavior; }
+            set { ProBuilderEditor.selectionModifierBehavior = value; }
         }
 
         public override ToolbarGroup group

--- a/com.unity.probuilder/Editor/MenuActions/Interaction/ToggleSelectBackFaces.cs
+++ b/com.unity.probuilder/Editor/MenuActions/Interaction/ToggleSelectBackFaces.cs
@@ -12,7 +12,7 @@ namespace UnityEditor.ProBuilder.Actions
 
         public override Texture2D icon
         {
-            get { return ProBuilderEditor.instance.m_BackfaceSelectEnabled ? m_Icons[1] : m_Icons[0]; }
+            get { return ProBuilderEditor.backfaceSelectionEnabled ? m_Icons[1] : m_Icons[0]; }
         }
 
         public override TooltipContent tooltip
@@ -35,7 +35,7 @@ The default value is <b>On</b>.
 
         public override string menuTitle
         {
-            get { return ProBuilderEditor.instance.m_BackfaceSelectEnabled ? "Select Hidden: On" : "Select Hidden: Off"; }
+            get { return ProBuilderEditor.backfaceSelectionEnabled ? "Select Hidden: On" : "Select Hidden: Off"; }
         }
 
         public override SelectMode validSelectModes
@@ -59,8 +59,8 @@ The default value is <b>On</b>.
 
         public override ActionResult DoAction()
         {
-            ProBuilderEditor.instance.backfaceSelectionEnabled = !ProBuilderEditor.instance.backfaceSelectionEnabled;
-            return new ActionResult(ActionResult.Status.Success, "Set Hidden Element Selection\n" + (!ProBuilderEditor.instance.m_BackfaceSelectEnabled ? "On" : "Off"));
+            ProBuilderEditor.backfaceSelectionEnabled = !ProBuilderEditor.backfaceSelectionEnabled;
+            return new ActionResult(ActionResult.Status.Success, "Set Hidden Element Selection\n" + (!ProBuilderEditor.backfaceSelectionEnabled ? "On" : "Off"));
         }
     }
 }


### PR DESCRIPTION
Fixes fb ticket 1093594

- Makes some properties on ProBuilderEditor static that should have been static in the first place (pref values)