### PR TITLE
Editor/fix editormeshhandles null ref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Bug Fixes
 
 - [case: 1242263] Fixed `UV Editor` `Move` and `Rotate` tools throwing null reference exceptions as of Unity 2020.2.0a9.
-- Fixed exception on script reloads in the `EditorMeshHandles` class.
+- [case: 1251289] Fixed exception on script reloads in the `EditorMeshHandles` class.
+
 
 ## [4.3.0-preview.9] - 2020-05-03
 

--- a/Editor/EditorCore/ProBuilderEditor.cs
+++ b/Editor/EditorCore/ProBuilderEditor.cs
@@ -327,7 +327,7 @@ namespace UnityEditor.ProBuilder
 
             LoadSettings();
             InitGUI();
-            UpdateSelection();
+            EditorApplication.delayCall += () => UpdateSelection();
             SetOverrideWireframe(true);
 
             if (selectModeChanged != null)


### PR DESCRIPTION
### Purpose of this PR

Fixes a race condition in `ProBuilderEditor` and `EditorMeshHandles`

### Links

**Fogbugz:** https://fogbugz.unity3d.com/f/cases/1251289/
