### PR TITLE
fix compile error 2018.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Bug Fixes
+
+- Fixed compile error in Unity 2018.4.
+
 ## [4.4.0-preview.1] - 2020-06-29
 
 ### Features

--- a/Editor/EditorCore/ShapeEditor.cs
+++ b/Editor/EditorCore/ShapeEditor.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Linq;
-using System.Reflection;
 using UnityEditor.Experimental.SceneManagement;
 using UnityEngine;
 using UnityEngine.ProBuilder;


### PR DESCRIPTION
### Purpose of this PR

https://forum.unity.com/threads/probuilder-version-4-3-1-does-not-compile-in-older-unity-versions.909182/
