### PR TITLE
Fix shortcut class not serializing

### DIFF
--- a/com.unity.probuilder/Runtime/Core/Shortcut.cs
+++ b/com.unity.probuilder/Runtime/Core/Shortcut.cs
@@ -3,6 +3,7 @@
 #endif
 
 #if !SHORTCUT_MANAGER
+using System;
 using UnityEngine;
 using System.Collections.Generic;
 
@@ -14,6 +15,7 @@ namespace UnityEngine.ProBuilder
 #if SHORTCUT_MANAGER
     [System.Obsolete]
 #endif
+    [Serializable]
     sealed class Shortcut
     {
         public Shortcut(string a, string d, KeyCode k, EventModifiers e)


### PR DESCRIPTION
https://forum.unity.com/threads/probuilder-probuilderpreferences-asset-not-saving.533772/#post-4374817

Fixes an issue with the `Shortcut` class not being saved to project settings.