### PR TITLE
Fix Bevel sometimes producing non-conformed normals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - [case: 1221121] Fixed a crash when undoing the creation of a `Poly Shape` object.
 - Fixed `Shape Editor` preferences not respecting "Reset All Preferences".
+- [case: 1132509] Fixed `Bevel` sometimes resulting in non-conforming face normals.
 
 ## [4.3.0-preview.3] - 2020-02-12
 

--- a/Runtime/MeshOperations/Bevel.cs
+++ b/Runtime/MeshOperations/Bevel.cs
@@ -215,19 +215,20 @@ namespace UnityEngine.ProBuilder.MeshOperations
             // get a hash of just the adjacent and bridge faces
             // HashSet<pb_Face> adjacent = new HashSet<pb_Face>(appendFaces.Select(x => x.face));
             // and also just the filled holes
-            HashSet<Face> newHoles = new HashSet<Face>(holeFaces.Select(x => x.face));
+            HashSet<Face> newFaces = new HashSet<Face>(holeFaces.Select(x => x.face));
+            newFaces.UnionWith(createdFaces);
             // now append filled holes to the full list of added faces
             appendFaces.AddRange(holeFaces);
 
             List<WingedEdge> allNewFaceEdges = WingedEdge.GetWingedEdges(mesh, appendFaces.Select(x => x.face));
 
-            for (int i = 0; i < allNewFaceEdges.Count && newHoles.Count > 0; i++)
+            for (int i = 0; i < allNewFaceEdges.Count && newFaces.Count > 0; i++)
             {
                 WingedEdge wing = allNewFaceEdges[i];
 
-                if (newHoles.Contains(wing.face))
+                if (newFaces.Contains(wing.face))
                 {
-                    newHoles.Remove(wing.face);
+                    newFaces.Remove(wing.face);
 
                     // find first edge whose opposite face isn't a filled hole* then
                     // conform normal by that.
@@ -238,7 +239,7 @@ namespace UnityEngine.ProBuilder.MeshOperations
                         {
                             var w = it.Current;
 
-                            if (w.opposite != null && !newHoles.Contains(w.opposite.face))
+                            if (w.opposite != null && !newFaces.Contains(w.opposite.face))
                             {
                                 w.face.submeshIndex = w.opposite.face.submeshIndex;
                                 w.face.uv = new AutoUnwrapSettings(w.opposite.face.uv);


### PR DESCRIPTION
Fixes an issue where the Bevel action only tested a subset of the newly created faces for normal conformity.

https://fogbugz.unity3d.com/f/cases/1132509/