### PR TITLE
4.1: Fix errors when assigning null mesh to preview shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [4.1.3] - 2020-01-06
+
+## Bug Fixes
+
+- Fixed the `Custom Shape` field in the `Shape Editor` throwing errors on invalid input.
+
 ## [4.1.2] - 2019-11-27
 
 ## Bug Fixes

--- a/Editor/EditorCore/ShapeEditor.cs
+++ b/Editor/EditorCore/ShapeEditor.cs
@@ -168,8 +168,8 @@ namespace UnityEditor.ProBuilder
             mesh.preserveMeshAssetOnDestroy = true;
             var umesh = mesh.mesh;
             DestroyImmediate(mesh);
-
-            umesh.hideFlags = HideFlags.DontSave;
+            if(umesh != null)
+                umesh.hideFlags = HideFlags.DontSave;
             m_PreviewObject.hideFlags = HideFlags.DontSave;
             m_PreviewObject.GetComponent<MeshRenderer>().sharedMaterial = BuiltinMaterials.ShapePreviewMaterial;
 


### PR DESCRIPTION
https://fogbugz.unity3d.com/f/cases/1204742/

Fixes an issue where assigning null to the New Shape editor preview object would throw errors.