### PR TITLE
Fix Element Selection Sporadic Failures

### DIFF
--- a/Editor/EditorCore/EditorMeshHandles.cs
+++ b/Editor/EditorCore/EditorMeshHandles.cs
@@ -274,9 +274,8 @@ namespace UnityEditor.ProBuilder
             }
             else if (selection.edge != Edge.Empty)
             {
-                using (var drawingScope = new LineDrawingScope(s_PreselectionColor, -1f, CompareFunction.Always))
+                using (var drawingScope = new LineDrawingScope(s_PreselectionColor, mesh.transform.localToWorldMatrix, -1f, CompareFunction.Always))
                 {
-                    GL.MultMatrix(mesh.transform.localToWorldMatrix);
                     drawingScope.DrawLine(positions[selection.edge.a], positions[selection.edge.b]);
                 }
             }

--- a/Editor/EditorCore/EditorSceneViewPicker.cs
+++ b/Editor/EditorCore/EditorSceneViewPicker.cs
@@ -11,8 +11,9 @@ namespace UnityEditor.ProBuilder
 {
     struct ScenePickerPreferences
     {
-        public float maxPointerDistance;
-        public float offPointerMultiplier;
+        public const float maxPointerDistance = 40f;
+        public const float offPointerMultiplier = .01f;
+
         public CullingMode cullMode;
         public SelectionModifierBehavior selectionModifierBehavior;
         public RectSelectMode rectSelectMode;
@@ -55,7 +56,7 @@ namespace UnityEditor.ProBuilder
                 MeshSelection.SetSelection((GameObject)null);
             }
 
-            if (pickedElementDistance > pickerPreferences.maxPointerDistance)
+            if (pickedElementDistance > ScenePickerPreferences.maxPointerDistance)
             {
                 if (appendModifier && Selection.gameObjects.Contains(s_Selection.gameObject))
                     MeshSelection.RemoveFromSelection(s_Selection.gameObject);
@@ -507,7 +508,7 @@ namespace UnityEditor.ProBuilder
             selection.Clear();
             s_NearestVertices.Clear();
             selection.gameObject = HandleUtility.PickGameObject(mousePosition, false);
-            float maxDistance = pickerOptions.maxPointerDistance * pickerOptions.maxPointerDistance;
+            float maxDistance = ScenePickerPreferences.maxPointerDistance * ScenePickerPreferences.maxPointerDistance;
             ProBuilderMesh hoveredMesh = selection.gameObject != null ? selection.gameObject.GetComponent<ProBuilderMesh>() : null;
 
             if (allowUnselected && selection.gameObject != null)
@@ -525,7 +526,7 @@ namespace UnityEditor.ProBuilder
                     if (!mesh.selectable)
                         continue;
 
-                    GetNearestVertices(mesh, mousePosition, s_NearestVertices, maxDistance, hoveredMesh == mesh || hoveredMesh == null ? 1.0f : pickerOptions.offPointerMultiplier);
+                    GetNearestVertices(mesh, mousePosition, s_NearestVertices, maxDistance, hoveredMesh == mesh || hoveredMesh == null ? 1.0f : ScenePickerPreferences.offPointerMultiplier);
                 }
             }
 
@@ -605,7 +606,7 @@ namespace UnityEditor.ProBuilder
 
                     // If the nearest edge was acquired by a raycast, then the distance to mesh is 0f.
                     if (hoveredIsInSelection)
-                        return 0f; // tup.distance;
+                        return tup.distance;
                 }
             }
 
@@ -619,7 +620,7 @@ namespace UnityEditor.ProBuilder
                 // object hovered over the currently selected
                 var distMultiplier = (hoveredMesh == mesh || hoveredMesh == null)
                     ? 1.0f
-                    : pickerPrefs.offPointerMultiplier;
+                    : ScenePickerPreferences.offPointerMultiplier;
 
                 foreach (var face in mesh.facesInternal)
                 {
@@ -636,7 +637,7 @@ namespace UnityEditor.ProBuilder
 
                         // best distance isn't set to maxPointerDistance because we want to preserve an unselected
                         // gameobject over a selected gameobject with an out of bounds edge.
-                        if (d > pickerPrefs.maxPointerDistance)
+                        if (d > ScenePickerPreferences.maxPointerDistance)
                             continue;
 
                         // account for stacked edges

--- a/Editor/EditorCore/EditorSceneViewPicker.cs
+++ b/Editor/EditorCore/EditorSceneViewPicker.cs
@@ -220,16 +220,11 @@ namespace UnityEditor.ProBuilder
                 }
 
                 if(activeObjectSelectionChanged)
-                {
                     MeshSelection.MakeActiveObject(candidateNewActiveObject);
-                }
                 else
-                {
                     MeshSelection.AddToSelection(candidateNewActiveObject);
-                }
 
-
-            return mesh;
+                return mesh;
             }
 
             return null;

--- a/Editor/EditorCore/ProBuilderEditor.cs
+++ b/Editor/EditorCore/ProBuilderEditor.cs
@@ -23,9 +23,6 @@ namespace UnityEditor.ProBuilder
         // Match the value set in RectSelection.cs
         const float k_MouseDragThreshold = 6f;
 
-        //Off pointer multiplier is a percentage of the picking distance
-        const float k_OffPointerMultiplierPercent = 0.1f;
-
         /// <value>
         /// Raised any time the ProBuilder editor refreshes the selection. This is called every frame when interacting with mesh elements, and after any mesh operation.
         /// </value>
@@ -68,8 +65,6 @@ namespace UnityEditor.ProBuilder
 
         [UserSetting("Toolbar", "Toolbar Location", "Where the Object, Face, Edge, and Vertex toolbar will be shown in the Scene View.")]
         static Pref<SceneToolbarLocation> s_SceneToolbarLocation = new Pref<SceneToolbarLocation>("editor.sceneToolbarLocation", SceneToolbarLocation.UpperCenter, SettingsScope.User);
-
-        const float k_PickingDistance = 40f;
 
         static Pref<bool> s_WindowIsFloating = new Pref<bool>("UnityEngine.ProBuilder.ProBuilderEditor-isUtilityWindow", false, SettingsScope.Project);
         static Pref<bool> m_BackfaceSelectEnabled = new Pref<bool>("editor.backFaceSelectEnabled", false);
@@ -398,8 +393,6 @@ namespace UnityEditor.ProBuilder
 
             m_ScenePickerPreferences = new ScenePickerPreferences()
             {
-                offPointerMultiplier = k_PickingDistance * k_OffPointerMultiplierPercent,
-                maxPointerDistance = k_PickingDistance,
                 cullMode = m_BackfaceSelectEnabled ? CullingMode.None : CullingMode.Back,
                 selectionModifierBehavior = m_SelectModifierBehavior,
                 rectSelectMode = m_DragSelectRectMode

--- a/Editor/EditorCore/ProBuilderEditor.cs
+++ b/Editor/EditorCore/ProBuilderEditor.cs
@@ -625,9 +625,8 @@ namespace UnityEditor.ProBuilder
             {
                 m_Hovering.CopyTo(m_HoveringPrevious);
 
-                if (GUIUtility.hotControl == 0)
-                    EditorSceneViewPicker.MouseRayHitTest(m_CurrentEvent.mousePosition, selectMode, m_ScenePickerPreferences, m_Hovering);
-                else
+                if (GUIUtility.hotControl != 0 ||
+                    EditorSceneViewPicker.MouseRayHitTest(m_CurrentEvent.mousePosition, selectMode, m_ScenePickerPreferences, m_Hovering) > ScenePickerPreferences.maxPointerDistance)
                     m_Hovering.Clear();
 
                 if (!m_Hovering.Equals(m_HoveringPrevious))


### PR DESCRIPTION
https://fogbugz.unity3d.com/f/cases/1173650 and https://issuetracker.unity3d.com/issues/probuilder-unable-to-select-face-slash-vertex-of-the-game-object-when-using-pb-toolbar

Fixes an issue where the scene picker preferences would in some cases (still unknown how these cases occur) could fail to initialize, resulting in the maximum allowed picking distance to be set to 0, effectively blocking any element from being selected. This PR sets the max pick distance to a constant value, which currently is a hidden setting.

Also fixes an issue where the hover preview would incorrectly highlight elements that are outside the picking range.