### PR TITLE
Ci/update yamato configs

### DIFF
--- a/.yamato/promotion.yml
+++ b/.yamato/promotion.yml
@@ -1,0 +1,76 @@
+test_editors:
+  - version: 2019.1
+test_platforms:
+  - name: win
+    type: Unity::VM
+    image: package-ci/win10:stable
+    flavor: b1.large
+---
+{% for editor in test_editors %}
+{% for platform in test_platforms %}
+promotion_test_{{ platform.name }}_{{ editor.version }}:
+  name : Promotion Test {{ editor.version }} on {{ platform.name }}
+  agent:
+    type: {{ platform.type }}
+    image: {{ platform.image }}
+    flavor: {{ platform.flavor}}
+  variables:
+    UPMCI_PROMOTION: 1
+  commands:
+    - npm install upm-ci-utils@stable -g --registry https://api.bintray.com/npm/unity/unity-npm
+    - upm-ci package test --unity-version {{ editor.version }}
+  artifacts:
+    logs:
+      paths:
+        - "upm-ci~/test-results/**/*"
+  dependencies:
+    - .yamato/upm-ci.yml#pack
+{% endfor %}
+{% endfor %}
+
+promotion_test_trigger:
+  name: Promotion Tests Trigger
+  agent:
+    type: Unity::VM
+    image: package-ci/win10:stable
+    flavor: b1.large
+  artifacts:
+    logs:
+      paths:
+        - "upm-ci~/test-results/**/*"
+    packages:
+      paths:
+        - "upm-ci~/packages/**/*"
+  dependencies:
+{% for editor in test_editors %}
+{% for platform in test_platforms %}
+    - .yamato/promotion.yml#promotion_test_{{platform.name}}_{{editor.version}}
+{% endfor %}
+{% endfor %}
+
+promote:
+  name: Promote to Production
+  agent:
+    type: Unity::VM
+    image: package-ci/win10:stable
+    flavor: b1.large
+  variables:
+    UPMCI_PROMOTION: 1
+  commands:
+    - npm install upm-ci-utils@stable -g --registry https://api.bintray.com/npm/unity/unity-npm
+    - upm-ci package promote
+  triggers:
+    tags:
+      only:
+        - /^(r|R)elease-\d+\.\d+\.\d+(-preview(\.\d+)?)?$/
+  artifacts:
+    artifacts:
+      paths:
+        - "upm-ci~/packages/*.tgz"
+  dependencies:
+    - .yamato/upm-ci.yml#pack
+{% for editor in test_editors %}
+{% for platform in test_platforms %}
+    - .yamato/promotion.yml#promotion_test_{{ platform.name }}_{{ editor.version }}
+{% endfor %}
+{% endfor %}

--- a/.yamato/promotion.yml
+++ b/.yamato/promotion.yml
@@ -1,5 +1,10 @@
 test_editors:
+  - version: 2018.3
+  - version: 2018.4
   - version: 2019.1
+  - version: 2019.2
+  - version: 2019.3
+  - version: trunk
 test_platforms:
   - name: win
     type: Unity::VM

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -9,7 +9,7 @@ test_platforms:
   - name: win
     type: Unity::VM
     image: package-ci/win10:stable
-    flavor: m1.large
+    flavor: b1.large
   - name: mac
     type: Unity::VM::osx
     image: buildfarm/mac:stable
@@ -20,17 +20,17 @@ pack:
   agent:
     type: Unity::VM
     image: package-ci/win10:stable
-    flavor: m1.large
+    flavor: b1.large
   commands:
-    - npm install upm-ci-utils -g --registry https://api.bintray.com/npm/unity/unity-npm
+    - npm install upm-ci-utils@stable -g --registry https://api.bintray.com/npm/unity/unity-npm
     - upm-ci package pack
   artifacts:
     packages:
       paths:
-        - "upm-ci~/packages/**/*"
+        - "upm-ci~/**/*"
 
-  {% for editor in test_editors %}
-  {% for platform in test_platforms %}
+{% for editor in test_editors %}
+{% for platform in test_platforms %}
 test_{{ platform.name }}_{{ editor.version }}:
   name : Test {{ editor.version }} on {{ platform.name }}
   agent:
@@ -38,23 +38,23 @@ test_{{ platform.name }}_{{ editor.version }}:
     image: {{ platform.image }}
     flavor: {{ platform.flavor}}
   commands:
-    - npm install upm-ci-utils -g --registry https://api.bintray.com/npm/unity/unity-npm
+    - npm install upm-ci-utils@stable -g --registry https://api.bintray.com/npm/unity/unity-npm
     - upm-ci package test --unity-version {{ editor.version }}
   artifacts:
-    logs.zip:
+    logs:
       paths:
         - "upm-ci~/test-results/**/*"
   dependencies:
     - .yamato/upm-ci.yml#pack
-  {% endfor %}
-  {% endfor %}
+{% endfor %}
+{% endfor %}
 
 test_trigger:
   name: Tests Trigger
   agent:
     type: Unity::VM
     image: package-ci/win10:stable
-    flavor: m1.large
+    flavor: b1.large
   commands:
     - dir
   triggers:
@@ -77,20 +77,20 @@ test_trigger:
     {% endfor %}
 
 publish:
-  name: Publish
+  name: Publish to Internal Registry
   agent:
     type: Unity::VM
     image: package-ci/win10:stable
-    flavor: m1.large
+    flavor: b1.large
   commands:
-    - npm install upm-ci-utils -g --registry https://api.bintray.com/npm/unity/unity-npm
+    - npm install upm-ci-utils@stable -g --registry https://api.bintray.com/npm/unity/unity-npm
     - upm-ci package publish
   triggers:
     tags:
       only:
-        - /^(v|V)\d+\.\d+\.\d+(-preview(\.\d+)?)?$/
+        - /^(r|R)(c|C)-\d+\.\d+\.\d+(-preview(\.\d+)?)?$/
   artifacts:
-    artifacts.zip:
+    artifacts:
       paths:
         - "upm-ci~/packages/*.tgz"
   dependencies:


### PR DESCRIPTION
**Goal of this PR:**
Update upm-ci.yml with last revision from Package Starter Kit. Major change is the flavor of the Win image used for the tests.

What this update also brings:
- Promotion.yml: allows automatic promotion of packages if  a tag of this format is created (Release-x.x.x(-preview.x). This means there is no need to ask Release Management anymore.
- Pushing to staging needs tags to be under this format : rc-x.x.x(-preview.x).
