### PR TITLE
Ensure to update internal data when users manually reset components.

### DIFF
--- a/Editor/EditorCore/MeshSelection.cs
+++ b/Editor/EditorCore/MeshSelection.cs
@@ -111,6 +111,7 @@ namespace UnityEditor.ProBuilder
             ProBuilderMesh.elementSelectionChanged += ElementSelectionChanged;
             EditorMeshUtility.meshOptimized += (x, y) => { s_TotalElementCountCacheIsDirty = true; };
             ProBuilderMesh.componentWillBeDestroyed += RemoveMeshFromSelectionInternal;
+            ProBuilderMesh.componentHasBeenReset += RefreshSelectionAfterComponentReset;
             OnObjectSelectionChanged();
         }
 
@@ -466,6 +467,11 @@ namespace UnityEditor.ProBuilder
         {
             if (s_TopSelection.Contains(mesh))
                 s_TopSelection.Remove(mesh);
+        }
+
+        internal static void RefreshSelectionAfterComponentReset(ProBuilderMesh mesh)
+        {
+            ProBuilderEditor.Refresh(true);
         }
 
         internal static void SetSelection(IList<GameObject> newSelection)

--- a/Runtime/Core/ProBuilderMesh.cs
+++ b/Runtime/Core/ProBuilderMesh.cs
@@ -783,6 +783,11 @@ namespace UnityEngine.ProBuilder
         internal static event Action<ProBuilderMesh> componentWillBeDestroyed;
 
         /// <value>
+        /// Invoked from ProBuilderMesh.Reset after component is rebuilt.
+        /// </value>
+        internal static event Action<ProBuilderMesh> componentHasBeenReset;
+
+        /// <value>
         /// Invoked when the element selection changes on any ProBuilderMesh.
         /// </value>
         /// <seealso cref="SetSelectedFaces"/>

--- a/Runtime/Core/ProBuilderMeshFunction.cs
+++ b/Runtime/Core/ProBuilderMeshFunction.cs
@@ -51,6 +51,16 @@ namespace UnityEngine.ProBuilder
                 Rebuild();
         }
 
+        void Reset()
+        {
+            if (meshSyncState != MeshSyncState.Null && meshSyncState != MeshSyncState.InstanceIDMismatch)
+            {
+                Rebuild();
+                if (componentHasBeenReset != null)
+                    componentHasBeenReset(this);
+            }
+        }
+
         void OnDestroy()
         {
             if (componentWillBeDestroyed != null)


### PR DESCRIPTION
**Goal of this PR:**
Today, when an user manually reset a ProBuilderMesh component, he looses the internal mesh data but the SceneView doesn't refresh what it renders.

This PR ensures two things:
- We rebuild a mesh based on the new set of data after a Reset(). In this case, it would result into an empty mesh.
- ProBuilderEditor will refresh its selection to behave in respect with the new data.

Fix this case: https://fogbugz.unity3d.com/f/cases/1196134