### PR TITLE
Fix ProBuilderMesh.sharedTextureLookup throwing exception at runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Bug Fixes
+
+- Fix `ProBuilderMesh.sharedTextureLookup` throwing a null reference exception when accessed from runtime.
+
 ## [4.3.0-preview.5] - 2020-03-05
 
 ### Features

--- a/Runtime/Core/ProBuilderMesh.cs
+++ b/Runtime/Core/ProBuilderMesh.cs
@@ -352,6 +352,8 @@ namespace UnityEngine.ProBuilder
                 if ((m_CacheValid & CacheValidState.SharedTexture) != CacheValidState.SharedTexture)
                 {
                     m_CacheValid |= CacheValidState.SharedTexture;
+                    if (m_SharedTextureLookup == null)
+                        m_SharedTextureLookup = new Dictionary<int, int>();
                     SharedVertex.GetSharedVertexLookup(m_SharedTextures, m_SharedTextureLookup);
                 }
 


### PR DESCRIPTION
It was just missing a null check. In the editor it is caught by the cache invalidation, but since that doesn't run at runtime it was never initializing.