### PR TITLE
Ensure "ProBuilderize" is available at window init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [case: 1247270] Fixed `Null Reference Exception` when entering Prefab Stage after merging multiple `ProBuilderMesh`.
 - [case: 1252394] Fixed dragging selection with Ctrl problem (and key pressed problem in general).
 - Fixed Cylinder shape clamping segments to 48.
+- Ensure "ProBuilderize" action is enabled for current selection on opening main window
 
 ### Known Issues
 

--- a/Editor/EditorCore/EditorToolbar.cs
+++ b/Editor/EditorCore/EditorToolbar.cs
@@ -67,6 +67,8 @@ namespace UnityEditor.ProBuilder
             isIconMode = ProBuilderEditor.s_IsIconGui;
             this.window = ProBuilderEditor.instance;
             CalculateMaxIconSize();
+
+            MeshSelection.ClearElementSelection();
         }
 
         void OnDisable()

--- a/Editor/EditorCore/EditorToolbar.cs
+++ b/Editor/EditorCore/EditorToolbar.cs
@@ -67,8 +67,6 @@ namespace UnityEditor.ProBuilder
             isIconMode = ProBuilderEditor.s_IsIconGui;
             this.window = ProBuilderEditor.instance;
             CalculateMaxIconSize();
-
-            MeshSelection.ClearElementSelection();
         }
 
         void OnDisable()

--- a/Editor/MenuActions/Object/ProBuilderize.cs
+++ b/Editor/MenuActions/Object/ProBuilderize.cs
@@ -15,13 +15,17 @@ namespace UnityEditor.ProBuilder.Actions
 
         public ProBuilderize()
         {
-            MeshSelection.objectSelectionChanged += () =>
-                {
-                    // can't just check if any MeshFilter is present because we need to know whether or not it's already a
-                    // probuilder mesh
-                    int meshCount = Selection.transforms.SelectMany(x => x.GetComponentsInChildren<MeshFilter>()).Count();
-                    m_Enabled = meshCount > 0 && meshCount != MeshSelection.selectedObjectCount;
-                };
+            MeshSelection.objectSelectionChanged += OnObjectSelectionChanged;
+
+            OnObjectSelectionChanged(); // invoke once as we might already have a selection in Hierarchy
+        }
+
+        private void OnObjectSelectionChanged()
+        {
+            // can't just check if any MeshFilter is present because we need to know whether or not it's already a
+            // probuilder mesh
+            int meshCount = Selection.transforms.SelectMany(x => x.GetComponentsInChildren<MeshFilter>()).Count();
+            m_Enabled = meshCount > 0 && meshCount != MeshSelection.selectedObjectCount;
         }
 
         public override ToolbarGroup group


### PR DESCRIPTION
### Purpose of this PR

Currently, if you have an active selection in Hierarchy that hasn't been ProBuilder-ized yet and open the main window, the action is not enabled.

This PR enables the action immediately, instead of having to deselect the object and select it again so the action is finally enabled in the action palette.

### Comments to Reviewers

That's my first contribution, I hope I didn't forget anything and it's properly done, let me know otherwise !