### PR TITLE
Fix CombineMesh.Combine() assigning sharedTextures data to the wrong …

### DIFF
--- a/Runtime/MeshOperations/CombineMeshes.cs
+++ b/Runtime/MeshOperations/CombineMeshes.cs
@@ -93,7 +93,7 @@ namespace UnityEngine.ProBuilder.MeshOperations
             meshTarget.SetVertices(vertices);
             meshTarget.faces = faces;
             meshTarget.sharedVertices = sharedVertices;
-            meshTarget.sharedVertices = sharedTextures != null ? sharedTextures.ToArray() : null;
+            meshTarget.sharedTextures = sharedTextures != null ? sharedTextures.ToArray() : null;
             meshTarget.renderer.sharedMaterials = materialMap.ToArray();
             meshTarget.ToMesh();
             meshTarget.Refresh();

--- a/Runtime/MeshOperations/CombineMeshes.cs
+++ b/Runtime/MeshOperations/CombineMeshes.cs
@@ -99,16 +99,19 @@ namespace UnityEngine.ProBuilder.MeshOperations
             meshTarget.Refresh();
             UVEditing.SetAutoAndAlignUnwrapParamsToUVs(meshTarget, autoUvFaces);
 
+            MeshValidation.EnsureMeshIsValid(meshTarget, out int removedVertices);
+
             var returnedMesh = new List<ProBuilderMesh>() { meshTarget };
             if (remainderMeshContributors.Count > 1)
             {
                 var newMeshes = CombineToNewMeshes(remainderMeshContributors);
-                foreach(var mesh in newMeshes)
+                foreach (var mesh in newMeshes)
                 {
+                    MeshValidation.EnsureMeshIsValid(mesh, out removedVertices);
                     returnedMesh.Add(mesh);
                 }
             }
-            else if(remainderMeshContributors.Count == 1)
+            else if (remainderMeshContributors.Count == 1)
             {
                 returnedMesh.Add(remainderMeshContributors[0]);
             }
@@ -189,7 +192,6 @@ namespace UnityEngine.ProBuilder.MeshOperations
                     else
                         vertices.Add(worldVertex);
                 }
-
 
                 foreach (var face in meshFaces)
                 {


### PR DESCRIPTION
**Goal of this PR:**
This PR fixes a bad reference assignment when merging objects. `sharedVertices` field gets written two times in a row with different kind of data.

Will likely help fix this case: https://fogbugz.unity3d.com/f/cases/1206302/

