### PR TITLE
Disable warning for deprecation of Lightmapping API

### DIFF
--- a/Editor/EditorCore/Lightmapping.cs
+++ b/Editor/EditorCore/Lightmapping.cs
@@ -30,9 +30,9 @@ namespace UnityEditor.ProBuilder
 
         [UserSetting]
         internal static Pref<UnwrapParameters> s_UnwrapParameters = new Pref<UnwrapParameters>("lightmapping.defaultLightmapUnwrapParameters", new UnwrapParameters());
-
+#pragma warning disable 618
         static Pref<UL.GIWorkflowMode> s_GiWorkflowMode = new Pref<UL.GIWorkflowMode>("lightmapping.giWorkflowMode", UL.GIWorkflowMode.Iterative, SettingsScope.User);
-
+#pragma warning restore 618
         static class Styles
         {
             public static readonly GUIContent hardAngle = new GUIContent("Hard Angle", "Angle between neighbor triangles that will generate seam.");
@@ -237,7 +237,7 @@ namespace UnityEditor.ProBuilder
 
             return param;
         }
-
+#pragma warning disable 618
         internal static void PushGIWorkflowMode()
         {
             s_GiWorkflowMode.SetValue(UL.giWorkflowMode, true);
@@ -250,5 +250,6 @@ namespace UnityEditor.ProBuilder
         {
             UL.giWorkflowMode = s_GiWorkflowMode;
         }
+#pragma warning restore 618
     }
 }

--- a/Editor/EditorCore/PreferencesUpdater.cs
+++ b/Editor/EditorCore/PreferencesUpdater.cs
@@ -90,7 +90,9 @@ namespace UnityEditor.ProBuilder
             new FormerPreferenceKeyMap("", "lightmapping.autoUnwrapLightmapUV", typeof(System.Boolean), SettingsScope.Project),
             new FormerPreferenceKeyMap(PreferenceKeys.pbShowMissingLightmapUvWarning, "lightmapping.showMissingLightmapWarning", typeof(System.Boolean), SettingsScope.User),
             new FormerPreferenceKeyMap("", "lightmapping.defaultLightmapUnwrapParameters", typeof(UnityEngine.ProBuilder.UnwrapParameters), SettingsScope.Project),
+#pragma warning disable 618
             new FormerPreferenceKeyMap("", "lightmapping.giWorkflowMode", typeof(UnityEditor.Lightmapping.GIWorkflowMode), SettingsScope.User),
+#pragma warning restore 618
             new FormerPreferenceKeyMap("pb_Log::m_LogLevel", "log.level", typeof(UnityEngine.ProBuilder.LogLevel), SettingsScope.Project),
             new FormerPreferenceKeyMap("pb_Log::m_Output", "log.output", typeof(UnityEngine.ProBuilder.LogOutput), SettingsScope.Project),
             new FormerPreferenceKeyMap("pb_Log::m_LogFilePath", "log.path", typeof(System.String), SettingsScope.Project),

--- a/Tests/Weekly/LightmapUVsAreValid.cs
+++ b/Tests/Weekly/LightmapUVsAreValid.cs
@@ -48,11 +48,13 @@ namespace UnityEditor.ProBuilder.Tests.Slow
         [UnityTest]
         public IEnumerator DefaultUnwrapParamsDoNotOverlap()
         {
+#pragma warning disable 618
             var lightmapMode = Lightmapping.giWorkflowMode;
 
             try
             {
                 Lightmapping.giWorkflowMode = Lightmapping.GIWorkflowMode.OnDemand;
+#pragma warning restore 618
 
 #if UNITY_2019_2_OR_NEWER
                 Lightmapping.bakeStarted += LightmappingStarted;
@@ -102,7 +104,9 @@ namespace UnityEditor.ProBuilder.Tests.Slow
                 Lightmapping.started -= LightmappingStarted;
                 Lightmapping.completed -= LightmappingCompleted;
 #endif
+#pragma warning disable 618
                 Lightmapping.giWorkflowMode = lightmapMode;
+#pragma warning restore 618
                 Cleanup();
             }
         }


### PR DESCRIPTION
https://ono.unity3d.com/unity/unity/pull-request/95782/_/lighting/lighting-settings-asset-take2 will hopefully land in 20.1 and will make all old settings API points for Lightmapping obsolete. They are still usable but will fire a warning. These changes make sure that we can still use the old API but it won't cause compile or runtime issues.
Testing status
Manual Tests: What did you do?
Nothing. It all seems to work with just disabling this warning. Have had to do this on a lot of code before.

Comments to reviewers
There is an internal API called Lightmapping.GetLightingSettingsOrDefaultsFallback() but we can't allow this to be public since we can't allow users to possibly change the global default settings that is read-only. Not sure how to do this in a nicer way for HDRPs right now.