### PR TITLE
Fix "New Shape" menu action always building a cube

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Bug Fixes
+
+- Fixed `New Shape` menu item always creating a Cube instead of the last selected shape.
+
 ## [4.3.0-preview.6] - 2020-03-23
 
 ### Bug Fixes

--- a/Editor/EditorCore/ProBuilderSettingsProvider.cs
+++ b/Editor/EditorCore/ProBuilderSettingsProvider.cs
@@ -13,18 +13,17 @@ namespace UnityEditor.ProBuilder
         static SettingsProvider CreateSettingsProvider()
         {
             var provider = new UserSettingsProvider(k_PreferencesPath,
-                    ProBuilderSettings.instance,
-                    new[] { typeof(ProBuilderSettingsProvider).Assembly });
+                ProBuilderSettings.instance,
+                new[] { typeof(ProBuilderSettingsProvider).Assembly });
 
             ProBuilderSettings.instance.afterSettingsSaved += () =>
-                {
-                    if (ProBuilderEditor.instance != null)
-                        ProBuilderEditor.ReloadSettings();
-                };
+            {
+                if(ProBuilderEditor.instance != null)
+                    ProBuilderEditor.ReloadSettings();
+            };
 
             return provider;
         }
-
 #else
 
         [NonSerialized]

--- a/Editor/EditorCore/ShapeEditor.cs
+++ b/Editor/EditorCore/ShapeEditor.cs
@@ -150,14 +150,24 @@ namespace UnityEditor.ProBuilder
 
         void CreateSelectedShape(bool forceCloseWindow = false)
         {
-            var res = s_ShapeBuilders[s_CurrentIndex].Build();
-            Undo.RegisterCreatedObjectUndo(res.gameObject, "Create Shape");
-            EditorUtility.InitObject(res);
+            var res = CreateActiveShape();
             ApplyPreviewTransform(res);
             DestroyPreviewObject(true);
 
             if (forceCloseWindow || s_CloseWindowAfterCreateShape)
                 Close();
+        }
+
+        /// <summary>
+        /// Create a shape with the last set <see cref="ShapeEditor"/> parameters.
+        /// </summary>
+        /// <returns>A reference to the <see cref="ProBuilderMesh"/> of the newly created GameObject.</returns>
+        public static ProBuilderMesh CreateActiveShape()
+        {
+            var res = s_ShapeBuilders[PMath.Clamp(s_CurrentIndex, 0, s_ShapeBuilders.Length - 1)].Build();
+            Undo.RegisterCreatedObjectUndo(res.gameObject, "Create Shape");
+            EditorUtility.InitObject(res);
+            return res;
         }
 
         void DestroyPreviewObject(bool immediate)

--- a/Editor/MenuActions/Editors/OpenShapeEditor.cs
+++ b/Editor/MenuActions/Editors/OpenShapeEditor.cs
@@ -34,7 +34,7 @@ namespace UnityEditor.ProBuilder.Actions
 
         public override ActionResult DoAction()
         {
-            ShapeEditor.MenuCreateCube();
+            ShapeEditor.CreateActiveShape();
             return new ActionResult(ActionResult.Status.Success, "Create Shape");
         }
 

--- a/Runtime/Core/Math.cs
+++ b/Runtime/Core/Math.cs
@@ -1310,7 +1310,11 @@ namespace UnityEngine.ProBuilder
         /// <returns>A value clamped with the range of lowerBound and upperBound.</returns>
         public static int Clamp(int value, int lowerBound, int upperBound)
         {
-            return value<lowerBound? lowerBound : value> upperBound ? upperBound : value;
+            return value < lowerBound
+                ? lowerBound
+                : value > upperBound
+                    ? upperBound
+                    : value;
         }
 
         internal static Vector3 Clamp(Vector3 value, Vector3 lowerBound, Vector3 upperBound)


### PR DESCRIPTION
The `New Shape` menu item now creates the last selected shape with it's last set parameters instead of always building a cube primitive with the default values.