### PR TITLE
Allow picking on a Terrain when trying to get the best plane.

### DIFF
--- a/Editor/EditorCore/EditorHandleUtility.cs
+++ b/Editor/EditorCore/EditorHandleUtility.cs
@@ -512,16 +512,13 @@ namespace UnityEditor.ProBuilder
                     ignorePicking.Add(go);
 
                 go = HandleUtility.PickGameObject(mousePosition, false, ignorePicking.ToArray());
-            } while (go != null && go.GetComponent<MeshFilter>() == null);
+            } while (go != null && (go.GetComponent<MeshFilter>() == null && go.GetComponent<Terrain>() == null));
 
             if (go != null)
             {
-                Mesh m = go.GetComponent<MeshFilter>().sharedMesh;
-
-                if (m != null)
+                if (go.GetComponent<MeshFilter>() != null && go.GetComponent<MeshFilter>().sharedMesh != null)
                 {
                     RaycastHit hit;
-
                     if (UnityEngine.ProBuilder.HandleUtility.MeshRaycast(
                         HandleUtility.GUIPointToWorldRay(mousePosition),
                         go,
@@ -530,6 +527,15 @@ namespace UnityEditor.ProBuilder
                         plane = new Plane(
                             go.transform.TransformDirection(hit.normal),
                             go.transform.TransformPoint(hit.point));
+                        return true;
+                    }
+                }
+                else if (go.GetComponent<Terrain>() != null)
+                {
+                    UnityEngine.RaycastHit hit;
+                    if (Physics.Raycast(HandleUtility.GUIPointToWorldRay(mousePosition), out hit))
+                    {
+                        plane = new Plane(hit.normal,hit.point);
                         return true;
                     }
                 }


### PR DESCRIPTION
Modified FindBestPlane to handle picking Terrain.
Note: Tried to create a unit test without success because FindBestPlane relies on UnityEditor.HandleUtility.PickGameObject which cannot be called outside OnGui calls.