### PR TITLE
V4.4/bugfix 1294866 annotation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Fixed the insertion of new points on a Poly Shape being unreliable. 
+- Fixed the insertion of new points on a Poly Shape being unreliable.
+- [case: 1294866] Fix annotation warning on InitializeOnLoad call. 
 
 ## [4.4.1] - 2020-11-10
 

--- a/Editor/EditorCore/EditorUtility.cs
+++ b/Editor/EditorCore/EditorUtility.cs
@@ -593,6 +593,16 @@ namespace UnityEditor.ProBuilder
             AnnotationUtility.SetIconEnabled(annotation.classID, annotation.scriptClass, enabled ? 1 : 0);
 #else
             Type annotationUtility = typeof(Editor).Assembly.GetType("UnityEditor.AnnotationUtility");
+
+            //Case 1294866 : Seems that getting the annotation array remove the warning
+            //Might be initializing something that is missing otherwise
+            MethodInfo getAnnotations = annotationUtility.GetMethod("GetAnnotations",
+            BindingFlags.Static | BindingFlags.NonPublic,
+             null,
+             new Type[] { },
+             null);
+            var annotations = getAnnotations.Invoke(null, new object[] {});
+
             MethodInfo setGizmoIconEnabled = annotationUtility.GetMethod("SetIconEnabled",
                 BindingFlags.Static | BindingFlags.NonPublic,
                 null,


### PR DESCRIPTION
**DO NOT FORGET TO INCLUDE A CHANGELOG ENTRY**

### Purpose of this PR

Having the ProBuilder package 4.4 installed causes Unity 2018.4 to output "Warning: Annotation not found!" every time a script is recompiled.

Seems that getting the annotation array before setting the icon remove the warning.

### Links
**Fogbugz:** https://fogbugz.unity3d.com/f/cases/1294866/
