### PR TITLE
Rename Snapping class to avoid conflicts with UnityEngine.Snapping

### DIFF
--- a/Editor/EditorCore/EditorUtility.cs
+++ b/Editor/EditorCore/EditorUtility.cs
@@ -328,9 +328,9 @@ namespace UnityEditor.ProBuilder
         internal static void SetPivotLocationAndSnap(ProBuilderMesh mesh)
         {
             if (ProGridsInterface.SnapEnabled())
-                mesh.transform.position = Snapping.SnapValue(mesh.transform.position, ProGridsInterface.SnapValue());
+                mesh.transform.position = ProGridsSnapping.SnapValue(mesh.transform.position, ProGridsInterface.SnapValue());
             else if (s_SnapNewShapesToGrid)
-                mesh.transform.position = Snapping.SnapValue(mesh.transform.position, new Vector3(
+                mesh.transform.position = ProGridsSnapping.SnapValue(mesh.transform.position, new Vector3(
                             EditorPrefs.GetFloat("MoveSnapX"),
                             EditorPrefs.GetFloat("MoveSnapY"),
                             EditorPrefs.GetFloat("MoveSnapZ")));

--- a/Editor/EditorCore/PolyShapeEditor.cs
+++ b/Editor/EditorCore/PolyShapeEditor.cs
@@ -541,7 +541,7 @@ namespace UnityEditor.ProBuilder
                     {
                         UndoUtility.RecordObject(polygon, "Move Polygon Shape Point");
 
-                        Vector3 snapMask = Snapping.GetSnappingMaskBasedOnNormalVector(m_Plane.normal);
+                        Vector3 snapMask = ProGridsSnapping.GetSnappingMaskBasedOnNormalVector(m_Plane.normal);
                         polygon.m_Points[ii] = ProGridsInterface.ProGridsSnap(trs.InverseTransformPoint(point), snapMask);
                         OnBeginVertexMovement();
                         RebuildPolyShapeMesh(false);

--- a/Editor/EditorCore/PositionMoveTool.cs
+++ b/Editor/EditorCore/PositionMoveTool.cs
@@ -88,7 +88,7 @@ namespace UnityEditor.ProBuilder
 
                         if (m_ActiveAxesWorld.active == 1)
                         {
-                            m_HandlePosition = Snapping.SnapValueOnRay(
+                            m_HandlePosition = ProGridsSnapping.SnapValueOnRay(
                                 new Ray(handlePositionOrigin, delta),
                                 delta.magnitude,
                                 progridsSnapValue,
@@ -96,12 +96,12 @@ namespace UnityEditor.ProBuilder
                         }
                         else
                         {
-                            m_HandlePosition = Snapping.SnapValue(m_HandlePosition, progridsSnapValue);
+                            m_HandlePosition = ProGridsSnapping.SnapValue(m_HandlePosition, progridsSnapValue);
                         }
                     }
                     else
                     {
-                        m_HandlePosition = Snapping.SnapValue(m_HandlePosition, progridsSnapValue);
+                        m_HandlePosition = ProGridsSnapping.SnapValue(m_HandlePosition, progridsSnapValue);
                     }
 
                     delta = m_HandlePosition - handlePositionOrigin;
@@ -160,7 +160,7 @@ namespace UnityEditor.ProBuilder
                             {
                                 var wp = postApplyMatrix.MultiplyPoint3x4(preApplyMatrix.MultiplyPoint3x4(origins[index]));
 
-                                var snap = Snapping.SnapValueOnRay(
+                                var snap = ProGridsSnapping.SnapValueOnRay(
                                     new Ray(wp, m_RawHandleDelta),
                                     translationMagnitude,
                                     progridsSnapValue,
@@ -171,7 +171,7 @@ namespace UnityEditor.ProBuilder
                             else
                             {
                                 var wp = postApplyMatrix.MultiplyPoint3x4(translation + preApplyMatrix.MultiplyPoint3x4(origins[index]));
-                                var snap = Snapping.SnapValue(wp, Vector3.one * progridsSnapValue);
+                                var snap = ProGridsSnapping.SnapValue(wp, Vector3.one * progridsSnapValue);
                                 positions[index] = worldToLocal.MultiplyPoint3x4(snap);
                             }
                         }

--- a/Editor/EditorCore/ProBuilderEditor.cs
+++ b/Editor/EditorCore/ProBuilderEditor.cs
@@ -1181,7 +1181,7 @@ namespace UnityEditor.ProBuilder
                     continue;
 
                 var indexes = mesh.GetCoincidentVertices(mesh.selectedIndexesInternal);
-                Snapping.SnapVertices(mesh, indexes, Vector3.one * snapVal);
+                ProGridsSnapping.SnapVertices(mesh, indexes, Vector3.one * snapVal);
 
                 mesh.ToMesh();
                 mesh.Refresh();

--- a/Editor/EditorCore/ProGridsInterface.cs
+++ b/Editor/EditorCore/ProGridsInterface.cs
@@ -216,7 +216,7 @@ namespace UnityEditor.ProBuilder
                 pivot = s_GetPivotDelegate();
 
                 // earlier version of progrids return a non-snapped pivot point
-                pivot = Snapping.SnapValue(pivot, SnapValue());
+                pivot = ProGridsSnapping.SnapValue(pivot, SnapValue());
                 return true;
             }
 
@@ -360,7 +360,7 @@ namespace UnityEditor.ProBuilder
                 return point;
 
             if (SnapEnabled())
-                return Snapping.SnapValue(point, ProGridsInterface.SnapValue());
+                return ProGridsSnapping.SnapValue(point, ProGridsInterface.SnapValue());
 
             return point;
         }
@@ -378,7 +378,7 @@ namespace UnityEditor.ProBuilder
             if (ProGridsInterface.SnapEnabled())
             {
                 float snap = ProGridsInterface.SnapValue();
-                return Snapping.SnapValue(point, snap);
+                return ProGridsSnapping.SnapValue(point, snap);
             }
 
             return point;
@@ -398,7 +398,7 @@ namespace UnityEditor.ProBuilder
             if (ProGridsInterface.SnapEnabled())
             {
                 float snap = ProGridsInterface.SnapValue();
-                return Snapping.SnapValue(point, mask * snap);
+                return ProGridsSnapping.SnapValue(point, mask * snap);
             }
 
             return point;

--- a/Editor/EditorCore/TextureMoveTool.cs
+++ b/Editor/EditorCore/TextureMoveTool.cs
@@ -76,13 +76,13 @@ namespace UnityEditor.ProBuilder
 
                 if (relativeSnapEnabled)
                 {
-                    m_Position.x = Snapping.SnapValue(m_Position.x, relativeSnapX);
-                    m_Position.y = Snapping.SnapValue(m_Position.y, relativeSnapY);
+                    m_Position.x = ProGridsSnapping.SnapValue(m_Position.x, relativeSnapX);
+                    m_Position.y = ProGridsSnapping.SnapValue(m_Position.y, relativeSnapY);
                 }
                 else if (progridsSnapEnabled)
                 {
-                    m_Position.x = Snapping.SnapValue(m_Position.x, progridsSnapValue);
-                    m_Position.y = Snapping.SnapValue(m_Position.y, progridsSnapValue);
+                    m_Position.x = ProGridsSnapping.SnapValue(m_Position.x, progridsSnapValue);
+                    m_Position.y = ProGridsSnapping.SnapValue(m_Position.y, progridsSnapValue);
                 }
 
                 // invert `y` because to users it's confusing that "up" in UV space visually moves the texture down

--- a/Editor/EditorCore/TextureRotateTool.cs
+++ b/Editor/EditorCore/TextureRotateTool.cs
@@ -37,9 +37,9 @@ namespace UnityEditor.ProBuilder
                     BeginEdit("Rotate Textures");
 
                 if (relativeSnapEnabled)
-                    m_Rotation = Snapping.SnapValue(m_Rotation, relativeSnapX);
+                    m_Rotation = ProGridsSnapping.SnapValue(m_Rotation, relativeSnapX);
                 else if (progridsSnapEnabled)
-                    m_Rotation = Snapping.SnapValue(m_Rotation, progridsSnapValue);
+                    m_Rotation = ProGridsSnapping.SnapValue(m_Rotation, progridsSnapValue);
 
                 foreach (var mesh in elementSelection)
                 {

--- a/Editor/EditorCore/UVEditor.cs
+++ b/Editor/EditorCore/UVEditor.cs
@@ -1323,7 +1323,7 @@ namespace UnityEditor.ProBuilder
 
                 if (ControlKey)
                 {
-                    handlePosition = Snapping.SnapValue(t_handlePosition, (Vector3) new Vector3Mask((handlePosition - t_handlePosition), Math.handleEpsilon) * s_GridSnapIncrement);
+                    handlePosition = ProGridsSnapping.SnapValue(t_handlePosition, (Vector3) new Vector3Mask((handlePosition - t_handlePosition), Math.handleEpsilon) * s_GridSnapIncrement);
                 }
                 else
                 {
@@ -1385,7 +1385,7 @@ namespace UnityEditor.ProBuilder
                 Vector2 newUVPosition = t_handlePosition;
 
                 if (ControlKey)
-                    newUVPosition = Snapping.SnapValue(newUVPosition, new Vector3Mask((handlePosition - t_handlePosition), Math.handleEpsilon) * s_GridSnapIncrement);
+                    newUVPosition = ProGridsSnapping.SnapValue(newUVPosition, new Vector3Mask((handlePosition - t_handlePosition), Math.handleEpsilon) * s_GridSnapIncrement);
 
                 for (int n = 0; n < selection.Length; n++)
                 {
@@ -1475,7 +1475,7 @@ namespace UnityEditor.ProBuilder
                 handlePosition.y += delta.y;
 
                 if (ControlKey)
-                    handlePosition = Snapping.SnapValue(handlePosition, new Vector3Mask((handlePosition - handlePosition), Math.handleEpsilon) * s_GridSnapIncrement);
+                    handlePosition = ProGridsSnapping.SnapValue(handlePosition, new Vector3Mask((handlePosition - handlePosition), Math.handleEpsilon) * s_GridSnapIncrement);
 
                 for (int n = 0; n < selection.Length; n++)
                 {
@@ -1507,7 +1507,7 @@ namespace UnityEditor.ProBuilder
                 }
 
                 if (ControlKey)
-                    uvRotation = Snapping.SnapValue(uvRotation, 15f);
+                    uvRotation = ProGridsSnapping.SnapValue(uvRotation, 15f);
 
                 // Do rotation around the handle pivot in manual mode
                 if (mode == UVMode.Mixed || mode == UVMode.Manual)
@@ -1555,7 +1555,7 @@ namespace UnityEditor.ProBuilder
             if (rotation != uvRotation)
             {
                 if (ControlKey)
-                    rotation = Snapping.SnapValue(rotation, 15f);
+                    rotation = ProGridsSnapping.SnapValue(rotation, 15f);
 
                 float delta = rotation - uvRotation;
                 uvRotation = rotation;
@@ -1614,7 +1614,7 @@ namespace UnityEditor.ProBuilder
             uvScale = EditorHandleUtility.ScaleHandle2d(2, UVToGUIPoint(handlePosition), uvScale, 128);
 
             if (ControlKey)
-                uvScale = Snapping.SnapValue(uvScale, s_GridSnapIncrement);
+                uvScale = ProGridsSnapping.SnapValue(uvScale, s_GridSnapIncrement);
 
             if (Math.Approx(uvScale.x, 0f, Mathf.Epsilon))
                 uvScale.x = .0001f;
@@ -1684,7 +1684,7 @@ namespace UnityEditor.ProBuilder
             previousScale.y = 1f / previousScale.y;
 
             if (ControlKey)
-                textureScale = Snapping.SnapValue(textureScale, s_GridSnapIncrement);
+                textureScale = ProGridsSnapping.SnapValue(textureScale, s_GridSnapIncrement);
 
             if (!modifyingUVs)
             {
@@ -3376,7 +3376,7 @@ namespace UnityEditor.ProBuilder
                 UVEditing.ApplyUVs(pb, uv, channel);
             }
         }
-       
+
         #endregion
         #region Screenshot Rendering
 

--- a/Runtime/Core/ProGridsSnapping.cs
+++ b/Runtime/Core/ProGridsSnapping.cs
@@ -6,7 +6,7 @@ namespace UnityEngine.ProBuilder
     /// <summary>
     /// Snapping functions and ProGrids compatibility.
     /// </summary>
-    static class Snapping
+    static class ProGridsSnapping
     {
         const float k_MaxRaySnapDistance = Mathf.Infinity;
 

--- a/Runtime/Core/ProGridsSnapping.cs.meta
+++ b/Runtime/Core/ProGridsSnapping.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 365042cb237a7419da99d2c0a1e9cf83
+guid: 62487c41697f04905ab94655526d1b8d
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Runtime/Core/VertexPositioning.cs
+++ b/Runtime/Core/VertexPositioning.cs
@@ -87,7 +87,7 @@ namespace UnityEngine.ProBuilder
                 for (i = 0; i < s_CoincidentVertices.Count; i++)
                 {
                     var v = l2w.MultiplyPoint3x4(verts[s_CoincidentVertices[i]] + localOffset);
-                    verts[s_CoincidentVertices[i]] = w2l.MultiplyPoint3x4(Snapping.SnapValue(v, ((Vector3)mask) * snapValue));
+                    verts[s_CoincidentVertices[i]] = w2l.MultiplyPoint3x4(ProGridsSnapping.SnapValue(v, ((Vector3)mask) * snapValue));
                 }
             }
             else


### PR DESCRIPTION
Unity 2019.3 introduces a new `Snapping` class in the `UnityEngine` namespace. This make `UnityEngine.ProBuilder.Snapping` ambiguous.