### PR TITLE
Wb 1396 merge objects retain properties

### DIFF
--- a/Editor/MenuActions/Object/MergeObjects.cs
+++ b/Editor/MenuActions/Object/MergeObjects.cs
@@ -34,7 +34,7 @@ namespace UnityEditor.ProBuilder.Actions
 
         public override bool enabled
         {
-            get { return base.enabled && MeshSelection.selectedObjectCount > 1; }
+            get { return base.enabled && MeshSelection.selectedObjectCount > 1 && MeshSelection.activeMesh != null; }
         }
 
         public override ActionResult DoAction()

--- a/Editor/MenuActions/Object/MergeObjects.cs
+++ b/Editor/MenuActions/Object/MergeObjects.cs
@@ -45,7 +45,7 @@ namespace UnityEditor.ProBuilder.Actions
             var selected = MeshSelection.top.ToArray();
             ProBuilderMesh currentMesh = MeshSelection.activeMesh;
             UndoUtility.RecordObject(currentMesh, "Merge Objects");
-            List<ProBuilderMesh> res = CombineMeshes.Combine(currentMesh, MeshSelection.topInternal);
+            List<ProBuilderMesh> res = CombineMeshes.Combine(MeshSelection.topInternal, currentMesh);
 
             if (res != null)
             {

--- a/Runtime/Core/TransformUtility.cs
+++ b/Runtime/Core/TransformUtility.cs
@@ -81,5 +81,43 @@ namespace UnityEngine.ProBuilder
 
             return v;
         }
+
+
+        /// <summary>
+        /// Transform a vertex fromw world space to local space.
+        /// </summary>
+        /// <param name="transform">The transform to apply.</param>
+        /// <param name="vertex">A world space vertex.</param>
+        /// <returns>A new vertex in transform coordinate space.</returns>
+        public static Vertex InverseTransformVertex(this Transform transform, Vertex vertex)
+        {
+            var v = new Vertex();
+
+            if (vertex.HasArrays(MeshArrays.Position))
+                v.position = transform.InverseTransformPoint(vertex.position);
+
+            if (vertex.HasArrays(MeshArrays.Color))
+                v.color = vertex.color;
+
+            if (vertex.HasArrays(MeshArrays.Normal))
+                v.normal = transform.InverseTransformDirection(vertex.normal);
+
+            if (vertex.HasArrays(MeshArrays.Tangent))
+                v.tangent = transform.InverseTransformDirection(vertex.tangent);
+
+            if (vertex.HasArrays(MeshArrays.Texture0))
+                v.uv0 = vertex.uv0;
+
+            if (vertex.HasArrays(MeshArrays.Texture1))
+                v.uv2 = vertex.uv2;
+
+            if (vertex.HasArrays(MeshArrays.Texture2))
+                v.uv3 = vertex.uv3;
+
+            if (vertex.HasArrays(MeshArrays.Texture3))
+                v.uv4 = vertex.uv4;
+
+            return v;
+        }
     }
 }

--- a/Runtime/MeshOperations/CombineMeshes.cs
+++ b/Runtime/MeshOperations/CombineMeshes.cs
@@ -186,6 +186,8 @@ namespace UnityEngine.ProBuilder.MeshOperations
                     var worldVertex = transform.TransformVertex(meshVertices[i]);
                     if (targetTransform != null)
                         vertices.Add(targetTransform.InverseTransformVertex(worldVertex));
+                    else
+                        vertices.Add(worldVertex);
                 }
 
 

--- a/Runtime/MeshOperations/CombineMeshes.cs
+++ b/Runtime/MeshOperations/CombineMeshes.cs
@@ -26,10 +26,10 @@ namespace UnityEngine.ProBuilder.MeshOperations
 
         /// <summary>
         /// Merge a collection of <see cref="ProBuilderMesh"/> objects to as few meshes as possible. It will re-use the meshTarget object as the first
-        /// destination for the first 65535 vertices. If the sum of vertices is above 65535 it will generate new meshes unless there is a single mesh left in which
-        /// case it will append it to the return list.
+        /// destination for the first <see cref="ProBuilderMesh.maxVertexCount"/> -1 vertices. If the sum of vertices is above <see cref="ProBuilderMesh.maxVertexCount"/> - 1
+        /// it will generate new meshes unless there is a single mesh left in which case it will append it to the return list.
         /// </summary>
-        /// <param name="meshes">A collection of meshes to be merged.</param>
+        /// <param name="meshes">A collection of meshes to be merged. Note: it is expected that meshes includes meshTarget.</param>
         /// <param name="meshTarget">A mesh which will be used as the starting point for merging and which will be kept as reference/target.</param>
         /// <returns>
         /// A list of merged meshes. In most cases this will be a single mesh corresponding to meshTarget. However it can be multiple in cases

--- a/Runtime/MeshOperations/CombineMeshes.cs
+++ b/Runtime/MeshOperations/CombineMeshes.cs
@@ -136,56 +136,16 @@ namespace UnityEngine.ProBuilder.MeshOperations
             if (!meshes.Any() || meshes.Count() < 2 )
                 return null;
 
-            var vertices = new List<Vertex>();
-            var faces = new List<Face>();
-            var autoUvFaces = new List<Face>();
-            var sharedVertices = new List<SharedVertex>();
-            var sharedTextures = new List<SharedVertex>();
-            int offset = 0;
-            var materialMap = new List<Material>();
+            if (!meshes.Contains(meshTarget))
+                return null;
+
+            var vertices = new List<Vertex>(meshTarget.GetVertices());
+            var faces = new List<Face>(meshTarget.facesInternal);            
+            var sharedVertices = new List<SharedVertex>(meshTarget.sharedVertices);
+            var sharedTextures = new List<SharedVertex>(meshTarget.sharedTextures);
+            int offset = meshTarget.vertexCount;
+            var materialMap = new List<Material>(meshTarget.renderer.sharedMaterials);
             var targetTransform = meshTarget.transform;
-
-
-            //First pass put the meshTarget as first vertices
-            foreach (var mesh in meshes)
-            {
-                if (mesh == meshTarget)
-                {
-                    var meshVertexCount = mesh.vertexCount;
-                    var meshVertices = mesh.GetVertices();
-                    var meshFaces = mesh.facesInternal;
-                    var meshSharedVertices = mesh.sharedVertices;
-                    var meshSharedTextures = mesh.sharedTextures;
-                    var materials = mesh.renderer.sharedMaterials;
-                    var materialCount = materials.Length;
-
-                    for (int i = 0; i < meshVertexCount; i++)
-                        vertices.Add(meshVertices[i]);
-
-                    foreach (var face in meshFaces)
-                    {
-                        faces.Add(face);
-                    }
-
-                    foreach (var sv in meshSharedVertices)
-                    {                   
-                        sharedVertices.Add(sv);
-                    }
-
-                    foreach (var st in meshSharedTextures)
-                    {
-                        sharedTextures.Add(st);
-                    }
-
-                    foreach (var mat in materials)
-                    {
-                        materialMap.Add(mat);
-                    }
-
-                    offset += meshVertexCount;
-                    break;
-                }
-            }
 
             var firstMeshContributors = new List<ProBuilderMesh>();
             var remainderMeshContributors = new List<ProBuilderMesh>();
@@ -207,6 +167,7 @@ namespace UnityEngine.ProBuilder.MeshOperations
                 }
             }
 
+            var autoUvFaces = new List<Face>();
             foreach (var mesh in firstMeshContributors)
             {
                 if (mesh == meshTarget)
@@ -286,6 +247,7 @@ namespace UnityEngine.ProBuilder.MeshOperations
             meshTarget.renderer.sharedMaterials = materialMap.ToArray();
             meshTarget.ToMesh();
             meshTarget.Refresh();
+            UVEditing.SetAutoAndAlignUnwrapParamsToUVs(meshTarget, autoUvFaces);
 
             var returnedMesh = new List<ProBuilderMesh>() { meshTarget };
             if (remainderMeshContributors.Count > 1)

--- a/Tests/Runtime/MeshOps/CombineMeshesTests.cs
+++ b/Tests/Runtime/MeshOps/CombineMeshesTests.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UObject = UnityEngine.Object;
+using NUnit.Framework;
+using UnityEngine.ProBuilder.Tests.Framework;
+using UnityEngine.ProBuilder.MeshOperations;
+
+
+namespace UnityEngine.ProBuilder.RuntimeTests.MeshOperations
+{
+    class CombineMeshesTests
+    {
+        ProBuilderMesh m_mesh1;
+        ProBuilderMesh m_mesh2;
+        ProBuilderMesh m_mesh3;
+        Vector3 m_meshScale;
+
+        [SetUp]
+        public void SetUp()
+        {
+            m_mesh1 = ShapeGenerator.CreateShape(ShapeType.Cube);
+            m_mesh2 = ShapeGenerator.CreateShape(ShapeType.Cone);
+            m_mesh3 = ShapeGenerator.CreateShape(ShapeType.Cylinder);
+            m_mesh1.gameObject.AddComponent<BoxCollider>();
+            m_meshScale = new Vector3(2.0f, 2.0f, 2.0f);
+            m_mesh1.gameObject.transform.localScale = m_meshScale;;
+        }
+
+        [TearDown]
+        public void Cleanup()
+        {
+            UObject.DestroyImmediate(m_mesh1);
+            UObject.DestroyImmediate(m_mesh2);
+            UObject.DestroyImmediate(m_mesh3);
+        }
+
+        [Test]
+        public void CombineMeshes_RetainObjectProperties()
+        {
+            var meshes = new List<ProBuilderMesh>();
+            meshes.Add(m_mesh1);
+            meshes.Add(m_mesh2);
+            meshes.Add(m_mesh3);
+
+            var newMeshes = CombineMeshes.Combine(m_mesh1, meshes);
+            Assert.That(newMeshes.Count, Is.EqualTo(1));
+            Assert.That(newMeshes[0], Is.EqualTo(m_mesh1));
+            Assert.That(newMeshes[0].gameObject.GetComponent<BoxCollider>, !Is.EqualTo(null));
+            Assert.That(newMeshes[0].transform.localScale, Is.EqualTo(m_meshScale));
+        }
+    }
+}

--- a/Tests/Runtime/MeshOps/CombineMeshesTests.cs
+++ b/Tests/Runtime/MeshOps/CombineMeshesTests.cs
@@ -43,7 +43,7 @@ namespace UnityEngine.ProBuilder.RuntimeTests.MeshOperations
             meshes.Add(m_mesh2);
             meshes.Add(m_mesh3);
 
-            var newMeshes = CombineMeshes.Combine(m_mesh1, meshes);
+            var newMeshes = CombineMeshes.Combine(meshes, m_mesh1);
             Assert.That(newMeshes.Count, Is.EqualTo(1));
             Assert.That(newMeshes[0], Is.EqualTo(m_mesh1));
             Assert.That(newMeshes[0].gameObject.GetComponent<BoxCollider>, !Is.EqualTo(null));

--- a/Tests/Runtime/MeshOps/CombineMeshesTests.cs.meta
+++ b/Tests/Runtime/MeshOps/CombineMeshesTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 683d28450003bb8489b8cc1d3b4caa33
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Basically in the past all objects were merged to new ProBuilderMesh. Right now we re-use the active mesh as the first target to re-use.

This address WB-1372 and WB-1373 as well.