### PR TITLE
Fixed null reference when pressing G without the probuilder toolbar

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -3,6 +3,7 @@ test_editors:
   - version: 2018.4
   - version: 2019.1
   - version: 2019.2
+  - version: 2019.3
   - version: trunk
 test_platforms:
   - name: win

--- a/Editor/EditorCore/ProBuilderEditor.cs
+++ b/Editor/EditorCore/ProBuilderEditor.cs
@@ -261,7 +261,8 @@ namespace UnityEditor.ProBuilder
 
         internal static void ResetToLastSelectMode()
         {
-            selectMode = s_Instance.m_LastComponentMode;
+            if (s_Instance != null)
+                selectMode = s_Instance.m_LastComponentMode;
         }
 
         static class SceneStyles


### PR DESCRIPTION
Issue: https://issuetracker.unity3d.com/issues/probuilder-editor-throws-a-nullreferenceexception-when-scene-view-is-focused-and-button-g-is-pressed