### PR TITLE
Ignore changes from a Reset when users trigger it

### DIFF
--- a/Runtime/Core/ProBuilderMeshFunction.cs
+++ b/Runtime/Core/ProBuilderMeshFunction.cs
@@ -51,6 +51,15 @@ namespace UnityEngine.ProBuilder
                 Rebuild();
         }
 
+#if UNITY_EDITOR
+        void Reset()
+        {
+            // Prevent reset from Unity Editor as it would put this component in a weird state.
+            if (meshSyncState != MeshSyncState.Null)
+                UnityEditor.Undo.PerformUndo();
+        }
+#endif
+
         void OnDestroy()
         {
             if (componentWillBeDestroyed != null)


### PR DESCRIPTION
**Goal of this PR:**
This PR prevents user to manually reset a ProBuilderMesh component by ignoring it. Otherwise, Reset would put the instance in a weird state without offering a way to populate the mesh data. That is something that users should not trigger.

Fix this case: https://fogbugz.unity3d.com/f/cases/1196134/