### PR TITLE
4.2: Fix errors when assigning null mesh to preview shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [4.2.2] - 2012-01-06
+
+## Bug Fixes
+
+- Fixed the `Custom Shape` field in the `Shape Editor` throwing errors on invalid input.
+
 ## [4.2.1] - 2019-11-22
 
 ## Features

--- a/Editor/EditorCore/ShapeEditor.cs
+++ b/Editor/EditorCore/ShapeEditor.cs
@@ -196,7 +196,8 @@ namespace UnityEditor.ProBuilder
         {
             ApplyPreviewTransform(mesh);
             Mesh umesh = mesh.mesh;
-            umesh.hideFlags = HideFlags.DontSave;
+            if(umesh != null)
+                umesh.hideFlags = HideFlags.DontSave;
 
             if (m_PreviewObject)
             {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.probuilder",
   "displayName": "ProBuilder",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "unity": "2018.3",
   "description": "Build, edit, and texture custom geometry in Unity. Use ProBuilder for in-scene level design, prototyping, collision meshes, all with on-the-fly play-testing.\n\nAdvanced features include UV editing, vertex colors, parametric shapes, and texture blending. With ProBuilder's model export feature it's easy to tweak your levels in any external 3D modelling suite.",
   "keywords": [


### PR DESCRIPTION
https://fogbugz.unity3d.com/f/cases/1204742/

Fixes an issue where assigning null to the New Shape editor preview object would throw errors.

