### PR TITLE
Fix tooltips not showing on macos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [case: 1203585] Removed `Custom Shape` option from the `Shape Editor` window.
 - [case: 1201746] The Move tool is now compatible with grid snapping (Unity 2019.3 and higher).
 - [case: 1214103] Fixed ProBuilder created meshes not rendering in project builds.
-
+- [case: 1211721] Fixed tooltips in the ProBuilder toolbar not rendering on macOS.
 
 ## [4.3.0-preview.3] - 2020-01-28
 

--- a/Editor/EditorCore/TooltipEditor.cs
+++ b/Editor/EditorCore/TooltipEditor.cs
@@ -16,7 +16,7 @@ namespace UnityEditor.ProBuilder
         static TooltipEditor()
         {
             s_ShowModeEnum = ReflectionUtility.GetType("UnityEditor.ShowMode");
-        
+
             s_ShowPopupWithModeMethod = typeof(EditorWindow).GetMethod(
                 "ShowPopupWithMode",
                 BindingFlags.NonPublic | BindingFlags.Instance);
@@ -58,12 +58,13 @@ namespace UnityEditor.ProBuilder
         {
             if (s_Instance == null)
             {
-                s_Instance = ScriptableObject.CreateInstance<TooltipEditor>();
+                s_Instance = CreateInstance<TooltipEditor>();
                 s_Instance.minSize = Vector2.zero;
                 s_Instance.maxSize = Vector2.zero;
                 s_Instance.hideFlags = HideFlags.HideAndDontSave;
 #if UNITY_2019_1_OR_NEWER
                 s_Instance.ShowTooltip();
+                s_Instance.m_Parent.window.SetAlpha(1f);
 #else
                 if (s_ShowPopupWithModeMethod != null && s_ShowModeEnum != null)
                     s_ShowPopupWithModeMethod.Invoke(s_Instance, new [] { Enum.ToObject(s_ShowModeEnum, 1), false});


### PR DESCRIPTION
Fixed tooltips in the ProBuilder toolbar not rendering on macOS.

https://fogbugz.unity3d.com/f/cases/1211721/