### PR TITLE
Wb 1192 freeze transform

### DIFF
--- a/Editor/MenuActions/Object/FreezeTransform.cs
+++ b/Editor/MenuActions/Object/FreezeTransform.cs
@@ -27,7 +27,7 @@ namespace UnityEditor.ProBuilder.Actions
         static readonly TooltipContent s_Tooltip = new TooltipContent
             (
                 "Freeze Transform",
-                @"Set the pivot point to world coordinates (0,0,0) and clear all Transform values while keeping the mesh in place."
+                @"Set the pivot point to world/parent coordinates (0,0,0) and clear Transform values while keeping the mesh in place."
             );
 
         public override bool enabled
@@ -44,17 +44,20 @@ namespace UnityEditor.ProBuilder.Actions
 
             var selection = MeshSelection.topInternal;
             Vector3[][] positions = new Vector3[selection.Count][];
+            
 
             for (int i = 0, c = selection.Count; i < c; i++)
-                positions[i] = selection[i].VerticesInWorldSpace();
+                positions[i] = selection[i].VerticesInParentSpace();
 
+            //Note need to sort from children to parent.
             for (int i = 0, c = selection.Count; i < c; i++)
-            {
+            {                
                 ProBuilderMesh pb = selection[i];
+                bool inParentSpace = (pb.transform.parent != null);
 
-                pb.transform.position = Vector3.zero;
-                pb.transform.rotation = Quaternion.identity;
-                pb.transform.localScale = Vector3.one;
+                pb.transform.position = (inParentSpace  ? pb.transform.parent.position : Vector3.zero);
+                pb.transform.rotation = (inParentSpace ? pb.transform.parent.rotation : Quaternion.identity);
+                pb.transform.localScale = (inParentSpace ? pb.transform.parent.localScale : Vector3.one);
 
                 foreach (Face face in pb.facesInternal)
                     face.manualUV = true;

--- a/Editor/MenuActions/Object/FreezeTransform.cs
+++ b/Editor/MenuActions/Object/FreezeTransform.cs
@@ -27,7 +27,7 @@ namespace UnityEditor.ProBuilder.Actions
         static readonly TooltipContent s_Tooltip = new TooltipContent
             (
                 "Freeze Transform",
-                @"Set the pivot point to world/parent coordinates (0,0,0) and clear Transform values while keeping the mesh in place."
+                @"Set the pivot point to world/parent coordinates (0,0,0) and clear all Transform values while keeping the mesh in place."
             );
 
         public override bool enabled

--- a/Editor/MenuActions/Object/FreezeTransform.cs
+++ b/Editor/MenuActions/Object/FreezeTransform.cs
@@ -43,17 +43,14 @@ namespace UnityEditor.ProBuilder.Actions
             UndoUtility.RecordMeshAndTransformSelection("Freeze Transforms");
 
             var selection = MeshSelection.topInternal;
-            Vector3[][] positions = new Vector3[selection.Count][];
-            
+                
 
-            for (int i = 0, c = selection.Count; i < c; i++)
-                positions[i] = selection[i].VerticesInParentSpace();
-
-            //Note need to sort from children to parent.
             for (int i = 0, c = selection.Count; i < c; i++)
             {                
                 ProBuilderMesh pb = selection[i];
+                TransformUtility.UnparentChildren(pb.transform);
                 bool inParentSpace = (pb.transform.parent != null);
+                Vector3[] positions = pb.VerticesInParentSpace();
 
                 pb.transform.position = (inParentSpace  ? pb.transform.parent.position : Vector3.zero);
                 pb.transform.rotation = (inParentSpace ? pb.transform.parent.rotation : Quaternion.identity);
@@ -62,11 +59,12 @@ namespace UnityEditor.ProBuilder.Actions
                 foreach (Face face in pb.facesInternal)
                     face.manualUV = true;
 
-                pb.positions = positions[i];
+                pb.positions = positions;
 
                 pb.ToMesh();
                 pb.Refresh();
                 pb.Optimize();
+                TransformUtility.ReparentChildren(pb.transform);
             }
 
             ProBuilderEditor.Refresh();

--- a/Runtime/Core/VertexPositioning.cs
+++ b/Runtime/Core/VertexPositioning.cs
@@ -34,6 +34,31 @@ namespace UnityEngine.ProBuilder
         }
 
         /// <summary>
+        /// Get a copy of a mesh positions array transformed into parent coordinates or world if no parents.
+        /// </summary>
+        /// <param name="mesh">The source mesh.</param>
+        /// <returns>An array containing all vertex positions in world space.</returns>
+        public static Vector3[] VerticesInParentSpace(this ProBuilderMesh mesh)
+        {
+            if (mesh == null)
+                throw new ArgumentNullException("mesh");
+
+            int len = mesh.vertexCount;
+            Vector3[] parentSpacePoints = new Vector3[len];
+            Vector3[] localPoints = mesh.positionsInternal;
+            Transform parentTransform = mesh.transform.parent;
+
+            for (int i = 0; i < len; i++)
+            {
+                parentSpacePoints[i] = mesh.transform.TransformPoint(localPoints[i]);
+                if (parentTransform)
+                    parentSpacePoints[i] = parentTransform.InverseTransformPoint(parentSpacePoints[i]);
+            }
+
+            return parentSpacePoints;
+        }
+
+        /// <summary>
         /// Translate a set of vertices with a world space offset.
         /// <br />
         /// Unlike most other mesh operations, this function applies the mesh positions to both ProBuilderMesh and the UnityEngine.Mesh.

--- a/Runtime/Core/VertexPositioning.cs
+++ b/Runtime/Core/VertexPositioning.cs
@@ -34,10 +34,10 @@ namespace UnityEngine.ProBuilder
         }
 
         /// <summary>
-        /// Get a copy of a mesh positions array transformed into parent coordinates or world if no parents.
+        /// Get a copy of a mesh positions array transformed into parent coordinates or world if no parent.
         /// </summary>
         /// <param name="mesh">The source mesh.</param>
-        /// <returns>An array containing all vertex positions in world space.</returns>
+        /// <returns>An array containing all vertex positions in parent space(or world if no parent).</returns>
         public static Vector3[] VerticesInParentSpace(this ProBuilderMesh mesh)
         {
             if (mesh == null)


### PR DESCRIPTION
Freeze transform will now freeze to parent if there is a parent, otherwise world.
It also address the issue with children being moved when freezing transform of parent.