### PR TITLE
Fix Polyshape Editor deleting GameObject if losing focus with no input

### DIFF
--- a/Editor/EditorCore/PolyShapeEditor.cs
+++ b/Editor/EditorCore/PolyShapeEditor.cs
@@ -40,7 +40,7 @@ namespace UnityEditor.ProBuilder
             get { return target as PolyShape; }
         }
 
-        Material CreateHighlightLineMaterial()
+        static Material CreateHighlightLineMaterial()
         {
             Material mat = new Material(Shader.Find("Hidden/ProBuilder/ScrollHighlight"));
             mat.SetColor("_Highlight", k_LineMaterialHighlightColor);
@@ -79,16 +79,6 @@ namespace UnityEditor.ProBuilder
             DestroyImmediate(m_LineMaterial);
             EditorApplication.update -= Update;
             Undo.undoRedoPerformed -= UndoRedoPerformed;
-
-            // Delete the created Polyshape if path is empty.
-            if (polygon != null && polygon.polyEditMode == PolyShape.PolyEditMode.Path && polygon.m_Points.Count == 0)
-                DiscardIncompleteShape();
-        }
-
-        void DiscardIncompleteShape()
-        {
-            if(polygon != null && polygon.gameObject != null)
-                Undo.DestroyObjectImmediate(polygon.gameObject);
         }
 
         public override void OnInspectorGUI()
@@ -650,18 +640,8 @@ namespace UnityEditor.ProBuilder
 
                 case KeyCode.Escape:
                 {
-                    if (polygon.polyEditMode == PolyShape.PolyEditMode.Path ||
-                        polygon.polyEditMode == PolyShape.PolyEditMode.Height)
-                    {
-                        DiscardIncompleteShape();
-                        evt.Use();
-                    }
-                    else if (polygon.polyEditMode == PolyShape.PolyEditMode.Edit)
-                    {
-                        SetPolyEditMode(PolyShape.PolyEditMode.None);
-                        evt.Use();
-                    }
-
+                    SetPolyEditMode(PolyShape.PolyEditMode.None);
+                    evt.Use();
                     break;
                 }
             }


### PR DESCRIPTION
fogbugz https://fogbugz.unity3d.com/f/cases/1193983/

Previously creating a new `Polyshape` object would delete the object if the Inspector lost focus before the user completes the shape. Now the shape is just committed as is (allowing empty points). Fixes the same issue when pressing `Escape` during initial shape editing.