### PR TITLE
Fix obj export with multiple meshes creating invalid files

### DIFF
--- a/Editor/EditorCore/ObjExporter.cs
+++ b/Editor/EditorCore/ObjExporter.cs
@@ -176,15 +176,18 @@ namespace UnityEditor.ProBuilder
 
                 sb.AppendLine(string.Format("g {0}", model.name));
 
-                var positionIndexMap = AppendPositions(sb, positions, colors, true, options.vertexColors);
+                Dictionary<int, int> positionIndexMap;
+                var positionCount = AppendPositions(sb, positions, colors, true, options.vertexColors, out positionIndexMap);
 
                 sb.AppendLine();
 
-                var textureIndexMap = AppendArrayVec2(sb, textures0, "vt", true);
+                Dictionary<int, int> textureIndexMap;
+                var textureCount = AppendArrayVec2(sb, textures0, "vt", true, out textureIndexMap);
 
                 sb.AppendLine();
 
-                var normalIndexMap = AppendArrayVec3(sb, normals, "vn", true);
+                Dictionary<int, int> normalIndexMap;
+                var normalCount = AppendArrayVec3(sb, normals, "vn", true, out normalIndexMap);
 
                 sb.AppendLine();
 
@@ -192,11 +195,6 @@ namespace UnityEditor.ProBuilder
                 for (int submeshIndex = 0; submeshIndex < subMeshCount; submeshIndex++)
                 {
                     Submesh submesh = model.submeshes[submeshIndex];
-
-                    if (subMeshCount > 1)
-                        sb.AppendLine(string.Format("g {0}_{1}", model.name, submeshIndex));
-                    else
-                        sb.AppendLine(string.Format("g {0}", model.name));
 
                     string materialName = "";
 
@@ -256,9 +254,9 @@ namespace UnityEditor.ProBuilder
                     sb.AppendLine();
                 }
 
-                positionOffset += positionIndexMap.Count;
-                normalOffset += normalIndexMap.Count;
-                textureOffset += textureIndexMap.Count;
+                positionOffset += positionCount;
+                normalOffset += normalCount;
+                textureOffset += textureCount;
             }
 
             return sb.ToString();
@@ -389,7 +387,7 @@ namespace UnityEditor.ProBuilder
             {
                 if (ReferenceEquals(null, obj))
                     return false;
-                    
+
                 return obj is PositionColorKey && Equals(obj);
             }
 
@@ -403,12 +401,12 @@ namespace UnityEditor.ProBuilder
         }
 
         // AppendPositions separately from AppendArrayVec3 to support the non-spec color extension that some DCCs can read
-        static Dictionary<int, int> AppendPositions(StringBuilder sb, Vector3[] positions, Color[] colors, bool mergeCoincident, bool includeColors)
+        static int AppendPositions(StringBuilder sb, Vector3[] positions, Color[] colors, bool mergeCoincident, bool includeColors, out Dictionary<int, int> coincidentIndexMap)
         {
             var writeColors = includeColors && colors != null && colors.Length == positions.Length;
 
             Dictionary<PositionColorKey, int> common = new Dictionary<PositionColorKey, int>();
-            Dictionary<int, int> map = new Dictionary<int, int>();
+            coincidentIndexMap = new Dictionary<int, int>();
 
             int index = 0;
 
@@ -429,16 +427,16 @@ namespace UnityEditor.ProBuilder
                     }
                     else
                     {
-                        map.Add(i, vertexIndex);
+                        coincidentIndexMap.Add(i, vertexIndex);
                         continue;
                     }
                 }
                 else
                 {
-                    vertexIndex = i;
+                    vertexIndex = index++;
                 }
 
-                map.Add(i, vertexIndex);
+                coincidentIndexMap.Add(i, vertexIndex);
 
                 if (writeColors)
                 {
@@ -459,16 +457,17 @@ namespace UnityEditor.ProBuilder
                 }
             }
 
-            return map;
+            return index;
         }
 
-        static Dictionary<int, int> AppendArrayVec2(StringBuilder sb, Vector2[] array, string prefix, bool mergeCoincident)
+        static int AppendArrayVec2(StringBuilder sb, Vector2[] array, string prefix, bool mergeCoincident, out Dictionary<int, int> coincidentIndexMap)
         {
+            coincidentIndexMap = new Dictionary<int, int>();
+
             if (array == null)
-                return null;
+                return 0;
 
             Dictionary<IntVec2, int> common = new Dictionary<IntVec2, int>();
-            Dictionary<int, int> map = new Dictionary<int, int>();
             int index = 0;
 
             for (int i = 0, c = array.Length; i < c; i++)
@@ -486,16 +485,16 @@ namespace UnityEditor.ProBuilder
                     }
                     else
                     {
-                        map.Add(i, vertexIndex);
+                        coincidentIndexMap.Add(i, vertexIndex);
                         continue;
                     }
                 }
                 else
                 {
-                    vertexIndex = i;
+                    vertexIndex = index++;
                 }
 
-                map.Add(i, vertexIndex);
+                coincidentIndexMap.Add(i, vertexIndex);
 
                 sb.AppendLine(string.Format(CultureInfo.InvariantCulture, "{0} {1} {2}",
                     prefix,
@@ -503,19 +502,23 @@ namespace UnityEditor.ProBuilder
                     texture.y));
             }
 
-            return map;
+            return index;
         }
 
-        static Dictionary<int, int> AppendArrayVec3(StringBuilder sb, Vector3[] array, string prefix, bool mergeCoincident)
+        static int AppendArrayVec3(StringBuilder sb, Vector3[] array, string prefix, bool mergeCoincident, out Dictionary<int, int> coincidentIndexMap)
         {
+            coincidentIndexMap = new Dictionary<int, int>();
+
+            if (array == null)
+                return 0;
+
             Dictionary<IntVec3, int> common = new Dictionary<IntVec3, int>();
-            Dictionary<int, int> map = new Dictionary<int, int>();
             int index = 0;
 
             for (int i = 0, c = array.Length; i < c; i++)
             {
-                var value = array[i];
-                var key = new IntVec3(value);
+                var vec = array[i];
+                var key = new IntVec3(vec);
                 int vertexIndex;
 
                 if (mergeCoincident)
@@ -527,25 +530,26 @@ namespace UnityEditor.ProBuilder
                     }
                     else
                     {
-                        map.Add(i, vertexIndex);
+                        coincidentIndexMap.Add(i, vertexIndex);
                         continue;
                     }
                 }
                 else
                 {
-                    vertexIndex = i;
+                    vertexIndex = index++;
                 }
 
-                map.Add(i, vertexIndex);
+                coincidentIndexMap.Add(i, vertexIndex);
 
                 sb.AppendLine(string.Format(CultureInfo.InvariantCulture, "{0} {1} {2} {3}",
                     prefix,
-                    value.x,
-                    value.y,
-                    value.z));
+                    vec.x,
+                    vec.y,
+                    vec.z));
             }
 
-            return map;
+            return index;
         }
+
     }
 }

--- a/Editor/MenuActions/Export/ExportObj.cs
+++ b/Editor/MenuActions/Export/ExportObj.cs
@@ -45,9 +45,7 @@ namespace UnityEditor.ProBuilder.Actions
             return new ActionResult(ActionResult.Status.Success, "Export OBJ");
         }
 
-        /**
-         *  Prompt user for a save file location and export meshes as Obj.
-         */
+        // Prompt user for a save file location and export meshes as Obj.
         public static string ExportWithFileDialog(IEnumerable<ProBuilderMesh> meshes, bool asGroup = true, bool allowQuads = true, ObjOptions options = null)
         {
             if (meshes == null || !meshes.Any())
@@ -84,7 +82,7 @@ namespace UnityEditor.ProBuilder.Actions
             return res;
         }
 
-        static string DoExport(string path, IEnumerable<Model> models, ObjOptions options)
+        internal static string DoExport(string path, IEnumerable<Model> models, ObjOptions options)
         {
             string name = Path.GetFileNameWithoutExtension(path);
             string directory = Path.GetDirectoryName(path);

--- a/Tests/.tests.json
+++ b/Tests/.tests.json
@@ -1,6 +1,5 @@
 {
 	"createSeparatePackage":true,
 	"name":"com.unity.probuilder.tests",
-	"displayName":"ProBuilder Tests",
-	"disableProjectUpdate": true
+	"displayName":"ProBuilder Tests"
 }

--- a/Tests/.tests.json
+++ b/Tests/.tests.json
@@ -1,5 +1,6 @@
 {
 	"createSeparatePackage":true,
 	"name":"com.unity.probuilder.tests",
-	"displayName":"ProBuilder Tests"
+	"displayName":"ProBuilder Tests",
+	"disableProjectUpdate": true
 }

--- a/Tests/Editor/Export/ExportObj.cs
+++ b/Tests/Editor/Export/ExportObj.cs
@@ -41,7 +41,7 @@ namespace UnityEngine.ProBuilder.EditorTests.Export
         }
 
         [Test]
-        public void ExportSingleCube_CreatesUnityReadableMeshFile()
+        public static void ExportSingleCube_CreatesUnityReadableMeshFile()
         {
             var cube = ShapeGenerator.CreateShape(ShapeType.Cube);
 
@@ -59,7 +59,7 @@ namespace UnityEngine.ProBuilder.EditorTests.Export
             Assume.That(string.IsNullOrEmpty(obj), Is.False);
             Assume.That(string.IsNullOrEmpty(mtl), Is.False);
 
-            string exportedPath = TestUtility.temporarySavedAssetsDirectory + "/SingleCube.obj";
+            string exportedPath = TestUtility.temporarySavedAssetsDirectory + "SingleCube.obj";
 
             File.WriteAllText(exportedPath, obj);
             AssetDatabase.ImportAsset(exportedPath);
@@ -76,7 +76,7 @@ namespace UnityEngine.ProBuilder.EditorTests.Export
         {
             var cube1 = new Model("Cube A", ShapeGenerator.CreateShape(ShapeType.Cube));
             var cube2 = new Model("Cube B", ShapeGenerator.CreateShape(ShapeType.Cube));
-            string exportedPath = TestUtility.temporarySavedAssetsDirectory + "/ObjGroup.obj";
+            string exportedPath = TestUtility.temporarySavedAssetsDirectory + "ObjGroup.obj";
 
             UnityEditor.ProBuilder.Actions.ExportObj.DoExport(exportedPath, new Model[] { cube1, cube2 }, new ObjOptions()
             {

--- a/Tests/Editor/Export/ExportStl.cs
+++ b/Tests/Editor/Export/ExportStl.cs
@@ -15,7 +15,7 @@ namespace UnityEngine.ProBuilder.EditorTests.Export
         {
             var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
             var current = Thread.CurrentThread.CurrentCulture;
-            string path = TestUtility.TemporarySavedAssetsDirectory + "/ExportStl.stl";
+            string path = TestUtility.temporarySavedAssetsDirectory + "/ExportStl.stl";
 
             try
             {

--- a/Tests/Framework/TestUtility.cs
+++ b/Tests/Framework/TestUtility.cs
@@ -17,23 +17,27 @@ namespace UnityEngine.ProBuilder.Tests.Framework
 {
     abstract class TemporaryAssetTest
     {
-        [SetUp]
-        public void Setup()
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
         {
-            if (!Directory.Exists(TestUtility.TemporarySavedAssetsDirectory))
-                Directory.CreateDirectory(TestUtility.TemporarySavedAssetsDirectory);
+            if (!Directory.Exists(TestUtility.temporarySavedAssetsDirectory))
+                Directory.CreateDirectory(TestUtility.temporarySavedAssetsDirectory);
         }
 
-        [TearDown]
-        public void Cleanup()
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
         {
-            if (Directory.Exists(TestUtility.TemporarySavedAssetsDirectory))
-                Directory.Delete(TestUtility.TemporarySavedAssetsDirectory, true);
+            if (Directory.Exists(TestUtility.temporarySavedAssetsDirectory))
+                Directory.Delete(TestUtility.temporarySavedAssetsDirectory, true);
 
-            var meta = TestUtility.TemporarySavedAssetsDirectory;
+            var meta = TestUtility.temporarySavedAssetsDirectory;
+
             if (meta.EndsWith("/") || meta.EndsWith("\\"))
                 meta = meta.Substring(0, meta.Length - 1);
+
             File.Delete(meta + ".meta");
+
+            AssetDatabase.Refresh();
         }
     }
 
@@ -67,7 +71,7 @@ namespace UnityEngine.ProBuilder.Tests.Framework
             }
         }
 
-        public static string TemporarySavedAssetsDirectory
+        public static string temporarySavedAssetsDirectory
         {
             get { return k_TempDirectory; }
         }
@@ -468,20 +472,20 @@ namespace UnityEngine.ProBuilder.Tests.Framework
 
         public static string SaveAssetTemporary<T>(UObject asset) where T : UObject
         {
-            if (!Directory.Exists(TemporarySavedAssetsDirectory))
-                Directory.CreateDirectory(TemporarySavedAssetsDirectory);
+            if (!Directory.Exists(temporarySavedAssetsDirectory))
+                Directory.CreateDirectory(temporarySavedAssetsDirectory);
 
-            string path = AssetDatabase.GenerateUniqueAssetPath(string.Format("{0}/{1}.asset", TemporarySavedAssetsDirectory, asset.name));
+            string path = AssetDatabase.GenerateUniqueAssetPath(string.Format("{0}/{1}.asset", temporarySavedAssetsDirectory, asset.name));
             AssetDatabase.CreateAsset(asset, path);
             return path;
         }
 
         public static void ClearTempAssets()
         {
-            if (!Directory.Exists(TemporarySavedAssetsDirectory))
+            if (!Directory.Exists(temporarySavedAssetsDirectory))
                 return;
 
-            Directory.Delete(TemporarySavedAssetsDirectory);
+            Directory.Delete(temporarySavedAssetsDirectory);
         }
 
         public static Material redMaterial

--- a/Tests/Runtime/MeshOps/ProBuilderizeTests.cs
+++ b/Tests/Runtime/MeshOps/ProBuilderizeTests.cs
@@ -32,7 +32,7 @@ namespace UnityEngine.ProBuilder.RuntimeTests.MeshOperations
         [Test]
         public static void ImportMeshWithQuads_MatchesWindingOrder()
         {
-            var srcPath = TestUtility.TemporarySavedAssetsDirectory + "maya-cube-quads.fbx";
+            var srcPath = TestUtility.temporarySavedAssetsDirectory + "maya-cube-quads.fbx";
 
             // do this song and dance because AssetDatabase.LoadAssetAtPath doesn't seem to work with models in the
             // Package directories
@@ -96,7 +96,7 @@ namespace UnityEngine.ProBuilder.RuntimeTests.MeshOperations
 
             TestUtility.AssertMeshesAreEqual(TestUtility.GetAssetTemplate<Mesh>("imported-cube-quads"), result.mesh);
             UObject.DestroyImmediate(result);
-            AssetDatabase.DeleteAsset(TestUtility.TemporarySavedAssetsDirectory + "maya-cube-quads.fbx");
+            AssetDatabase.DeleteAsset(TestUtility.temporarySavedAssetsDirectory + "maya-cube-quads.fbx");
         }
     }
 }


### PR DESCRIPTION
WB-1492

Fixes an issue where the obj exporter would incorrectly offset additional mesh groups by the original vertex count instead of the coincident merged counts.

Adds new unit tests for obj export.