### PR TITLE
Fix boolean preview not updating if shapes

### DIFF
--- a/Editor/EditorCore/BooleanEditor.cs
+++ b/Editor/EditorCore/BooleanEditor.cs
@@ -131,8 +131,16 @@ namespace UnityEditor.ProBuilder
             ProBuilderMesh lpb = m_LeftGameObject != null ? m_LeftGameObject.GetComponent<ProBuilderMesh>() : null;
             ProBuilderMesh rpb = m_RightGameObject != null ? m_RightGameObject.GetComponent<ProBuilderMesh>() : null;
 
+            EditorGUI.BeginChangeCheck();
+
             lpb = (ProBuilderMesh)EditorGUILayout.ObjectField(lpb, typeof(ProBuilderMesh), true);
             rpb = (ProBuilderMesh)EditorGUILayout.ObjectField(rpb, typeof(ProBuilderMesh), true);
+
+            if (EditorGUI.EndChangeCheck())
+            {
+                DestroyImmediate(m_LeftPreviewEditor);
+                DestroyImmediate(m_RightPreviewEditor);
+            }
 
             m_LeftGameObject = lpb != null ? lpb.gameObject : null;
             m_RightGameObject = rpb != null ? rpb.gameObject : null;


### PR DESCRIPTION
When the donor objects are modified from the ObjectField instead of drag and drop into the preview wells.

Fixes Fogbugz case 1062439