### PR TITLE
Fixed issue with background color applying to entire probuilder menu action

### DIFF
--- a/Editor/EditorCore/MenuAction.cs
+++ b/Editor/EditorCore/MenuAction.cs
@@ -326,11 +326,12 @@ namespace UnityEditor.ProBuilder
             }
             else
             {
-                GUI.backgroundColor = ToolbarGroupUtility.GetColor(group);
-
                 // in text mode always use the vertical layout.
                 isHorizontal = false;
                 GUILayout.BeginHorizontal(MenuActionStyles.rowStyleVertical, layoutOptions);
+
+                GUI.backgroundColor = ToolbarGroupUtility.GetColor(group);
+
                 if (GUILayout.Button(menuTitle, MenuActionStyles.buttonStyleVertical))
                 {
                     ActionResult res = DoAction();


### PR DESCRIPTION
With a recent change in trunk, it's now not needed to have a texture in a style to use GUI.backgroundColor. I've reordered the GUI.backgroundColor call so it doesn't affect our GUI.BeginHorizontal rect.

What it looked like:
![image](https://user-images.githubusercontent.com/44209648/61731142-d4be4280-ad48-11e9-87d5-3ae573a88dcc.png)
