### PR TITLE
Package/remove tests as separate package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - [case: 1203585] Removed `Custom Shape` option from the `Shape Editor` window.
 
+## [4.3.0-preview.3] - 2020-01-28
+
 ## [4.3.0-preview.2] - 2020-01-15
 
 ## Bug Fixes

--- a/Tests/.tests.json
+++ b/Tests/.tests.json
@@ -1,5 +1,3 @@
 {
-	"createSeparatePackage":true,
-	"name":"com.unity.probuilder.tests",
-	"displayName":"ProBuilder Tests"
+	"createSeparatePackage":false
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.probuilder",
   "displayName": "ProBuilder",
-  "version": "4.3.0-preview.2",
+  "version": "4.3.0-preview.3",
   "unity": "2018.3",
   "description": "Build, edit, and texture custom geometry in Unity. Use ProBuilder for in-scene level design, prototyping, collision meshes, all with on-the-fly play-testing.\n\nAdvanced features include UV editing, vertex colors, parametric shapes, and texture blending. With ProBuilder's model export feature it's easy to tweak your levels in any external 3D modelling suite.",
   "keywords": [


### PR DESCRIPTION
Clean up package config with tests.
Will unlock Yamato but you'll still get errors because of 
```
Failed - "Path Length Validation"
    Error: Tests/Templates/UnityEngine.Mesh/Runtime/MeshOps/AutoTextureUnwrappingTests/SetOffsetAndRotate_InLocalSpace_IsAppliedToMesh/Sprite.asset.meta is 141 characters, which is long
[20:34:58.515 INF] er than the limit of 140 characters. You must use shorter names.

    Error: Tests/Templates/UnityEngine.Mesh/Runtime/MeshOps/ProBuilderizeTests/ImportMeshWithQuads_MatchesWindingOrder/imported-cube-triangles.asset.meta is 142 characters, which is longer than the limit of 140 characters. You must use shorter names.
```