### PR TITLE
Fixed Shortcuts Not Being Saved in 2018.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Bug Fixes
+- [case: 1259506] Fixed shortcut not being saved in 2018.4.
+
 ## [4.4.0-preview.1] - 2020-06-21
 
 ### Features
@@ -26,7 +31,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [case: 1249056] Fixed Ctrl selection being inconsistent.
 - [case: 1247270] Fixed `Null Reference Exception` when entering Prefab Stage after merging multiple `ProBuilderMesh`.
 - [case: 1252394] Fixed dragging selection with Ctrl problem (and key pressed problem in general).
-- [case: 1259506] Fixed shortcut not being saved in 2018.4.
 - Fixed Cylinder shape clamping segments to 48.
 
 ### Known Issues

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [case: 1249056] Fixed Ctrl selection being inconsistent.
 - [case: 1247270] Fixed `Null Reference Exception` when entering Prefab Stage after merging multiple `ProBuilderMesh`.
 - [case: 1252394] Fixed dragging selection with Ctrl problem (and key pressed problem in general).
+- [case: 1259506] Fixed shortcut not being saved in 2018.4.
 - Fixed Cylinder shape clamping segments to 48.
 
 ### Known Issues

--- a/Editor/EditorCore/ShortcutManager.cs
+++ b/Editor/EditorCore/ShortcutManager.cs
@@ -88,6 +88,7 @@ namespace UnityEditor.ProBuilder
 
         static void ShortcutEditPanel()
         {
+            EditorGUI.BeginChangeCheck();
             s_SelectedIndex = Math.Min(Math.Max(0, s_SelectedIndex), s_Shortcuts.Length - 1);
 
             GUILayout.Label("Key", EditorStyles.boldLabel);
@@ -105,6 +106,8 @@ namespace UnityEditor.ProBuilder
             GUILayout.Label("Description", EditorStyles.boldLabel);
 
             GUILayout.Label(s_Shortcuts[s_SelectedIndex].description, EditorStyles.wordWrappedLabel);
+            if (EditorGUI.EndChangeCheck())
+                ProBuilderEditor.s_Shortcuts.ApplyModifiedProperties();
         }
     }
 }


### PR DESCRIPTION
### Purpose of this PR

Preferences are normally change when the value is set but in the case of shortcut we modify the array directly. This PR ensure that changing the shortcut from the UI saves the changes.

### Links

**Fogbugz:** [case#1259506](https://fogbugz.unity3d.com/f/cases/1259506/)