### PR TITLE
fix selection info lagging one selection behind

### DIFF
--- a/Editor/EditorCore/ProBuilderEditor.cs
+++ b/Editor/EditorCore/ProBuilderEditor.cs
@@ -1040,8 +1040,8 @@ namespace UnityEditor.ProBuilder
 
             if (selectionChanged)
             {
-                UpdateSceneInfo();
                 MeshSelection.OnComponentSelectionChanged();
+                UpdateSceneInfo();
             }
 
             if (selectionUpdated != null)


### PR DESCRIPTION
The selection info box was not updating the `selected elements` correctly, this fixes it.
![Screen Shot 2019-05-03 at 3 09 37 PM](https://user-images.githubusercontent.com/1683036/57159977-7f137300-6db5-11e9-8d56-63470892d66c.png)
