### PR TITLE
Fixed Issue With Free Slider Height When On Android Platform Target

### DIFF
--- a/Editor/EditorCore/EditorGUIUtility.cs
+++ b/Editor/EditorCore/EditorGUIUtility.cs
@@ -278,7 +278,7 @@ namespace UnityEditor.ProBuilder.UI
             const float MAX_LABEL_WIDTH = 128f;
             const float MIN_FIELD_WIDTH = 48f;
             
-            Rect rect = UnityEditor.EditorGUILayout.GetSliderRect(true);
+            Rect rect = EditorGUILayout.GetSliderRect(true);
             float y = rect.y;
 
             float labelWidth = content != null ? Mathf.Max(MIN_LABEL_WIDTH, Mathf.Min(GUI.skin.label.CalcSize(content).x + PAD, MAX_LABEL_WIDTH)) : 0f;

--- a/Editor/EditorCore/EditorGUIUtility.cs
+++ b/Editor/EditorCore/EditorGUIUtility.cs
@@ -273,24 +273,22 @@ namespace UnityEditor.ProBuilder.UI
             pixelsPerPoint = UnityEditor.EditorGUIUtility.pixelsPerPoint;
 
             float PAD = 8f / pixelsPerPoint;
-            const float SLIDER_HEIGHT = 16f;
+            float sliderHeight = UnityEditor.EditorGUIUtility.singleLineHeight;
             const float MIN_LABEL_WIDTH = 0f;
             const float MAX_LABEL_WIDTH = 128f;
             const float MIN_FIELD_WIDTH = 48f;
-
-            GUILayoutUtility.GetRect(UnityEditor.EditorGUIUtility.currentViewWidth / pixelsPerPoint, 18);
-
-            Rect previousRect = GUILayoutUtility.GetLastRect();
-            float y = previousRect.y;
+            
+            Rect rect = UnityEditor.EditorGUILayout.GetSliderRect(true);
+            float y = rect.y;
 
             float labelWidth = content != null ? Mathf.Max(MIN_LABEL_WIDTH, Mathf.Min(GUI.skin.label.CalcSize(content).x + PAD, MAX_LABEL_WIDTH)) : 0f;
             float remaining = ((Screen.width / pixelsPerPoint) - (PAD * 2f)) - labelWidth;
             float sliderWidth = remaining - (MIN_FIELD_WIDTH + PAD);
             float floatWidth = MIN_FIELD_WIDTH;
 
-            Rect labelRect = new Rect(PAD, y + 2f, labelWidth, SLIDER_HEIGHT);
-            Rect sliderRect = new Rect(labelRect.x + labelWidth, y + 1f, sliderWidth, SLIDER_HEIGHT);
-            Rect floatRect = new Rect(sliderRect.x + sliderRect.width + PAD, y + 1f, floatWidth, SLIDER_HEIGHT);
+            Rect labelRect = new Rect(PAD, y + 2f, labelWidth, sliderHeight);
+            Rect sliderRect = new Rect(labelRect.x + labelWidth, y + 1f, sliderWidth, sliderHeight);
+            Rect floatRect = new Rect(sliderRect.x + sliderRect.width + PAD, y + 1f, floatWidth, sliderHeight);
 
             if (content != null)
                 GUI.Label(labelRect, content);


### PR DESCRIPTION
[[case #1183100]](https://fogbugz.unity3d.com/f/cases/1183100/)

Our Free Slider would look like this when the target platform was android:

![image](https://user-images.githubusercontent.com/44209648/72094387-577d8e80-32e4-11ea-9447-65979d1ee798.png)

It also look a bit weird on windows (you can see the difference by looking at the curvature field which is a normal unity slider):

![image](https://user-images.githubusercontent.com/44209648/72094517-96134900-32e4-11ea-9c73-4557d46e7fa7.png)

Result with the fix on both platform: 

![image](https://user-images.githubusercontent.com/44209648/72094602-c22eca00-32e4-11ea-87df-3158ff625ec4.png)

