### PR TITLE
Collect coincident vertices when doing split vertices action

### DIFF
--- a/Editor/EditorCore/MeshSelection.cs
+++ b/Editor/EditorCore/MeshSelection.cs
@@ -77,6 +77,7 @@ namespace UnityEditor.ProBuilder
         internal static int selectedEdgeCountObjectMax { get; private set; }
         internal static int selectedVertexCountObjectMax { get; private set; }
         internal static int selectedSharedVertexCountObjectMax { get; private set; }
+        internal static int selectedCoincidentVertexCountMax { get; private set; }
 
         // Faces that need to be refreshed when moving or modifying the actual selection
         internal static Dictionary<ProBuilderMesh, List<Face>> selectedFacesInEditZone
@@ -175,6 +176,7 @@ namespace UnityEditor.ProBuilder
             selectedFaceCountObjectMax = 0;
             selectedVertexCountObjectMax = 0;
             selectedSharedVertexCountObjectMax = 0;
+            selectedCoincidentVertexCountMax = 0;
             selectedEdgeCountObjectMax = 0;
 
             RecalculateSelectedComponentCounts();
@@ -218,6 +220,7 @@ namespace UnityEditor.ProBuilder
 
                 selectedVertexCountObjectMax = System.Math.Max(selectedVertexCountObjectMax, mesh.selectedIndexesInternal.Length);
                 selectedSharedVertexCountObjectMax = System.Math.Max(selectedSharedVertexCountObjectMax, mesh.selectedSharedVerticesCount);
+                selectedCoincidentVertexCountMax = System.Math.Max(selectedCoincidentVertexCountMax, mesh.selectedCoincidentVertexCount);
                 selectedFaceCountObjectMax = System.Math.Max(selectedFaceCountObjectMax, mesh.selectedFaceCount);
                 selectedEdgeCountObjectMax = System.Math.Max(selectedEdgeCountObjectMax, mesh.selectedEdgeCount);
             }

--- a/Editor/MenuActions/Geometry/SplitVertices.cs
+++ b/Editor/MenuActions/Geometry/SplitVertices.cs
@@ -50,63 +50,17 @@ namespace UnityEditor.ProBuilder.Actions
 
             foreach (ProBuilderMesh mesh in MeshSelection.topInternal)
             {
-                // loose verts to split
-                List<int> tris = new List<int>(mesh.selectedIndexesInternal);
-
-                if (mesh.selectedFacesInternal.Length > 0)
-                {
-                    int[] sharedVertexHandles = new int[mesh.selectedIndexesInternal.Length];
-
-                    // Get shared index index for each vert in selection
-                    for (int i = 0; i < mesh.selectedIndexesInternal.Length; i++)
-                        sharedVertexHandles[i] = mesh.GetSharedVertexHandle(mesh.selectedIndexesInternal[i]);
-
-                    // cycle through selected faces and remove the tris that compose full faces.
-                    foreach (Face face in mesh.selectedFacesInternal)
-                    {
-                        List<int> faceSharedIndexes = new List<int>();
-
-                        for (int j = 0; j < face.distinctIndexesInternal.Length; j++)
-                            faceSharedIndexes.Add(mesh.GetSharedVertexHandle(face.distinctIndexesInternal[j]));
-
-                        List<int> usedTris = new List<int>();
-                        for (int i = 0; i < sharedVertexHandles.Length; i++)
-                            if (faceSharedIndexes.Contains(sharedVertexHandles[i]))
-                                usedTris.Add(mesh.selectedIndexesInternal[i]);
-
-                        // This face *is* composed of selected tris.  Remove these tris from the loose index list
-                        foreach (int i in usedTris)
-                            if (tris.Contains(i))
-                                tris.Remove(i);
-                    }
-                }
-
-                // Now split the faces, and any loose vertices
-                mesh.DetachFaces(mesh.selectedFacesInternal);
-
-                splitCount += mesh.selectedIndexesInternal.Length;
-                mesh.SplitVertices(mesh.selectedIndexesInternal);
-
-                // Reattach detached face vertices (if any are to be had)
-                if (mesh.selectedFacesInternal.Length > 0)
-                    mesh.WeldVertices(mesh.selectedFacesInternal.SelectMany(x => x.indexes), Mathf.Epsilon);
-
-                // And set the selected triangles to the newly split
-                List<int> newTriSelection = new List<int>(mesh.selectedFacesInternal.SelectMany(x => x.indexes));
-                newTriSelection.AddRange(tris);
-                mesh.SetSelectedVertices(newTriSelection.ToArray());
-
-                mesh.ToMesh();
-                mesh.Refresh();
-                mesh.Optimize();
+                var coincident = mesh.selectedCoincidentVertices;
+                splitCount += coincident.Count();
+                mesh.SplitVertices(coincident);
             }
 
             ProBuilderEditor.Refresh();
 
             if (splitCount > 0)
                 return new ActionResult(ActionResult.Status.Success, "Split " + splitCount + (splitCount > 1 ? " Vertices" : " Vertex"));
-            else
-                return new ActionResult(ActionResult.Status.Failure, "Split Vertices\nInsuffient Vertices Selected");
+                
+            return new ActionResult(ActionResult.Status.Failure, "Split Vertices\nInsuffient Vertices Selected");
         }
     }
 }

--- a/Editor/MenuActions/Geometry/SplitVertices.cs
+++ b/Editor/MenuActions/Geometry/SplitVertices.cs
@@ -37,7 +37,15 @@ namespace UnityEditor.ProBuilder.Actions
 
         public override bool enabled
         {
-            get { return base.enabled && MeshSelection.selectedVertexCount > 0; }
+            get
+            {
+                // This isn't completely accurate, because to check that each selected vertex has coincident vertices is
+                // unnecessarily expensive for the purposes of this property. So here we handle the most common case,
+                // where a single vertex is selected with no additional coincident vertices.
+                return base.enabled
+                    && MeshSelection.selectedVertexCountObjectMax > 0
+                    && !(MeshSelection.selectedVertexCountObjectMax == 1 && MeshSelection.selectedCoincidentVertexCountMax == 1);
+            }
         }
 
         public override ActionResult DoAction()
@@ -51,7 +59,7 @@ namespace UnityEditor.ProBuilder.Actions
             foreach (ProBuilderMesh mesh in MeshSelection.topInternal)
             {
                 var coincident = mesh.selectedCoincidentVertices;
-                splitCount += coincident.Count();
+                splitCount += mesh.selectedSharedVerticesCount;
                 mesh.SplitVertices(coincident);
             }
 
@@ -59,7 +67,7 @@ namespace UnityEditor.ProBuilder.Actions
 
             if (splitCount > 0)
                 return new ActionResult(ActionResult.Status.Success, "Split " + splitCount + (splitCount > 1 ? " Vertices" : " Vertex"));
-                
+
             return new ActionResult(ActionResult.Status.Failure, "Split Vertices\nInsuffient Vertices Selected");
         }
     }

--- a/Runtime/Core/ProBuilderMeshSelection.cs
+++ b/Runtime/Core/ProBuilderMeshSelection.cs
@@ -20,6 +20,7 @@ namespace UnityEngine.ProBuilder
 
         bool m_SelectedCacheDirty;
         int m_SelectedSharedVerticesCount = 0;
+        int m_SelectedCoincidentVertexCount = 0;
         HashSet<int> m_SelectedSharedVertices = new HashSet<int>();
         List<int> m_SelectedCoincidentVertices = new List<int>();
 
@@ -65,6 +66,15 @@ namespace UnityEngine.ProBuilder
             }
         }
 
+        internal int selectedCoincidentVertexCount
+        {
+            get
+            {
+                CacheSelection();
+                return m_SelectedCoincidentVertexCount;
+            }
+        }
+
         internal IEnumerable<int> selectedSharedVertices
         {
             get
@@ -95,14 +105,18 @@ namespace UnityEngine.ProBuilder
                 m_SelectedCoincidentVertices.Clear();
                 var lookup = sharedVertexLookup;
                 m_SelectedSharedVerticesCount = 0;
+                m_SelectedCoincidentVertexCount = 0;
 
                 foreach (var i in m_SelectedVertices)
                 {
                     if (m_SelectedSharedVertices.Add(lookup[i]))
                     {
-                        m_SelectedSharedVerticesCount++;
+                        var coincident = sharedVerticesInternal[lookup[i]];
 
-                        foreach (var n in sharedVerticesInternal[lookup[i]])
+                        m_SelectedSharedVerticesCount++;
+                        m_SelectedCoincidentVertexCount += coincident.Count;
+
+                        foreach (var n in coincident)
                             m_SelectedCoincidentVertices.Add(n);
                     }
                 }


### PR DESCRIPTION
Fixes WB-1359

Split Vertex action now operates on all coincident vertices in the selection, not just the selected indices.