### PR TITLE
[Backport] Poly Shape Point Insertion Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+- Fixed the insertion of new points on a Poly Shape being unreliable. 
+
 ## [4.4.1] - 2020-11-10
 
 - [case: 1286720] Fixed `Bezier Shape` and `Poly Shape` component preventing build when `Script Stripping` was enabled.


### PR DESCRIPTION
### Purpose of this PR

The poly shape point insertion was fixed while switching to an Editor Tool for version 5. This PR backports this fix to version 4.

### Links

**Bug Report on Forum:** https://forum.unity.com/threads/creating-a-new-point-on-poly-shape-is-really-difficult-interface.1006952/
 
### Comments to Reviewers

The fix is mostly from this [commit](https://github.com/Unity-Technologies/com.unity.probuilder/commit/ec6d85bbc7a6608c27b137794242f52cbb03bcf7) and was manually merged back into PolyShapeEditor.