### PR TITLE
Fix build process removing MeshFilter component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - [case: 1203585] Removed `Custom Shape` option from the `Shape Editor` window.
 - [case: 1201746] The Move tool is now compatible with grid snapping (Unity 2019.3 and higher).
+- [case: 1214103] Fixed ProBuilder created meshes not rendering in project builds.
 
 ## [4.3.0-preview.2] - 2020-01-15
 

--- a/Editor/EditorCore/UnityScenePostProcessor.cs
+++ b/Editor/EditorCore/UnityScenePostProcessor.cs
@@ -67,6 +67,9 @@ namespace UnityEditor.ProBuilder
 
                 Object.DestroyImmediate(mesh);
                 Object.DestroyImmediate(entity);
+
+                var filter = go.DemandComponent<MeshFilter>();
+                filter.hideFlags = HideFlags.None;
             }
         }
 


### PR DESCRIPTION
https://fogbugz.unity3d.com/f/cases/1214103/

Fixes the `Mesh Filter` component not being included in builds.