### PR TITLE
Fix collection 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- [case: 1213742] Fixed bug where `Delete` menu item would incorrectly shows as available with no selection.
+- [case: 1192479] Fixed an issue where translating UV positions in the `UV Editor` with a handle would not update the Inspector offset values.
+- [case: 1176370] Fixed entering Play Mode with the `Shape Editor` open creating a new shape in the scene.
+- [case: 1218413] Fixed `Poly Shape` input incorrectly snapping vertices when input plane is not on a grid.
+
 ### Bug Fixes
 
 - [case: 1221121] Fixed a crash when undoing the creation of a `Poly Shape` object.

--- a/Debug/Editor/GenerateMenuItems.cs
+++ b/Debug/Editor/GenerateMenuItems.cs
@@ -153,17 +153,17 @@ namespace UnityEditor.ProBuilder
 
         static void AppendMenuItem(StringBuilder sb, MenuActionData data)
         {
+            var category = GetActionCategory(data.path);
+            var priority = GetMenuPriority(category);
+            var menuItemShortcut = GetMenuFormattedShortcut(data.menuItemShortcut);
+
             // Verify
-            sb.AppendLine($"\t\t[MenuItem(k_MenuPrefix + \"{data.path} \", true)]");
+            sb.AppendLine($"\t\t[MenuItem(k_MenuPrefix + \"{data.path}{menuItemShortcut}\", true, {priority})]");
             sb.AppendLine($"\t\tstatic bool MenuVerify_{data.typeString}()");
             sb.AppendLine( "\t\t{");
             sb.AppendLine($"\t\t\tvar instance = EditorToolbarLoader.GetInstance<{data.typeString}>();");
             sb.AppendLine( "\t\t\treturn instance != null && instance.enabled;");
             sb.AppendLine( "\t\t}");
-
-            var category = GetActionCategory(data.path);
-            var priority = GetMenuPriority(category);
-            var menuItemShortcut = GetMenuFormattedShortcut(data.menuItemShortcut);
 
             sb.AppendLine();
 

--- a/Editor/EditorCore/EditorToolbarMenuItems.cs
+++ b/Editor/EditorCore/EditorToolbarMenuItems.cs
@@ -22,7 +22,7 @@ namespace UnityEditor.ProBuilder
         const string k_MenuPrefix = "Tools/ProBuilder/";
         const string k_ShortcutPrefix = "ProBuilder/";
 
-		[MenuItem(k_MenuPrefix + "Editors/New Bezier Shape ", true)]
+		[MenuItem(k_MenuPrefix + "Editors/New Bezier Shape", true, PreferenceKeys.menuEditor + 1)]
 		static bool MenuVerify_NewBezierShape()
 		{
 			var instance = EditorToolbarLoader.GetInstance<NewBezierShape>();
@@ -37,7 +37,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Editors/New Poly Shape ", true)]
+		[MenuItem(k_MenuPrefix + "Editors/New Poly Shape", true, PreferenceKeys.menuEditor + 1)]
 		static bool MenuVerify_NewPolyShape()
 		{
 			var instance = EditorToolbarLoader.GetInstance<NewPolyShape>();
@@ -52,7 +52,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Editors/Open Lightmap UV Editor ", true)]
+		[MenuItem(k_MenuPrefix + "Editors/Open Lightmap UV Editor", true, PreferenceKeys.menuEditor + 1)]
 		static bool MenuVerify_OpenLightmapUVEditor()
 		{
 			var instance = EditorToolbarLoader.GetInstance<OpenLightmapUVEditor>();
@@ -67,7 +67,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Editors/Open Material Editor ", true)]
+		[MenuItem(k_MenuPrefix + "Editors/Open Material Editor", true, PreferenceKeys.menuEditor + 1)]
 		static bool MenuVerify_OpenMaterialEditor()
 		{
 			var instance = EditorToolbarLoader.GetInstance<OpenMaterialEditor>();
@@ -82,7 +82,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Editors/Open Shape Editor Menu Item ", true)]
+		[MenuItem(k_MenuPrefix + "Editors/Open Shape Editor Menu Item %#k", true, PreferenceKeys.menuEditor + 1)]
 		static bool MenuVerify_OpenShapeEditorMenuItem()
 		{
 			var instance = EditorToolbarLoader.GetInstance<OpenShapeEditorMenuItem>();
@@ -97,7 +97,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Editors/Open Smoothing Editor ", true)]
+		[MenuItem(k_MenuPrefix + "Editors/Open Smoothing Editor", true, PreferenceKeys.menuEditor + 1)]
 		static bool MenuVerify_OpenSmoothingEditor()
 		{
 			var instance = EditorToolbarLoader.GetInstance<OpenSmoothingEditor>();
@@ -112,7 +112,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Editors/Open UV Editor ", true)]
+		[MenuItem(k_MenuPrefix + "Editors/Open UV Editor", true, PreferenceKeys.menuEditor + 1)]
 		static bool MenuVerify_OpenUVEditor()
 		{
 			var instance = EditorToolbarLoader.GetInstance<OpenUVEditor>();
@@ -127,7 +127,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Editors/Open Vertex Color Editor ", true)]
+		[MenuItem(k_MenuPrefix + "Editors/Open Vertex Color Editor", true, PreferenceKeys.menuEditor + 1)]
 		static bool MenuVerify_OpenVertexColorEditor()
 		{
 			var instance = EditorToolbarLoader.GetInstance<OpenVertexColorEditor>();
@@ -142,7 +142,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Editors/Open Vertex Position Editor ", true)]
+		[MenuItem(k_MenuPrefix + "Editors/Open Vertex Position Editor", true, PreferenceKeys.menuEditor + 1)]
 		static bool MenuVerify_OpenVertexPositionEditor()
 		{
 			var instance = EditorToolbarLoader.GetInstance<OpenVertexPositionEditor>();
@@ -157,7 +157,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Export/Export Asset ", true)]
+		[MenuItem(k_MenuPrefix + "Export/Export Asset", true, PreferenceKeys.menuExport + 0)]
 		static bool MenuVerify_ExportAsset()
 		{
 			var instance = EditorToolbarLoader.GetInstance<ExportAsset>();
@@ -172,7 +172,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Export/Export Obj ", true)]
+		[MenuItem(k_MenuPrefix + "Export/Export Obj", true, PreferenceKeys.menuExport + 0)]
 		static bool MenuVerify_ExportObj()
 		{
 			var instance = EditorToolbarLoader.GetInstance<ExportObj>();
@@ -187,7 +187,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Export/Export Ply ", true)]
+		[MenuItem(k_MenuPrefix + "Export/Export Ply", true, PreferenceKeys.menuExport + 0)]
 		static bool MenuVerify_ExportPly()
 		{
 			var instance = EditorToolbarLoader.GetInstance<ExportPly>();
@@ -202,7 +202,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Export/Export Stl Ascii ", true)]
+		[MenuItem(k_MenuPrefix + "Export/Export Stl Ascii", true, PreferenceKeys.menuExport + 0)]
 		static bool MenuVerify_ExportStlAscii()
 		{
 			var instance = EditorToolbarLoader.GetInstance<ExportStlAscii>();
@@ -217,7 +217,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Export/Export Stl Binary ", true)]
+		[MenuItem(k_MenuPrefix + "Export/Export Stl Binary", true, PreferenceKeys.menuExport + 0)]
 		static bool MenuVerify_ExportStlBinary()
 		{
 			var instance = EditorToolbarLoader.GetInstance<ExportStlBinary>();
@@ -232,7 +232,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Geometry/Bevel Edges ", true)]
+		[MenuItem(k_MenuPrefix + "Geometry/Bevel Edges", true, PreferenceKeys.menuGeometry + 3)]
 		static bool MenuVerify_BevelEdges()
 		{
 			var instance = EditorToolbarLoader.GetInstance<BevelEdges>();
@@ -247,7 +247,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Geometry/Bridge Edges ", true)]
+		[MenuItem(k_MenuPrefix + "Geometry/Bridge Edges &b", true, PreferenceKeys.menuGeometry + 3)]
 		static bool MenuVerify_BridgeEdges()
 		{
 			var instance = EditorToolbarLoader.GetInstance<BridgeEdges>();
@@ -262,7 +262,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Geometry/Collapse Vertices ", true)]
+		[MenuItem(k_MenuPrefix + "Geometry/Collapse Vertices &c", true, PreferenceKeys.menuGeometry + 3)]
 		static bool MenuVerify_CollapseVertices()
 		{
 			var instance = EditorToolbarLoader.GetInstance<CollapseVertices>();
@@ -277,7 +277,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Geometry/Conform Face Normals ", true)]
+		[MenuItem(k_MenuPrefix + "Geometry/Conform Face Normals", true, PreferenceKeys.menuGeometry + 3)]
 		static bool MenuVerify_ConformFaceNormals()
 		{
 			var instance = EditorToolbarLoader.GetInstance<ConformFaceNormals>();
@@ -292,7 +292,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Geometry/Delete Faces ", true)]
+		[MenuItem(k_MenuPrefix + "Geometry/Delete Faces [⌫]", true, PreferenceKeys.menuGeometry + 3)]
 		static bool MenuVerify_DeleteFaces()
 		{
 			var instance = EditorToolbarLoader.GetInstance<DeleteFaces>();
@@ -310,7 +310,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Geometry/Detach Faces ", true)]
+		[MenuItem(k_MenuPrefix + "Geometry/Detach Faces", true, PreferenceKeys.menuGeometry + 3)]
 		static bool MenuVerify_DetachFaces()
 		{
 			var instance = EditorToolbarLoader.GetInstance<DetachFaces>();
@@ -325,7 +325,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Geometry/Duplicate Faces ", true)]
+		[MenuItem(k_MenuPrefix + "Geometry/Duplicate Faces", true, PreferenceKeys.menuGeometry + 3)]
 		static bool MenuVerify_DuplicateFaces()
 		{
 			var instance = EditorToolbarLoader.GetInstance<DuplicateFaces>();
@@ -340,7 +340,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Geometry/Extrude ", true)]
+		[MenuItem(k_MenuPrefix + "Geometry/Extrude %e", true, PreferenceKeys.menuGeometry + 3)]
 		static bool MenuVerify_Extrude()
 		{
 			var instance = EditorToolbarLoader.GetInstance<Extrude>();
@@ -355,7 +355,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Geometry/Fill Hole ", true)]
+		[MenuItem(k_MenuPrefix + "Geometry/Fill Hole", true, PreferenceKeys.menuGeometry + 3)]
 		static bool MenuVerify_FillHole()
 		{
 			var instance = EditorToolbarLoader.GetInstance<FillHole>();
@@ -370,7 +370,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Geometry/Flip Face Edge ", true)]
+		[MenuItem(k_MenuPrefix + "Geometry/Flip Face Edge", true, PreferenceKeys.menuGeometry + 3)]
 		static bool MenuVerify_FlipFaceEdge()
 		{
 			var instance = EditorToolbarLoader.GetInstance<FlipFaceEdge>();
@@ -385,7 +385,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Geometry/Flip Face Normals ", true)]
+		[MenuItem(k_MenuPrefix + "Geometry/Flip Face Normals &n", true, PreferenceKeys.menuGeometry + 3)]
 		static bool MenuVerify_FlipFaceNormals()
 		{
 			var instance = EditorToolbarLoader.GetInstance<FlipFaceNormals>();
@@ -400,7 +400,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Geometry/Insert Edge Loop ", true)]
+		[MenuItem(k_MenuPrefix + "Geometry/Insert Edge Loop &u", true, PreferenceKeys.menuGeometry + 3)]
 		static bool MenuVerify_InsertEdgeLoop()
 		{
 			var instance = EditorToolbarLoader.GetInstance<InsertEdgeLoop>();
@@ -415,7 +415,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Geometry/Merge Faces ", true)]
+		[MenuItem(k_MenuPrefix + "Geometry/Merge Faces", true, PreferenceKeys.menuGeometry + 3)]
 		static bool MenuVerify_MergeFaces()
 		{
 			var instance = EditorToolbarLoader.GetInstance<MergeFaces>();
@@ -430,7 +430,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Geometry/Offset Elements ", true)]
+		[MenuItem(k_MenuPrefix + "Geometry/Offset Elements", true, PreferenceKeys.menuGeometry + 3)]
 		static bool MenuVerify_OffsetElements()
 		{
 			var instance = EditorToolbarLoader.GetInstance<OffsetElements>();
@@ -445,7 +445,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Geometry/Set Pivot To Selection ", true)]
+		[MenuItem(k_MenuPrefix + "Geometry/Set Pivot To Selection %j", true, PreferenceKeys.menuGeometry + 3)]
 		static bool MenuVerify_SetPivotToSelection()
 		{
 			var instance = EditorToolbarLoader.GetInstance<SetPivotToSelection>();
@@ -460,7 +460,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Geometry/Smart Connect ", true)]
+		[MenuItem(k_MenuPrefix + "Geometry/Smart Connect &e", true, PreferenceKeys.menuGeometry + 3)]
 		static bool MenuVerify_SmartConnect()
 		{
 			var instance = EditorToolbarLoader.GetInstance<SmartConnect>();
@@ -475,7 +475,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Geometry/Smart Subdivide ", true)]
+		[MenuItem(k_MenuPrefix + "Geometry/Smart Subdivide &s", true, PreferenceKeys.menuGeometry + 3)]
 		static bool MenuVerify_SmartSubdivide()
 		{
 			var instance = EditorToolbarLoader.GetInstance<SmartSubdivide>();
@@ -490,7 +490,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Geometry/Split Vertices ", true)]
+		[MenuItem(k_MenuPrefix + "Geometry/Split Vertices &x", true, PreferenceKeys.menuGeometry + 3)]
 		static bool MenuVerify_SplitVertices()
 		{
 			var instance = EditorToolbarLoader.GetInstance<SplitVertices>();
@@ -505,7 +505,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Geometry/Triangulate Faces ", true)]
+		[MenuItem(k_MenuPrefix + "Geometry/Triangulate Faces", true, PreferenceKeys.menuGeometry + 3)]
 		static bool MenuVerify_TriangulateFaces()
 		{
 			var instance = EditorToolbarLoader.GetInstance<TriangulateFaces>();
@@ -520,7 +520,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Geometry/Weld Vertices ", true)]
+		[MenuItem(k_MenuPrefix + "Geometry/Weld Vertices &v", true, PreferenceKeys.menuGeometry + 3)]
 		static bool MenuVerify_WeldVertices()
 		{
 			var instance = EditorToolbarLoader.GetInstance<WeldVertices>();
@@ -535,7 +535,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Interaction/Toggle Drag Rect Mode ", true)]
+		[MenuItem(k_MenuPrefix + "Interaction/Toggle Drag Rect Mode", true, PreferenceKeys.menuSelection + 1)]
 		static bool MenuVerify_ToggleDragRectMode()
 		{
 			var instance = EditorToolbarLoader.GetInstance<ToggleDragRectMode>();
@@ -550,7 +550,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Interaction/Toggle Drag Selection Mode ", true)]
+		[MenuItem(k_MenuPrefix + "Interaction/Toggle Drag Selection Mode", true, PreferenceKeys.menuSelection + 1)]
 		static bool MenuVerify_ToggleDragSelectionMode()
 		{
 			var instance = EditorToolbarLoader.GetInstance<ToggleDragSelectionMode>();
@@ -565,7 +565,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Interaction/Toggle Handle Orientation ", true)]
+		[MenuItem(k_MenuPrefix + "Interaction/Toggle Handle Orientation [p]", true, PreferenceKeys.menuSelection + 1)]
 		static bool MenuVerify_ToggleHandleOrientation()
 		{
 			var instance = EditorToolbarLoader.GetInstance<ToggleHandleOrientation>();
@@ -583,7 +583,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Interaction/Toggle Select Back Faces ", true)]
+		[MenuItem(k_MenuPrefix + "Interaction/Toggle Select Back Faces", true, PreferenceKeys.menuSelection + 1)]
 		static bool MenuVerify_ToggleSelectBackFaces()
 		{
 			var instance = EditorToolbarLoader.GetInstance<ToggleSelectBackFaces>();
@@ -598,7 +598,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Object/Center Pivot ", true)]
+		[MenuItem(k_MenuPrefix + "Object/Center Pivot", true, PreferenceKeys.menuGeometry + 2)]
 		static bool MenuVerify_CenterPivot()
 		{
 			var instance = EditorToolbarLoader.GetInstance<CenterPivot>();
@@ -613,7 +613,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Object/Conform Object Normals ", true)]
+		[MenuItem(k_MenuPrefix + "Object/Conform Object Normals", true, PreferenceKeys.menuGeometry + 2)]
 		static bool MenuVerify_ConformObjectNormals()
 		{
 			var instance = EditorToolbarLoader.GetInstance<ConformObjectNormals>();
@@ -628,7 +628,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Object/Flip Object Normals ", true)]
+		[MenuItem(k_MenuPrefix + "Object/Flip Object Normals", true, PreferenceKeys.menuGeometry + 2)]
 		static bool MenuVerify_FlipObjectNormals()
 		{
 			var instance = EditorToolbarLoader.GetInstance<FlipObjectNormals>();
@@ -643,7 +643,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Object/Freeze Transform ", true)]
+		[MenuItem(k_MenuPrefix + "Object/Freeze Transform", true, PreferenceKeys.menuGeometry + 2)]
 		static bool MenuVerify_FreezeTransform()
 		{
 			var instance = EditorToolbarLoader.GetInstance<FreezeTransform>();
@@ -658,7 +658,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Object/Merge Objects ", true)]
+		[MenuItem(k_MenuPrefix + "Object/Merge Objects", true, PreferenceKeys.menuGeometry + 2)]
 		static bool MenuVerify_MergeObjects()
 		{
 			var instance = EditorToolbarLoader.GetInstance<MergeObjects>();
@@ -673,7 +673,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Object/Mirror Objects ", true)]
+		[MenuItem(k_MenuPrefix + "Object/Mirror Objects", true, PreferenceKeys.menuGeometry + 2)]
 		static bool MenuVerify_MirrorObjects()
 		{
 			var instance = EditorToolbarLoader.GetInstance<MirrorObjects>();
@@ -688,7 +688,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Object/Pro Builderize ", true)]
+		[MenuItem(k_MenuPrefix + "Object/Pro Builderize", true, PreferenceKeys.menuGeometry + 2)]
 		static bool MenuVerify_ProBuilderize()
 		{
 			var instance = EditorToolbarLoader.GetInstance<ProBuilderize>();
@@ -703,7 +703,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Object/Set Collider ", true)]
+		[MenuItem(k_MenuPrefix + "Object/Set Collider", true, PreferenceKeys.menuGeometry + 2)]
 		static bool MenuVerify_SetCollider()
 		{
 			var instance = EditorToolbarLoader.GetInstance<SetCollider>();
@@ -718,7 +718,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Object/Set Trigger ", true)]
+		[MenuItem(k_MenuPrefix + "Object/Set Trigger", true, PreferenceKeys.menuGeometry + 2)]
 		static bool MenuVerify_SetTrigger()
 		{
 			var instance = EditorToolbarLoader.GetInstance<SetTrigger>();
@@ -733,7 +733,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Object/Subdivide Object ", true)]
+		[MenuItem(k_MenuPrefix + "Object/Subdivide Object", true, PreferenceKeys.menuGeometry + 2)]
 		static bool MenuVerify_SubdivideObject()
 		{
 			var instance = EditorToolbarLoader.GetInstance<SubdivideObject>();
@@ -748,7 +748,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Object/Triangulate Object ", true)]
+		[MenuItem(k_MenuPrefix + "Object/Triangulate Object", true, PreferenceKeys.menuGeometry + 2)]
 		static bool MenuVerify_TriangulateObject()
 		{
 			var instance = EditorToolbarLoader.GetInstance<TriangulateObject>();
@@ -763,7 +763,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Selection/Grow Selection ", true)]
+		[MenuItem(k_MenuPrefix + "Selection/Grow Selection &g", true, PreferenceKeys.menuSelection + 0)]
 		static bool MenuVerify_GrowSelection()
 		{
 			var instance = EditorToolbarLoader.GetInstance<GrowSelection>();
@@ -778,7 +778,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Selection/Invert Selection ", true)]
+		[MenuItem(k_MenuPrefix + "Selection/Invert Selection %#i", true, PreferenceKeys.menuSelection + 0)]
 		static bool MenuVerify_InvertSelection()
 		{
 			var instance = EditorToolbarLoader.GetInstance<InvertSelection>();
@@ -793,7 +793,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Selection/Select Hole ", true)]
+		[MenuItem(k_MenuPrefix + "Selection/Select Hole", true, PreferenceKeys.menuSelection + 0)]
 		static bool MenuVerify_SelectHole()
 		{
 			var instance = EditorToolbarLoader.GetInstance<SelectHole>();
@@ -808,7 +808,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Selection/Select Loop ", true)]
+		[MenuItem(k_MenuPrefix + "Selection/Select Loop &l", true, PreferenceKeys.menuSelection + 0)]
 		static bool MenuVerify_SelectLoop()
 		{
 			var instance = EditorToolbarLoader.GetInstance<SelectLoop>();
@@ -823,7 +823,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Selection/Select Material ", true)]
+		[MenuItem(k_MenuPrefix + "Selection/Select Material", true, PreferenceKeys.menuSelection + 0)]
 		static bool MenuVerify_SelectMaterial()
 		{
 			var instance = EditorToolbarLoader.GetInstance<SelectMaterial>();
@@ -838,7 +838,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Selection/Select Ring ", true)]
+		[MenuItem(k_MenuPrefix + "Selection/Select Ring &r", true, PreferenceKeys.menuSelection + 0)]
 		static bool MenuVerify_SelectRing()
 		{
 			var instance = EditorToolbarLoader.GetInstance<SelectRing>();
@@ -853,7 +853,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Selection/Select Smoothing Group ", true)]
+		[MenuItem(k_MenuPrefix + "Selection/Select Smoothing Group", true, PreferenceKeys.menuSelection + 0)]
 		static bool MenuVerify_SelectSmoothingGroup()
 		{
 			var instance = EditorToolbarLoader.GetInstance<SelectSmoothingGroup>();
@@ -868,7 +868,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Selection/Select Vertex Color ", true)]
+		[MenuItem(k_MenuPrefix + "Selection/Select Vertex Color", true, PreferenceKeys.menuSelection + 0)]
 		static bool MenuVerify_SelectVertexColor()
 		{
 			var instance = EditorToolbarLoader.GetInstance<SelectVertexColor>();
@@ -883,7 +883,7 @@ namespace UnityEditor.ProBuilder
 				EditorUtility.ShowNotification(instance.DoAction().notification);
 		}
 
-		[MenuItem(k_MenuPrefix + "Selection/Shrink Selection ", true)]
+		[MenuItem(k_MenuPrefix + "Selection/Shrink Selection &#g", true, PreferenceKeys.menuSelection + 0)]
 		static bool MenuVerify_ShrinkSelection()
 		{
 			var instance = EditorToolbarLoader.GetInstance<ShrinkSelection>();

--- a/Editor/EditorCore/PolyShapeEditor.cs
+++ b/Editor/EditorCore/PolyShapeEditor.cs
@@ -308,6 +308,20 @@ namespace UnityEditor.ProBuilder
             DoPointPlacement();
         }
 
+        // Returns a local space point,
+        Vector3 GetPointInLocalSpace(Vector3 point)
+        {
+            var trs = polygon.transform;
+
+            if (polygon.isOnGrid)
+            {
+                Vector3 snapMask = ProBuilderSnapping.GetSnappingMaskBasedOnNormalVector(m_Plane.normal);
+                return trs.InverseTransformPoint(ProGridsInterface.ProGridsSnap(point, snapMask));
+            }
+
+            return trs.InverseTransformPoint(point);
+        }
+
         void DoPointPlacement()
         {
             Event evt = Event.current;
@@ -324,8 +338,7 @@ namespace UnityEditor.ProBuilder
                     if (m_Plane.Raycast(ray, out hitDistance))
                     {
                         evt.Use();
-
-                        polygon.m_Points[m_SelectedIndex] = ProGridsInterface.ProGridsSnap(polygon.transform.InverseTransformPoint(ray.GetPoint(hitDistance)), Vector3.one);
+                        polygon.m_Points[m_SelectedIndex] = GetPointInLocalSpace(ray.GetPoint(hitDistance));
                         RebuildPolyShapeMesh(false);
                         SceneView.RepaintAll();
                     }
@@ -370,7 +383,7 @@ namespace UnityEditor.ProBuilder
                             polygon.transform.rotation = Quaternion.LookRotation(cameraFacingPlaneNormal) * Quaternion.Euler(new Vector3(90f, 0f, 0f));
                         }
 
-                        Vector3 point = ProGridsInterface.ProGridsSnap(polygon.transform.InverseTransformPoint(hit), Vector3.one);
+                        Vector3 point = GetPointInLocalSpace(hit);
 
                         if (polygon.m_Points.Count > 2 && Math.Approx3(polygon.m_Points[0], point))
                         {
@@ -438,13 +451,6 @@ namespace UnityEditor.ProBuilder
         void SetupInputPlane(Vector2 mousePosition)
         {
             m_Plane = EditorHandleUtility.FindBestPlane(mousePosition);
-
-            if (ProGridsInterface.SnapEnabled())
-            {
-                m_Plane.SetNormalAndPosition(
-                    m_Plane.normal,
-                    ProGridsInterface.ProGridsSnap(m_Plane.normal * -m_Plane.distance));
-            }
 
             var planeNormal = m_Plane.normal;
             var planeCenter = m_Plane.normal * -m_Plane.distance;
@@ -547,9 +553,7 @@ namespace UnityEditor.ProBuilder
                     if (EditorGUI.EndChangeCheck())
                     {
                         UndoUtility.RecordObject(polygon, "Move Polygon Shape Point");
-
-                        Vector3 snapMask = ProBuilderSnapping.GetSnappingMaskBasedOnNormalVector(m_Plane.normal);
-                        polygon.m_Points[ii] = ProGridsInterface.ProGridsSnap(trs.InverseTransformPoint(point), snapMask);
+                        polygon.m_Points[ii] = GetPointInLocalSpace(point);
                         OnBeginVertexMovement();
                         RebuildPolyShapeMesh(false);
                     }

--- a/Editor/EditorCore/ShapeEditor.cs
+++ b/Editor/EditorCore/ShapeEditor.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using UnityEditor.Experimental.SceneManagement;
 using UnityEngine;
 using UnityEngine.ProBuilder;
+using PMath = UnityEngine.ProBuilder.Math;
 using UnityEditor.SettingsManagement;
 using UnityEngine.ProBuilder.MeshOperations;
 using UnityEngine.SceneManagement;
@@ -34,6 +35,8 @@ namespace UnityEditor.ProBuilder
             GetWindow<ShapeEditor>("Shape Tool");
         }
 
+        static readonly Vector3 k_MinShapeDimensions = new Vector3(.001f, .001f, .001f);
+        static readonly Vector3 k_MaxShapeDimensions = new Vector3(1000000f, 1000000f, 1000000f);
         Vector2 m_Scroll = Vector2.zero;
         [SettingsKey("ShapeEditor.s_CurrentIndex")]
         static Pref<int> s_CurrentIndex = new Pref<int>("ShapeEditor.s_CurrentIndex", 0, SettingsScope.User);
@@ -255,7 +258,7 @@ namespace UnityEditor.ProBuilder
             public override void OnGUI()
             {
                 s_CubeSize.value = EditorGUILayout.Vector3Field("Size", s_CubeSize);
-                s_CubeSize.value = Vector3.Max(s_CubeSize.value, new Vector3(.001f, .001f, .001f));
+                s_CubeSize.value = Vector3.Min(Vector3.Max(s_CubeSize.value, k_MinShapeDimensions), k_MaxShapeDimensions);
             }
 
             public override ProBuilderMesh Build(bool preview = false)
@@ -288,7 +291,7 @@ namespace UnityEditor.ProBuilder
             public override void OnGUI()
             {
                 s_PrismSize.value = EditorGUILayout.Vector3Field("Size", s_PrismSize);
-                s_PrismSize.value = Vector3.Max(s_PrismSize.value, new Vector3(.001f, .001f, .001f));
+                s_PrismSize.value = Vector3.Min(Vector3.Max(s_PrismSize.value, k_MinShapeDimensions), k_MaxShapeDimensions);
             }
 
             public override ProBuilderMesh Build(bool preview = false)
@@ -313,6 +316,7 @@ namespace UnityEditor.ProBuilder
             public override void OnGUI()
             {
                 s_Steps.value = (int)Mathf.Max(UI.EditorGUIUtility.FreeSlider("Steps", s_Steps, 2, 64), 2);
+                s_Steps.value = PMath.Clamp(s_Steps, 2, 512);
                 s_Sides.value = EditorGUILayout.Toggle("Build Sides", s_Sides);
                 s_Circumference.value = EditorGUILayout.Slider("Curvature", s_Circumference, 0f, 360f);
 
@@ -348,7 +352,7 @@ namespace UnityEditor.ProBuilder
                     size.z = UI.EditorGUIUtility.FreeSlider("Depth", size.z, 0.01f, 10f);
                 }
 
-                s_Size.value = size;
+                s_Size.value = PMath.Clamp(size, k_MinShapeDimensions, k_MaxShapeDimensions);
             }
 
             public override ProBuilderMesh Build(bool preview = false)
@@ -389,15 +393,17 @@ namespace UnityEditor.ProBuilder
             public override void OnGUI()
             {
                 s_Radius.value = EditorGUILayout.FloatField("Radius", s_Radius);
-                s_Radius.value = Mathf.Clamp(s_Radius, .01f, Mathf.Infinity);
+                s_Radius.value = Mathf.Clamp(s_Radius, k_MinShapeDimensions.x, k_MinShapeDimensions.x);
 
                 s_AxisSegments.value = EditorGUILayout.IntField("Number of Sides", s_AxisSegments);
-                s_AxisSegments.value = UnityEngine.ProBuilder.Math.Clamp(s_AxisSegments, 4, 48);
+                s_AxisSegments.value = PMath.Clamp(s_AxisSegments, 4, 128);
 
                 s_Height.value = EditorGUILayout.FloatField("Height", s_Height);
+                s_Height.value = Mathf.Clamp(s_Height.value, k_MinShapeDimensions.x, k_MaxShapeDimensions.x);
 
                 s_HeightSegments.value = EditorGUILayout.IntField("Height Segments", s_HeightSegments);
                 s_HeightSegments.value = UnityEngine.ProBuilder.Math.Clamp(s_HeightSegments, 0, 48);
+                s_HeightSegments.value = Mathf.Clamp(s_HeightSegments.value, 0, 128);
 
                 s_Smooth.value = EditorGUILayout.Toggle("Smooth", s_Smooth);
 
@@ -482,21 +488,14 @@ namespace UnityEditor.ProBuilder
 
                 s_Width.value = EditorGUILayout.FloatField("Width", s_Width);
                 s_Height.value = EditorGUILayout.FloatField("Length", s_Height);
-
-                if (s_Height < 1f)
-                    s_Height.value = 1f;
-
-                if (s_Width < 1f)
-                    s_Width.value = 1f;
+                s_Width.value = Mathf.Clamp(s_Width.value, k_MinShapeDimensions.x, k_MaxShapeDimensions.x);
+                s_Height.value = Mathf.Clamp(s_Height.value, k_MinShapeDimensions.x, k_MaxShapeDimensions.x);
 
                 s_WidthSegments.value = EditorGUILayout.IntField("Width Segments", s_WidthSegments);
                 s_HeightSegments.value = EditorGUILayout.IntField("Length Segments", s_HeightSegments);
 
-                if (s_WidthSegments < 0)
-                    s_WidthSegments.value = 0;
-
-                if (s_HeightSegments < 0)
-                    s_HeightSegments.value = 0;
+                s_WidthSegments.value = PMath.Clamp(s_WidthSegments.value, 0, 512);
+                s_HeightSegments.value = PMath.Clamp(s_HeightSegments.value, 0, 512);
             }
 
             public override ProBuilderMesh Build(bool preview = false)
@@ -532,15 +531,12 @@ namespace UnityEditor.ProBuilder
                 s_AxisSegments.value = EditorGUILayout.IntField("Number of Sides", s_AxisSegments);
                 s_HeightSegments.value = EditorGUILayout.IntField("Height Segments", s_HeightSegments);
 
-                if (s_Radius < .1f)
-                    s_Radius.value = .1f;
-
-                if (s_Height < .1f)
-                    s_Height.value = .1f;
-
+                s_Radius.value = Mathf.Clamp(s_Radius.value, k_MinShapeDimensions.x, k_MaxShapeDimensions.x);
+                s_Height.value = Mathf.Clamp(s_Height.value, k_MinShapeDimensions.x, k_MaxShapeDimensions.x);
                 s_HeightSegments.value = (int)Mathf.Clamp(s_HeightSegments, 0f, 32f);
                 s_Thickness.value = Mathf.Clamp(s_Thickness, .01f, s_Radius - .01f);
-                s_AxisSegments.value = (int)Mathf.Clamp(s_AxisSegments, 3f, 32f);
+                s_AxisSegments.value = PMath.Clamp(s_AxisSegments, 3, 64);
+                s_HeightSegments.value = PMath.Clamp(s_HeightSegments.value, 0, 128);
             }
 
             public override ProBuilderMesh Build(bool preview = false)
@@ -571,13 +567,9 @@ namespace UnityEditor.ProBuilder
                 s_Height.value = EditorGUILayout.FloatField("Height", s_Height);
                 s_AxisSegments.value = EditorGUILayout.IntField("Number of Sides", s_AxisSegments);
 
-                if (s_Radius < .1f)
-                    s_Radius.value = .1f;
-
-                if (s_Height < .1f)
-                    s_Height.value = .1f;
-
-                s_AxisSegments.value = (int)Mathf.Clamp(s_AxisSegments, 3f, 32f);
+                s_Radius.value = Mathf.Clamp(s_Radius.value, k_MinShapeDimensions.x, k_MaxShapeDimensions.x);
+                s_Height.value = Mathf.Clamp(s_Height.value, k_MinShapeDimensions.x, k_MaxShapeDimensions.x);
+                s_AxisSegments.value = PMath.Clamp(s_AxisSegments, 3, 64);
             }
 
             public override ProBuilderMesh Build(bool preview = false)
@@ -661,8 +653,9 @@ namespace UnityEditor.ProBuilder
 
             public override void OnGUI()
             {
-                s_Radius.value = EditorGUILayout.Slider("Radius", s_Radius, 0.01f, 10f);
-                s_Subdivisions.value = (int) EditorGUILayout.Slider("Subdivisions", s_Subdivisions, 0, 4);
+                s_Radius.value = EditorGUILayout.FloatField("Radius", s_Radius.value);
+                s_Radius.value = Mathf.Clamp(s_Radius.value, k_MinShapeDimensions.x, k_MaxShapeDimensions.x);
+                s_Subdivisions.value = (int) EditorGUILayout.Slider("Subdivisions", s_Subdivisions, 0, 5);
             }
 
             public override ProBuilderMesh Build(bool preview = false)
@@ -707,10 +700,10 @@ namespace UnityEditor.ProBuilder
 
             public override void OnGUI()
             {
-                s_Rows.value = (int)EditorGUILayout.IntSlider(
+                s_Rows.value = EditorGUILayout.IntSlider(
                         new GUIContent("Rows", "How many rows the torus will have.  More equates to smoother geometry."),
                         s_Rows, 3, 32);
-                s_Columns.value = (int)EditorGUILayout.IntSlider(
+                s_Columns.value = EditorGUILayout.IntSlider(
                         new GUIContent("Columns",
                             "How many columns the torus will have.  More equates to smoother geometry."), s_Columns, 3, 64);
 
@@ -719,11 +712,9 @@ namespace UnityEditor.ProBuilder
                 if (!s_UseInnerOuterMethod)
                 {
                     s_Radius.value = EditorGUILayout.FloatField("Radius", s_Radius);
-
-                    if (s_Radius < .001f)
-                        s_Radius.value = .001f;
-
+                    s_Radius.value = Mathf.Clamp(s_Radius.value, k_MinShapeDimensions.x, k_MaxShapeDimensions.x);
                     s_TubeRadius.value = UI.EditorGUIUtility.Slider(new GUIContent("Tube Radius", "How thick the donut will be."), s_TubeRadius, .01f, s_Radius);
+                    s_TubeRadius.value = Mathf.Clamp(s_TubeRadius.value, k_MinShapeDimensions.x, k_MaxShapeDimensions.x);
                 }
                 else
                 {

--- a/Editor/EditorCore/ShapeEditor.cs
+++ b/Editor/EditorCore/ShapeEditor.cs
@@ -178,7 +178,7 @@ namespace UnityEditor.ProBuilder
                 DestroyImmediate(m_PreviewObject);
 
                 // When entering play mode the editor tracker isn't rebuilt before the Inspector redraws, meaning the
-                // preview object is still assumed to be in the selection. Flush the selection changes by rebuilding
+                // preview object is still assumed to be in the selection. Flushing the selection changes by rebuilding
                 // active editor tracker fixes this.
 #if UNITY_2019_3_OR_NEWER
                 ActiveEditorTracker.RebuildAllIfNecessary();
@@ -199,8 +199,9 @@ namespace UnityEditor.ProBuilder
 
             if (m_PreviewObject)
             {
-                var mf = m_PreviewObject.GetComponent<MeshFilter>();
-                if (mf.sharedMesh != null)
+                if (!m_PreviewObject.TryGetComponent(out MeshFilter mf))
+                    mf = m_PreviewObject.AddComponent<MeshFilter>();
+                if(mf.sharedMesh != null)
                     DestroyImmediate(mf.sharedMesh);
                 m_PreviewObject.GetComponent<MeshFilter>().sharedMesh = umesh;
                 mesh.preserveMeshAssetOnDestroy = true;

--- a/Runtime/Core/Math.cs
+++ b/Runtime/Core/Math.cs
@@ -1313,6 +1313,11 @@ namespace UnityEngine.ProBuilder
             return value<lowerBound? lowerBound : value> upperBound ? upperBound : value;
         }
 
+        internal static Vector3 Clamp(Vector3 value, Vector3 lowerBound, Vector3 upperBound)
+        {
+            return Vector3.Max(Vector3.Min(value, upperBound), lowerBound);
+        }
+
         internal static Vector3 ToSignedMask(this Vector3 vec, float delta = k_FltEpsilon)
         {
             return new Vector3(

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     }
   ],
   "dependencies": {
-    "com.unity.settings-manager": "1.0.2"
+    "com.unity.settings-manager": "1.0.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- [x] https://fogbugz.unity3d.com/f/cases/1213742/ Delete menu item incorrectly shows as available
- [x] https://fogbugz.unity3d.com/f/cases/1192479/ Moving UV positions with the handle now updates the UV inspector Offset values
- [x] https://fogbugz.unity3d.com/f/cases/1176370/ Entering play mode with Shape Editor open creates a new shape in the scene
- [x] https://fogbugz.unity3d.com/f/cases/1218413/ Fixed Poly Shape input incorrectly snapping vertices when input plane is not on grid
- [x] Clamp all Shape Editor values to sane values, preventing (lengthy) editor freezes. In some cases a slight freeze is allowed, ex Sphere subdivisions.
- [x] Reference Settings Manager 1.0.1 until 1.0.2 lands in trunk.