### PR TITLE
Fixed shader warning in URP for UNITY_PASS_FORWARDBASE redefinition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [case: 1262236] Ensure PolyShape is not empty to avoid nullref while exporting.
 - [case: 1276085] Fixed `UV Actions` window allowing resize events outside of the containing window.
 - [case: 1276074] Fixed a case where `Fit UVs` action could result in `NaN` values.
+- [case: 1281254] Fixed shader warning in URP for UNITY_PASS_FORWARDBASE macro redefinition.
 - Fixed rect selection not working with Universal Render Pipeline.
 
 ### Changes

--- a/Content/Shader/ScrollHighlight.shader
+++ b/Content/Shader/ScrollHighlight.shader
@@ -29,7 +29,9 @@ Shader "Hidden/ProBuilder/ScrollHighlight" {
             CGPROGRAM
             #pragma vertex vert
             #pragma fragment frag
+            #ifndef UNITY_PASS_FORWARDBASE
             #define UNITY_PASS_FORWARDBASE
+            #endif
             #include "UnityCG.cginc"
             #pragma multi_compile_fwdbase_fullshadows
             #pragma target 3.0


### PR DESCRIPTION
### Purpose of this PR

UNITY_PASS_FORWARDBASE macro instruction was causing a warning message when using probuilder in URP from the shader :
Hidden/ProBuilder/ScrollHighlight

### Links

**Fogbugz:** https://fogbugz.unity3d.com/f/cases/1281254/

### Comments to Reviewers
Not sure that all Probuilder Shaders have been fully verified for SRP? 
