### PR TITLE
updating PickGameObject as HandleUtility API was modified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changes
 
+- Modified PickGameObject calls to fit Unity API modifications
 - Removing preprocessor directives for Unity 2018 and below for Probuilder 5.0  
 - Modified the AppendVerticesToEdge to handle edges split for non-convex faces.
 

--- a/Editor/EditorCore/EditorHandleUtility.cs
+++ b/Editor/EditorCore/EditorHandleUtility.cs
@@ -354,7 +354,8 @@ namespace UnityEditor.ProBuilder
 
             do
             {
-                nearestGameObject = HandleUtility.PickGameObject(mousePosition, false, list.ToArray());
+                int materialIndex;
+                nearestGameObject = HandleUtility.PickGameObject(mousePosition, false, list.ToArray(), null, out materialIndex);
 
                 if (nearestGameObject != null)
                     list.Add(nearestGameObject);
@@ -538,7 +539,8 @@ namespace UnityEditor.ProBuilder
                 if (go != null)
                     ignorePicking.Add(go);
 
-                go = HandleUtility.PickGameObject(mousePosition, false, ignorePicking.ToArray());
+                int materialIndex;
+                go = HandleUtility.PickGameObject(mousePosition, false, ignorePicking.ToArray(), null, out materialIndex);
             } while (go != null && (go.GetComponent<MeshFilter>() == null && go.GetComponent<Terrain>() == null));
 
             if (go != null)


### PR DESCRIPTION
### Purpose of this PR

Updating calls to HandleUtility.API as exposed methods has been modified

### Links

This PR relies on another PR in Unity trunk to access to PickGameObjectInSelection method.
( https://github.cds.internal.unity3d.com/unity/unity/pull/1619 )

Fogbugz : https://fogbugz.unity3d.com/f/cases/1271427/

Polybrush related PR : https://github.com/Unity-Technologies/polybrush/pull/144

