### PR TITLE
Fix SelectionCache throwing errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [4.3.0-preview.1] - 2019-12-16
+
+## Bug Fixes
+
+- Fixed an issue where an invalid selection on `ProBuilderMesh` could prevent the selected mesh from being edited due to errors.
+
 ## [4.3.0-preview.0] - 2019-12-16
 
 ## Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [4.3.0] - 1111-11-11
+## [4.3.0-preview.0] - 2019-12-16
 
+## Bug Fixes
+
+- Fixed case where the default material could fail to initialize when a Scriptable Render Pipeline is in use at runtime.
 
 ## [4.2.1] - 2019-11-22
 

--- a/Runtime/Core/BuiltinMaterials.cs
+++ b/Runtime/Core/BuiltinMaterials.cs
@@ -253,7 +253,7 @@ namespace UnityEngine.ProBuilder
 
         internal static Material GetDefaultMaterial()
         {
-            Material material;
+            Material material = null;
 
             if (GraphicsSettings.renderPipelineAsset != null)
             {
@@ -263,9 +263,10 @@ namespace UnityEngine.ProBuilder
                     material = GraphicsSettings.renderPipelineAsset.GetDefaultMaterial();
 #endif
             }
-            else
+
+            if (material == null)
             {
-                material = (Material)Resources.Load("Materials/ProBuilderDefault", typeof(Material));
+                material = (Material) Resources.Load("Materials/ProBuilderDefault", typeof(Material));
 
                 if (material == null || !material.shader.isSupported)
                     material = GetLegacyDiffuse();

--- a/Runtime/Core/ProBuilderMeshSelection.cs
+++ b/Runtime/Core/ProBuilderMeshSelection.cs
@@ -107,18 +107,25 @@ namespace UnityEngine.ProBuilder
                 m_SelectedSharedVerticesCount = 0;
                 m_SelectedCoincidentVertexCount = 0;
 
-                foreach (var i in m_SelectedVertices)
+                try
                 {
-                    if (m_SelectedSharedVertices.Add(lookup[i]))
+                    foreach (var i in m_SelectedVertices)
                     {
-                        var coincident = sharedVerticesInternal[lookup[i]];
+                        if (m_SelectedSharedVertices.Add(lookup[i]))
+                        {
+                            var coincident = sharedVerticesInternal[lookup[i]];
 
-                        m_SelectedSharedVerticesCount++;
-                        m_SelectedCoincidentVertexCount += coincident.Count;
+                            m_SelectedSharedVerticesCount++;
+                            m_SelectedCoincidentVertexCount += coincident.Count;
 
-                        foreach (var n in coincident)
-                            m_SelectedCoincidentVertices.Add(n);
+                            foreach (var n in coincident)
+                                m_SelectedCoincidentVertices.Add(n);
+                        }
                     }
+                }
+                catch
+                {
+                    ClearSelection();
                 }
             }
         }
@@ -294,7 +301,6 @@ namespace UnityEngine.ProBuilder
             m_SelectedFaces = new int[0];
             m_SelectedEdges = new Edge[0];
             m_SelectedVertices = new int[0];
-
             m_SelectedCacheDirty = true;
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.probuilder",
   "displayName": "ProBuilder",
-  "version": "4.3.0",
+  "version": "4.3.0-preview.0",
   "unity": "2018.3",
   "description": "Build, edit, and texture custom geometry in Unity. Use ProBuilder for in-scene level design, prototyping, collision meshes, all with on-the-fly play-testing.\n\nAdvanced features include UV editing, vertex colors, parametric shapes, and texture blending. With ProBuilder's model export feature it's easy to tweak your levels in any external 3D modelling suite.",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.probuilder",
   "displayName": "ProBuilder",
-  "version": "4.3.0-preview.0",
+  "version": "4.3.0-preview.1",
   "unity": "2018.3",
   "description": "Build, edit, and texture custom geometry in Unity. Use ProBuilder for in-scene level design, prototyping, collision meshes, all with on-the-fly play-testing.\n\nAdvanced features include UV editing, vertex colors, parametric shapes, and texture blending. With ProBuilder's model export feature it's easy to tweak your levels in any external 3D modelling suite.",
   "keywords": [


### PR DESCRIPTION
https://forum.unity.com/threads/errors-and-cant-select-verticies.791490/

Fixes an issue where the `ProBuilderMesh` selection cache could end up in an unrecoverable state, preventing the mesh from being editable.