### PR TITLE
Fixing memory leak created by the constant refresh of the selected pbMesh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Bug Fixes
 
+- Fix for constant PB Mesh refresh causing Memory leak 
 - [case: 1254339] Correct offset when rendering UVs and correct export when UV Editor is docked.
 - Fixed PolyShape in Prefab mode: PolyShapeMode was not serialized when exiting prefab mode. Update point insertion visualization.
 - [case: 1259845] Fixed dimension overlay being hidden on playmode or reboot of the editor.

--- a/Editor/EditorCore/ProBuilderEditor.cs
+++ b/Editor/EditorCore/ProBuilderEditor.cs
@@ -190,8 +190,8 @@ namespace UnityEditor.ProBuilder
 
             set
             {
-                toolManager?.SetSelectMode(value);
-                Refresh();
+                if(toolManager != null && toolManager.SetSelectMode(value))
+                    Refresh();
             }
         }
 

--- a/Editor/EditorCore/ProBuilderToolManager.cs
+++ b/Editor/EditorCore/ProBuilderToolManager.cs
@@ -109,10 +109,10 @@ namespace UnityEditor.ProBuilder
 #endif
         }
 
-        public void SetSelectMode(SelectMode mode)
+        public bool SetSelectMode(SelectMode mode)
         {
             if (mode == selectMode)
-                return;
+                return false;
 
             selectMode = mode;
 
@@ -135,6 +135,7 @@ namespace UnityEditor.ProBuilder
             else if (mode == SelectMode.Object && GetBuiltinToolType(ToolManager.activeToolType, out Type builtin))
                 ToolManager.SetActiveTool(builtin);
 #endif
+            return true;
         }
 
         public void ResetToLastSelectMode()


### PR DESCRIPTION
### Purpose of this PR

Fixing a memory leak of ~4Mb per second using PB 5.0 with Unity >= 2021.1.

The problem was introduced since this commit :
https://github.com/Unity-Technologies/com.unity.probuilder/pull/345/commits/0fb88c56551d36f1e26d19989ce54509e4460239

The modification from 
```
                var mode = selectMode;
                mode = UI.EditorGUIUtility.DoElementModeToolbar(m_ElementModeToolbarRect, mode);
                if (mode != selectMode)
                    selectMode = mode;
```
to
```
                selectMode = UI.EditorGUIUtility.DoElementModeToolbar(m_ElementModeToolbarRect, selectMode);
```

caused constant calls to `Refresh()` on the selection and thus I tracked the leak to the call of the method `RebuildMeshHandle`. 
It seems that with newer version of Unity methods `MeshHandles.CreateFaceMesh` and `MeshHandles.CreateEdgeMesh` are leaking as it was not causing problem with previous Unity version.

To prevent this this fix reduces calls to `Refresh `to be done only when necessary and not every frame.

However, I guess we should have a detailed look in the Clear method as it seems it is not deallocating memory the way it should with lastest Unity versions.
`        [NativeMethod("Clear")]                 extern private void ClearImpl(bool keepVertexLayout);`

### Links

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]