### PR TITLE
Make assemblies auto referenced by default

### DIFF
--- a/com.unity.probuilder/Editor/Unity.ProBuilder.Editor.asmdef
+++ b/com.unity.probuilder/Editor/Unity.ProBuilder.Editor.asmdef
@@ -14,7 +14,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": false,
+    "autoReferenced": true,
     "defineConstraints": [],
     "versionDefines": []
 }

--- a/com.unity.probuilder/Runtime/Unity.ProBuilder.asmdef
+++ b/com.unity.probuilder/Runtime/Unity.ProBuilder.asmdef
@@ -10,6 +10,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": false,
-    "defineConstraints": []
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": []
 }


### PR DESCRIPTION
Removes the requirement that projects wanting to use the ProBuilder API also make use of Assembly Definition files.