### PR TITLE
Adding dpi screen resolution to handle tooltip placement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [case: 1283111] Fixed `Poly Shape` tool not snapping placed vertices with grid snapping enabled.
 - [case: 1284741] Fixed missing tooltips for some items in the `Smooth Group Editor` window.
 - [case: 1283167] Fixed `Mesh Collider` mesh value not updating with modifications.
+- [case: 1285651] Fixed tooltip going out of screen when screen display is scale up
 
 ### Changes
 

--- a/Editor/EditorCore/TooltipEditor.cs
+++ b/Editor/EditorCore/TooltipEditor.cs
@@ -76,8 +76,11 @@ namespace UnityEditor.ProBuilder
             this.content = content;
             Vector2 size = content.CalcSize();
 
+            var dpiRatio = Screen.dpi / 96f;
+            var screenWidth = Screen.currentResolution.width / dpiRatio;
+
             Vector2 p = new Vector2(rect.x + rect.width + k_PositionPadding, rect.y);
-             if(((p.x % Screen.currentResolution.width) + size.x) > Screen.currentResolution.width)
+             if((p.x + size.x) > screenWidth)
                 p.x = rect.x - k_PositionPadding - size.x;
 
             minSize = size;


### PR DESCRIPTION
**DO NOT FORGET TO INCLUDE A CHANGELOG ENTRY**

### Purpose of this PR

Fix tooltip display that was going out of screen when screen was using a zoom (different dpi).

### Links

**Fogbugz:** https://fogbugz.unity3d.com/f/cases/1285651/
**Jira:**

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]