### PR TITLE
Disable Driven Properties and MeshFilter DontSave flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Fixed `New Shape` menu item always creating a Cube instead of the last selected shape.
 
+### Changes
+
+- [Preview] Reverted fix for prefabs showing `MeshFilter` and `ProBuilderMesh.mesh` values as consistently dirty.
+
 ## [4.3.0-preview.6] - 2020-03-23
 
 ### Bug Fixes

--- a/Editor/EditorCore/UnityScenePostProcessor.cs
+++ b/Editor/EditorCore/UnityScenePostProcessor.cs
@@ -59,10 +59,11 @@ namespace UnityEditor.ProBuilder
 
                 GameObject gameObject = mesh.gameObject;
                 var entity = ProcessLegacyEntity(gameObject);
-                var filter = gameObject.DemandComponent<MeshFilter>();
 
+#if ENABLE_DRIVEN_PROPERTIES
                 // clear editor-only HideFlags and serialization ignores
                 mesh.ClearDrivenProperties();
+                var filter = gameObject.DemandComponent<MeshFilter>();
                 filter.hideFlags = HideFlags.None;
                 mesh.mesh.hideFlags = HideFlags.None;
 
@@ -71,6 +72,7 @@ namespace UnityEditor.ProBuilder
                 filter.sharedMesh = mesh.mesh;
                 if (mesh.TryGetComponent(out MeshCollider collider))
                     collider.sharedMesh = mesh.mesh;
+#endif
 
                 // early out if we're not planning to remove the ProBuilderMesh component
                 if (m_ScriptStripping == false)

--- a/Runtime/Core/ProBuilderMesh.cs
+++ b/Runtime/Core/ProBuilderMesh.cs
@@ -22,6 +22,8 @@ namespace UnityEngine.ProBuilder
     {
 #if ENABLE_DRIVEN_PROPERTIES
         internal const HideFlags k_MeshFilterHideFlags = HideFlags.DontSave | HideFlags.HideInInspector | HideFlags.NotEditable;
+#else
+        internal const HideFlags k_MeshFilterHideFlags = HideFlags.HideInInspector | HideFlags.NotEditable;
 #endif
 
         /// <summary>
@@ -158,7 +160,7 @@ namespace UnityEngine.ProBuilder
                 {
                     if (!gameObject.TryGetComponent<MeshFilter>(out m_MeshFilter))
                         return null;
-#if UNITY_EDITOR && ENABLE_DRIVEN_PROPERTIES
+#if UNITY_EDITOR
                     m_MeshFilter.hideFlags = k_MeshFilterHideFlags;
 #endif
                 }

--- a/Runtime/Core/ProBuilderMesh.cs
+++ b/Runtime/Core/ProBuilderMesh.cs
@@ -20,7 +20,9 @@ namespace UnityEngine.ProBuilder
 //    [MonoBehaviourIcon("Packages/com.unity.probuilder/Content/Icons/Scripts/ProBuilderMesh@64.png")]
     public sealed partial class ProBuilderMesh : MonoBehaviour
     {
+#if ENABLE_DRIVEN_PROPERTIES
         internal const HideFlags k_MeshFilterHideFlags = HideFlags.DontSave | HideFlags.HideInInspector | HideFlags.NotEditable;
+#endif
 
         /// <summary>
         /// Max number of UV channels that ProBuilderMesh format supports.
@@ -156,7 +158,7 @@ namespace UnityEngine.ProBuilder
                 {
                     if (!gameObject.TryGetComponent<MeshFilter>(out m_MeshFilter))
                         return null;
-#if UNITY_EDITOR
+#if UNITY_EDITOR && ENABLE_DRIVEN_PROPERTIES
                     m_MeshFilter.hideFlags = k_MeshFilterHideFlags;
 #endif
                 }

--- a/Runtime/Core/ProBuilderMeshFunction.cs
+++ b/Runtime/Core/ProBuilderMeshFunction.cs
@@ -24,6 +24,7 @@ namespace UnityEngine.ProBuilder
             InvalidateCaches();
         }
 
+#if ENABLE_DRIVEN_PROPERTIES
         // Using the internal callbacks here to avoid registering this component as "enable-able"
         void OnEnableINTERNAL()
         {
@@ -51,6 +52,7 @@ namespace UnityEngine.ProBuilder
             if(gameObject != null && gameObject.TryGetComponent(out MeshCollider meshCollider))
                 SerializationUtility.UnregisterDrivenProperty(this, meshCollider, "m_Mesh");
         }
+#endif
 #endif
 
         void Awake()
@@ -121,7 +123,7 @@ namespace UnityEngine.ProBuilder
         {
             if (filter == null)
                 m_MeshFilter = gameObject.AddComponent<MeshFilter>();
-#if UNITY_EDITOR
+#if UNITY_EDITOR && ENABLE_DRIVEN_PROPERTIES
             m_MeshFilter.hideFlags = k_MeshFilterHideFlags;
 #endif
             filter.sharedMesh = m_Mesh;
@@ -275,7 +277,9 @@ namespace UnityEngine.ProBuilder
             // if the mesh vertex count hasn't been modified, we can keep most of the mesh elements around
             if (mesh == null)
             {
+#if ENABLE_DRIVEN_PROPERTIES
                 SerializationUtility.RegisterDrivenProperty(this, this, "m_Mesh");
+#endif
                 mesh = new Mesh();
             }
             else if (mesh.vertexCount != vertexCount)
@@ -390,7 +394,9 @@ namespace UnityEngine.ProBuilder
 
             if(gameObject.TryGetComponent<MeshCollider>(out MeshCollider collider))
             {
+#if ENABLE_DRIVEN_PROPERTIES
                 SerializationUtility.RegisterDrivenProperty(this, collider, "m_Mesh");
+#endif
                 collider.sharedMesh = null;
                 collider.sharedMesh = mesh;
             }

--- a/Runtime/Core/ProBuilderMeshFunction.cs
+++ b/Runtime/Core/ProBuilderMeshFunction.cs
@@ -123,7 +123,7 @@ namespace UnityEngine.ProBuilder
         {
             if (filter == null)
                 m_MeshFilter = gameObject.AddComponent<MeshFilter>();
-#if UNITY_EDITOR && ENABLE_DRIVEN_PROPERTIES
+#if UNITY_EDITOR
             m_MeshFilter.hideFlags = k_MeshFilterHideFlags;
 #endif
             filter.sharedMesh = m_Mesh;

--- a/Runtime/Core/SerializationUtility.cs
+++ b/Runtime/Core/SerializationUtility.cs
@@ -1,3 +1,4 @@
+#if ENABLE_DRIVEN_PROPERTIES
 using System.Reflection;
 using System;
 using System.Diagnostics;
@@ -57,3 +58,4 @@ namespace UnityEngine.ProBuilder
         }
     }
 }
+#endif

--- a/Tests/Editor/Editor/ReflectedMethodsExist.cs
+++ b/Tests/Editor/Editor/ReflectedMethodsExist.cs
@@ -48,6 +48,7 @@ namespace UnityEngine.ProBuilder.EditorTests.Editor
             Assert.IsNotNull(mi);
         }
 
+#if ENABLE_DRIVEN_PROPERTIES
         [Test]
         public static void DrivenPropertyManager_RegisterProperty()
         {
@@ -59,6 +60,7 @@ namespace UnityEngine.ProBuilder.EditorTests.Editor
         {
             Assert.That(SerializationUtility.unregisterProperty, Is.Not.Null);
         }
+#endif
 
         [Test]
         public static void AnnotationUtility_SetIconEnabled()

--- a/Tests/Editor/Object/CreateDestroy.cs
+++ b/Tests/Editor/Object/CreateDestroy.cs
@@ -51,7 +51,7 @@ static class CreateDestroy
         LogAssert.NoUnexpectedReceived();
     }
 
-    [Test]
+    [Test, Ignore("Requires ENABLE_DRIVEN_PROPERTIES feature")]
     public static void CreatePrimitive_SetsMeshFilterHideFlags_DontSave()
     {
         var mesh = ShapeGenerator.CreateShape(ShapeType.Cube);

--- a/Tests/Editor/Object/PrefabTests.cs
+++ b/Tests/Editor/Object/PrefabTests.cs
@@ -28,7 +28,7 @@ public class PrefabTests
         AssetDatabase.DeleteAsset(path);
     }
 
-    [Test]
+    [Test, Ignore("Requires ENABLE_DRIVEN_PROPERTIES feature")]
     public void CreatePrefab_DoesNot_SerializeMeshFilter()
     {
         var prefab = CreatePrefab();
@@ -38,7 +38,7 @@ public class PrefabTests
 
     // this is just a smoke test to make sure that prefab behaviour hasn't changed. if this does not fail but
     // CreatePrefab_DoesNot_SerializeMeshFilter does, then it's a probuilder problem.
-    [Test]
+    [Test, Ignore("Requires ENABLE_DRIVEN_PROPERTIES feature")]
     public void CreatePrefab_FromUnityPrimitive_DoesNotInclude_ComponentsWith_HideFlagsDontSave()
     {
         var go = GameObject.CreatePrimitive(PrimitiveType.Cube);
@@ -56,7 +56,7 @@ public class PrefabTests
         AssetDatabase.DeleteAsset(prefabPath);
     }
 
-    [Test]
+    [Test, Ignore("Requires ENABLE_DRIVEN_PROPERTIES feature")]
     public void CreatePrefab_DoesNot_SerializeMeshColliderMeshProperty()
     {
         var prefabPath = AssetDatabase.GenerateUniqueAssetPath("Assets/PrefabTest.prefab");
@@ -81,7 +81,7 @@ public class PrefabTests
             AssetDatabase.DeleteAsset(prefabPath);
     }
 
-    [UnityTest]
+    [UnityTest, Ignore("Requires ENABLE_DRIVEN_PROPERTIES feature")]
     public IEnumerator Prefab_HasNoOverrides_WhenInstantiated()
     {
         var prefab = CreatePrefab();
@@ -97,7 +97,7 @@ public class PrefabTests
         DestroyPrefab(prefab);
     }
 
-    [UnityTest]
+    [UnityTest, Ignore("Requires ENABLE_DRIVEN_PROPERTIES feature")]
     public IEnumerator ModifyPrefabInstance_DoesNotSetDirty_MeshFilter()
     {
         var prefab = CreatePrefab();
@@ -121,7 +121,7 @@ public class PrefabTests
         DestroyPrefab(prefab);
     }
 
-    [UnityTest]
+    [UnityTest, Ignore("Requires ENABLE_DRIVEN_PROPERTIES feature")]
     public IEnumerator ModifyPrefabInstance_DoesNotSetDirty_MeshCollider_SharedMesh()
     {
         var prefab = CreatePrefab();


### PR DESCRIPTION
### Purpose of this PR

This feature was causing a lot of unnecessary mesh rebuilds due to the MeshFilter no longer serializing a reference the generated mesh. 

Most critically, it breaks the mesh persistence when entering play mode and prefab stages. This makes it nearly impossible to work with a ProBuilder created mesh within other systems.

### Comments to Reviewers

This feature is still in code behind a pre-processor flag. Once a fix is found for the mesh persistence issue we should re-enable this feature.