### PR TITLE
Fix vertices collapsing to a center point when "Snap on All Axes" is enabled

### DIFF
--- a/Editor/EditorCore/PositionMoveTool.cs
+++ b/Editor/EditorCore/PositionMoveTool.cs
@@ -87,25 +87,18 @@ namespace UnityEditor.ProBuilder
                 else if (progridsSnapEnabled)
                 {
                     // Handle is only snapped on all axes in the case where `snapAxisConstraint == false && snapAsGroup == true`
-                    if (snapAxisConstraint || !m_SnapAsGroup)
+                    if (m_SnapAsGroup && snapAxisConstraint && m_ActiveAxesWorld.active == 1)// || !m_SnapAsGroup)
                     {
                         m_ActiveAxesModel |= new Vector3Mask(handleRotationOriginInverse * delta, k_CardinalAxisError);
                         m_ActiveAxesWorld = new Vector3Mask(handleRotation * m_ActiveAxesModel);
 
-                        if (m_ActiveAxesWorld.active == 1)
-                        {
-                            m_HandlePosition = ProGridsSnapping.SnapValueOnRay(
-                                new Ray(handlePositionOrigin, delta),
-                                delta.magnitude,
-                                progridsSnapValue,
-                                m_ActiveAxesWorld);
-                        }
-                        else
-                        {
-                            m_HandlePosition = ProGridsSnapping.SnapValue(m_HandlePosition, progridsSnapValue);
-                        }
+                        m_HandlePosition = ProGridsSnapping.SnapValueOnRay(
+                            new Ray(handlePositionOrigin, delta),
+                            delta.magnitude,
+                            progridsSnapValue,
+                            m_ActiveAxesWorld);
                     }
-                    else
+                    else if(m_SnapAsGroup)
                     {
                         m_HandlePosition = ProGridsSnapping.SnapValue(m_HandlePosition, progridsSnapValue);
                     }
@@ -125,7 +118,6 @@ namespace UnityEditor.ProBuilder
                     }
                 }
 #endif
-
                 ApplyTranslation(handleRotationOriginInverse * delta);
             }
 
@@ -170,7 +162,8 @@ namespace UnityEditor.ProBuilder
                                     new Ray(wp, m_RawHandleDelta),
                                     translationMagnitude,
                                     progridsSnapValue,
-                                    m_ActiveAxesWorld);
+                                    m_ActiveAxesWorld,
+                                    false);
 
                                 positions[index] = worldToLocal.MultiplyPoint3x4(snap);
                             }

--- a/Editor/EditorCore/StaticEditorMeshHandles.cs
+++ b/Editor/EditorCore/StaticEditorMeshHandles.cs
@@ -5,6 +5,7 @@ using UObject = UnityEngine.Object;
 using UnityEngine.ProBuilder;
 using System.Reflection;
 using UnityEngine.Rendering;
+using Math = UnityEngine.ProBuilder.Math;
 
 namespace UnityEditor.ProBuilder
 {
@@ -54,6 +55,17 @@ namespace UnityEditor.ProBuilder
             Handles.DotHandleCap(0, p + matrix.MultiplyVector(direction) * d, Quaternion.identity, s * dotCapSize, e);
             Handles.DrawLine(p, p + matrix.MultiplyVector(direction) * d);
             Handles.color = Color.white;
+        }
+
+        internal static void DrawPlane(Vector3 normal, Vector3 origin, float size)
+        {
+            if (Event.current.type == EventType.Repaint)
+            {
+                var rot = Quaternion.LookRotation(normal, Vector3.up);
+                Handles.RectangleHandleCap(0, origin, rot, size, EventType.Repaint);
+                Handles.DotHandleCap(0, origin, rot, size * .05f, EventType.Repaint);
+                Handles.Slider(origin, normal);
+            }
         }
 
         internal struct PointDrawingScope : IDisposable

--- a/Editor/EditorCore/VertexManipulationTool.cs
+++ b/Editor/EditorCore/VertexManipulationTool.cs
@@ -147,6 +147,7 @@ namespace UnityEditor.ProBuilder
         bool m_IsEditing;
 
         float m_ProgridsSnapValue = .25f;
+        // Snap only on active axis when true
         bool m_SnapAxisConstraint = true;
         bool m_ProgridsSnapEnabled;
         static bool s_Initialized;
@@ -192,6 +193,9 @@ namespace UnityEditor.ProBuilder
             get { return m_ProgridsSnapValue; }
         }
 
+        /// <summary>
+        /// Snap only on the active axes when true.
+        /// </summary>
         protected bool snapAxisConstraint
         {
             get { return m_SnapAxisConstraint; }

--- a/Editor/EditorCore/VertexManipulationTool.cs
+++ b/Editor/EditorCore/VertexManipulationTool.cs
@@ -1,15 +1,10 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using UnityEngine;
 using UnityEngine.ProBuilder;
 using UnityEngine.ProBuilder.MeshOperations;
 using UnityEditor.SettingsManagement;
-
-#if !UNITY_2018_3_OR_NEWER
-using UnityEditor.SettingsManagement;
-#endif
 
 #if DEBUG_HANDLES
 using UnityEngine.Rendering;


### PR DESCRIPTION
Fix case where the Translate handle would snap on all axes, and then snap vertex positions on all axes. This results in incorrect vertex positions, commonly ending with all vertices smooshed into a single point.

https://unity3d.atlassian.net/browse/WB-1211