### PR TITLE
Add an offset elements menu action

### DIFF
--- a/Editor/EditorCore/EditorToolbarLoader.cs
+++ b/Editor/EditorCore/EditorToolbarLoader.cs
@@ -85,6 +85,7 @@ namespace UnityEditor.ProBuilder
 
                 // All
                 new Actions.SetPivotToSelection(),
+                new Actions.MoveElements(),
 
                 // Faces (All)
                 new Actions.DeleteFaces(),

--- a/Editor/EditorCore/EditorToolbarMenuItems.cs
+++ b/Editor/EditorCore/EditorToolbarMenuItems.cs
@@ -415,6 +415,21 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
+		[MenuItem(k_MenuPrefix + "Geometry/Move Elements ", true)]
+		static bool MenuVerify_MoveElements()
+		{
+			var instance = EditorToolbarLoader.GetInstance<MoveElements>();
+			return instance != null && instance.enabled;
+		}
+
+		[MenuItem(k_MenuPrefix + "Geometry/Move Elements", false, PreferenceKeys.menuGeometry + 3)]
+		static void MenuPerform_MoveElements()
+		{
+			var instance = EditorToolbarLoader.GetInstance<MoveElements>();
+			if(instance != null && instance.enabled)
+				EditorUtility.ShowNotification(instance.DoAction().notification);
+		}
+
 		[MenuItem(k_MenuPrefix + "Geometry/Set Pivot To Selection ", true)]
 		static bool MenuVerify_SetPivotToSelection()
 		{

--- a/Editor/MenuActions/Geometry/MoveElements.cs
+++ b/Editor/MenuActions/Geometry/MoveElements.cs
@@ -1,0 +1,101 @@
+using UnityEngine;
+using UnityEngine.ProBuilder;
+
+namespace UnityEditor.ProBuilder.Actions
+{
+    sealed class MoveElements : MenuAction
+    {
+        enum CoordinateSpace
+        {
+            Local,
+            World
+        }
+
+        static readonly TooltipContent s_TooltipFace = new TooltipContent ( "Move Faces", "Move the selected elements by a set amount." );
+        static readonly TooltipContent s_TooltipEdge = new TooltipContent ( "Move Edges", "Move the selected elements by a set amount." );
+        static readonly TooltipContent s_TooltipVert = new TooltipContent ( "Move Vertices", "Move the selected elements by a set amount." );
+
+        static Pref<Vector3> s_MoveDistance = new Pref<Vector3>("MoveElements.s_MoveDistance", Vector3.up);
+        static Pref<CoordinateSpace> s_CoordinateSpace = new Pref<CoordinateSpace>("MoveElements.s_CoordinateSpace", CoordinateSpace.World);
+
+        public override ToolbarGroup group { get { return ToolbarGroup.Geometry; } }
+        public override Texture2D icon { get { return IconUtility.GetIcon(null, IconSkin.Pro); } }
+
+        public override TooltipContent tooltip
+        {
+            get
+            {
+                if(ProBuilderEditor.selectMode == SelectMode.Face)
+                    return s_TooltipFace;
+                if(ProBuilderEditor.selectMode == SelectMode.Edge)
+                    return s_TooltipEdge;
+                return s_TooltipVert;
+            }
+        }
+
+        public override SelectMode validSelectModes
+        {
+            get { return SelectMode.Face | SelectMode.Edge | SelectMode.Vertex; }
+        }
+
+        public override bool enabled
+        {
+            get { return base.enabled && MeshSelection.selectedVertexCount > 0; }
+        }
+
+        protected override MenuActionState optionsMenuState
+        {
+            get { return MenuActionState.VisibleAndEnabled; }
+        }
+
+        protected override void OnSettingsGUI()
+        {
+            GUILayout.Label("Move Settings", EditorStyles.boldLabel);
+
+            var dist = s_MoveDistance.value;
+            var coord = s_CoordinateSpace.value;
+
+            EditorGUI.BeginChangeCheck();
+
+            coord = (CoordinateSpace) EditorGUILayout.EnumPopup("Space", coord);
+            dist = EditorGUILayout.Vector3Field("Move", dist);
+
+            if (EditorGUI.EndChangeCheck())
+            {
+                s_MoveDistance.SetValue(dist, true);
+                s_CoordinateSpace.SetValue(coord);
+            }
+
+            GUILayout.FlexibleSpace();
+
+            if (GUILayout.Button("Move Selection"))
+                EditorUtility.ShowNotification(DoAction().notification);
+        }
+
+        public override ActionResult DoAction()
+        {
+            if (MeshSelection.selectedObjectCount < 1)
+                return ActionResult.NoSelection;
+
+            UndoUtility.RecordSelection("Move Elements(s)");
+
+            foreach (var mesh in MeshSelection.topInternal)
+            {
+                var positions = mesh.positionsInternal;
+
+                var offset = s_CoordinateSpace.value == CoordinateSpace.World
+                    ? mesh.transform.InverseTransformDirection(s_MoveDistance.value)
+                    : s_MoveDistance.value;
+
+                foreach (var i in mesh.selectedCoincidentVertices)
+                    positions[i] += offset;
+
+                mesh.Rebuild();
+                mesh.Optimize();
+                ProBuilderEditor.Refresh();
+            }
+
+            return new ActionResult(ActionResult.Status.Success, "Move " + MeshSelection.selectedVertexCount + " Element(s)");
+        }
+    }
+}

--- a/Editor/MenuActions/Geometry/MoveElements.cs.meta
+++ b/Editor/MenuActions/Geometry/MoveElements.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1c69d9710acab499bbb7b9fc17853f33
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Replacing the "Offset" button and vector field in the Inspector, a new toolbar action "Move Elements" is introduced.

It has two fields to set, `Space: [ World, Local ]` and `Move: XYZ`.

![image](https://user-images.githubusercontent.com/1683036/57950667-e8b37700-78b5-11e9-98f4-3b2d44f55147.png)
