### PR TITLE
Fixed Issue When Changing Pivot If the Transform Has Children

### DIFF
--- a/Runtime/Core/TransformUtility.cs
+++ b/Runtime/Core/TransformUtility.cs
@@ -17,8 +17,8 @@ namespace UnityEngine.ProBuilder
         internal static void UnparentChildren(Transform t)
         {
             Transform[] children = new Transform[t.childCount];
-
-            for (int i = 0; i < t.childCount; i++)
+            
+            for (int i = t.childCount - 1; i >= 0; --i)
             {
                 Transform child = t.GetChild(i);
                 children[i] = child;
@@ -36,8 +36,8 @@ namespace UnityEngine.ProBuilder
         {
             Transform[] children;
 
-            if (s_ChildStack.TryGetValue(t, out children))
-            {
+            if (s_ChildStack.TryGetValue(t, out children)) 
+            { 
                 foreach (Transform c in children)
                     c.SetParent(t, true);
 

--- a/Tests/Runtime/Utilities.meta
+++ b/Tests/Runtime/Utilities.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 284fc6be8e255574aa979eeb3d466869
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Runtime/Utilities/TransformUtilityTests.cs
+++ b/Tests/Runtime/Utilities/TransformUtilityTests.cs
@@ -1,0 +1,77 @@
+﻿using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.ProBuilder;
+
+class TransformUtilityTests
+{
+    const int k_ChildCount = 4;
+
+    Transform m_Parent;
+    Transform[] m_Children;
+
+    [SetUp]
+    public void Setup()
+    {
+        m_Parent = new GameObject("Parent").transform;
+        m_Children = new Transform[k_ChildCount];
+
+        for (int i = 0; i < k_ChildCount; ++i)
+        {
+            Transform child = new GameObject($"Child {i}").transform;
+            child.parent = m_Parent;
+            m_Children[i] = child;
+        }
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Object.DestroyImmediate(m_Parent.gameObject);
+
+        //Ensure that children are destroyed if they are not reparented
+        foreach (var child in m_Children)
+        {
+            if (child != null)
+                Object.DestroyImmediate(child.gameObject);
+        }
+    }
+
+    [Test]
+    public void UnparentChildren_HasZeroChildren()
+    {
+        Assume.That(m_Parent.childCount, Is.EqualTo(k_ChildCount));
+
+        TransformUtility.UnparentChildren(m_Parent);
+        Assert.That(m_Parent.childCount, Is.EqualTo(0));
+
+        TransformUtility
+            .ReparentChildren(m_Parent); //This call is to ensure that we clear the child dictionary created by unparent
+    }
+
+    [Test]
+    public void UnparentChildrenAndReparentChildren_HasSameAmountOfChildren()
+    {
+        Assume.That(m_Parent.childCount, Is.EqualTo(k_ChildCount));
+        TransformUtility.UnparentChildren(m_Parent);
+        Assume.That(m_Parent.childCount, Is.EqualTo(0));
+
+        TransformUtility.ReparentChildren(m_Parent);
+        Assert.That(m_Parent.childCount, Is.EqualTo(k_ChildCount));
+    }
+
+    [Test]
+    public void UnparentChildrenAndReparentChildren_ChildrenAreInSameOrder()
+    {
+        Assume.That(m_Parent.childCount, Is.EqualTo(k_ChildCount));
+        TransformUtility.UnparentChildren(m_Parent);
+        Assume.That(m_Parent.childCount, Is.EqualTo(0));
+
+        TransformUtility.ReparentChildren(m_Parent);
+        Assume.That(m_Parent.childCount, Is.EqualTo(k_ChildCount));
+
+        for (int i = 0; i < k_ChildCount; ++i)
+        {
+            Assert.That(m_Parent.GetChild(i), Is.EqualTo(m_Children[i]));
+        }
+    }
+}

--- a/Tests/Runtime/Utilities/TransformUtilityTests.cs.meta
+++ b/Tests/Runtime/Utilities/TransformUtilityTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 61561ab4f7c3de24298dc7dbee45c011
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
[[case#1208475]](https://fogbugz.unity3d.com/f/cases/1208475/)

@JoelFortin The unparent/reparent utility method that was changed is only use in the _Center Pivot_ Action and _Set Pivot To Selection_ Action and nowhere else in the code.