### PR TITLE
Ensuring that selection is clear at start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [case: 1283111] Fixed `Poly Shape` tool not snapping placed vertices with grid snapping enabled.
 - [case: 1284741] Fixed missing tooltips for some items in the `Smooth Group Editor` window.
 - [case: 1283167] Fixed `Mesh Collider` mesh value not updating with modifications.
+- [case: 1286045] Fixed selection cleaning problem after scene restart.
 
 ### Changes
 

--- a/Runtime/Core/ProBuilderMeshFunction.cs
+++ b/Runtime/Core/ProBuilderMeshFunction.cs
@@ -59,6 +59,8 @@ namespace UnityEngine.ProBuilder
         {
             EnsureMeshFilterIsAssigned();
             EnsureMeshColliderIsAssigned();
+            //Ensure no element is selected at awake
+            ClearSelection();
 
             if (vertexCount > 0
                 && faceCount > 0


### PR DESCRIPTION
### Purpose of this PR

As selection is serialized, it is saved with the scene.
When loading a scene, the previous selection is loaded with the ProBuilderMesh even if not selected.
This results in weird behaviors when trying to apply material on PB objects right after loading the scene.

The PR just ensures selection is cleared on ProBuilder's meshes.

### Links

**Fogbugz:** https://fogbugz.unity3d.com/f/cases/1286045/
**Jira:**

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]