### PR TITLE
Fix Unlit Solid Color shader flickering in Forward Rendering path

### DIFF
--- a/com.unity.probuilder/Content/Shader/FaceHighlight.shader
+++ b/com.unity.probuilder/Content/Shader/FaceHighlight.shader
@@ -9,12 +9,12 @@ Shader "Hidden/ProBuilder/FaceHighlight"
 
     SubShader
     {
-        Tags { "IgnoreProjector"="True" "RenderType"="Geometry" }
+        Tags { "IgnoreProjector"="True" "Queue"="Transparent" }
         Lighting Off
         ZTest [_HandleZTest]
         ZWrite On
         Cull Off
-        Blend Off
+        Blend SrcAlpha OneMinusSrcAlpha
 
         Pass
         {

--- a/com.unity.probuilder/Content/Shader/FacePicker.shader
+++ b/com.unity.probuilder/Content/Shader/FacePicker.shader
@@ -2,10 +2,6 @@
 
 Shader "Hidden/ProBuilder/FacePicker"
 {
-    Properties {
-        _Tint ("Tint", Color) = (1,1,1,1)
-    }
-
     SubShader
     {
         Tags { "ProBuilderPicker"="Base" }
@@ -49,7 +45,7 @@ Shader "Hidden/ProBuilder/FacePicker"
 
             float4 frag (v2f i) : COLOR
             {
-                return _Tint * i.color;
+                return i.color;
             }
 
             ENDCG

--- a/com.unity.probuilder/Content/Shader/NormalPreview.shader
+++ b/com.unity.probuilder/Content/Shader/NormalPreview.shader
@@ -11,8 +11,6 @@ Shader "Hidden/ProBuilder/NormalPreview"
 
         Pass
         {
-            AlphaTest Greater .25
-
             CGPROGRAM
             #pragma vertex vert
             #pragma fragment frag

--- a/com.unity.probuilder/Content/Shader/ReferenceUnlit.shader
+++ b/com.unity.probuilder/Content/Shader/ReferenceUnlit.shader
@@ -9,7 +9,13 @@ Shader "ProBuilder/Reference Unlit"
 
     SubShader
     {
-        Tags { "Queue"="AlphaTest" "IgnoreProjector"="True" "RenderType"="Transparent" }
+        Tags
+        {
+            "Queue"="Transparent"
+            "IgnoreProjector"="True"
+            "RenderType"="Transparent"
+        }
+        
         Lighting Off
         ZTest LEqual
         Blend SrcAlpha OneMinusSrcAlpha

--- a/com.unity.probuilder/Content/Shader/SmoothingPreview.shader
+++ b/com.unity.probuilder/Content/Shader/SmoothingPreview.shader
@@ -15,8 +15,6 @@ Shader "Hidden/ProBuilder/SmoothingPreview"
 
         Pass
         {
-            AlphaTest Greater .25
-
             CGPROGRAM
             #pragma vertex vert
             #pragma fragment frag

--- a/com.unity.probuilder/Content/Shader/TransparentOverlay.shader
+++ b/com.unity.probuilder/Content/Shader/TransparentOverlay.shader
@@ -7,7 +7,7 @@ Shader "Hidden/ProBuilder/TransparentOverlay"
 
     SubShader
     {
-        Tags { "IgnoreProjector"="True" "RenderType"="Transparent" }
+        Tags { "IgnoreProjector"="True" "RenderType"="Transparent" "Queue"="Transparent" }
         Lighting Off
         ZTest LEqual
         ZWrite On
@@ -16,8 +16,6 @@ Shader "Hidden/ProBuilder/TransparentOverlay"
 
         Pass
         {
-            AlphaTest Greater .25
-
             CGPROGRAM
             #pragma vertex vert
             #pragma fragment frag

--- a/com.unity.probuilder/Content/Shader/UnlitSolidColor.shader
+++ b/com.unity.probuilder/Content/Shader/UnlitSolidColor.shader
@@ -9,7 +9,7 @@ Shader "ProBuilder/Unlit Solid Color"
 
     SubShader
     {
-        Tags { "IgnoreProjector"="True" "RenderType"="Geometry" }
+        Tags { "IgnoreProjector"="True" "Queue"="Transparent" }
         Lighting Off
         ZTest LEqual
         ZWrite On
@@ -18,8 +18,6 @@ Shader "ProBuilder/Unlit Solid Color"
 
         Pass
         {
-            AlphaTest Greater .25
-
             CGPROGRAM
             #pragma vertex vert
             #pragma fragment frag

--- a/com.unity.probuilder/Content/Shader/UnlitVertexColor.shader
+++ b/com.unity.probuilder/Content/Shader/UnlitVertexColor.shader
@@ -4,7 +4,7 @@ Shader "ProBuilder/UnlitVertexColor"
 {
     SubShader
     {
-        Tags { "Queue"="AlphaTest" "IgnoreProjector"="True" "RenderType"="Transparent" }
+        Tags { "Queue"="Transparent" "IgnoreProjector"="True" "RenderType"="Transparent" }
         Lighting Off
         ZTest LEqual
         Blend SrcAlpha OneMinusSrcAlpha
@@ -13,8 +13,6 @@ Shader "ProBuilder/UnlitVertexColor"
 
         Pass
         {
-            AlphaTest Greater .25
-
             CGPROGRAM
             #pragma vertex vert
             #pragma fragment frag

--- a/com.unity.probuilder/Content/Shader/VertexPicker.shader
+++ b/com.unity.probuilder/Content/Shader/VertexPicker.shader
@@ -22,7 +22,6 @@ Shader "Hidden/ProBuilder/VertexPicker"
         Pass
         {
             Name "Vertices"
-            AlphaTest Greater .25
 
 CGPROGRAM
             #pragma vertex vert


### PR DESCRIPTION
Fixes fogbugz ticket 1083088

This fixes some incorrect tags and blend modes in shaders. In most cases the errors are benign, but in some instances result in flickering and incorrectly discarded pixels.