### PR TITLE
fix TooltipEditor.Hide calling FindObjectsOfTypeAll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Bug Fixes
+
+- Fixed `TooltipEditor.Hide` affecting performance linearly with scene size.
+
+
 ## [4.4.0-preview.1] - 2020-06-21
 
 ### Features

--- a/Editor/EditorCore/TooltipEditor.cs
+++ b/Editor/EditorCore/TooltipEditor.cs
@@ -60,17 +60,10 @@ namespace UnityEditor.ProBuilder
             return s_Instance;
         }
 
-        // unlike highlander, this will hide
         public static void Hide()
         {
-            TooltipEditor[] windows = Resources.FindObjectsOfTypeAll<TooltipEditor>();
-
-            for (int i = 0; i < windows.Length; i++)
-            {
-                windows[i].Close();
-                GameObject.DestroyImmediate(windows[i]);
-                windows[i] = null;
-            }
+            if (s_Instance != null)
+                s_Instance.Close();
         }
 
         public static void Show(Rect rect, TooltipContent content)


### PR DESCRIPTION
### Purpose of this PR

Fixes an issue where calling `Tooltip.Hide` would negatively affect editor performance.