### PR TITLE
Added Missing Dependency Builtin Modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Bug Fixes
+
+- Added Particle System and IMGUI modules as a dependency.
+
 ## [5.0.0-pre.10] - 2021-01-22
 
 ### Internal

--- a/Runtime/Core/MeshUtility.cs
+++ b/Runtime/Core/MeshUtility.cs
@@ -635,6 +635,7 @@ namespace UnityEngine.ProBuilder
 
         internal static bool IsUsedInParticuleSystem(ProBuilderMesh pbmesh)
         {
+#if USING_PARTICLE_SYSTEM
             ParticleSystem pSys;
             if(pbmesh.TryGetComponent(out pSys))
             {
@@ -645,17 +646,20 @@ namespace UnityEngine.ProBuilder
                     return true;
                 }
             }
+#endif
             return false;
         }
 
         internal static void RestoreParticuleSystem(ProBuilderMesh pbmesh)
         {
+#if USING_PARTICLE_SYSTEM
             ParticleSystem pSys;
             if(pbmesh.TryGetComponent(out pSys))
             {
                 var shapeModule = pSys.shape;
                 shapeModule.meshRenderer = pbmesh.renderer;
             }
+#endif
         }
 
     }

--- a/Runtime/Unity.ProBuilder.asmdef
+++ b/Runtime/Unity.ProBuilder.asmdef
@@ -17,6 +17,11 @@
             "name": "com.unity.render-pipelines.high-definition",
             "expression": "7.1.0",
             "define": "HDRP_7_1_0_OR_NEWER"
+        },
+        {
+            "name": "com.unity.modules.particlesystem",
+            "expression": "1.0.0",
+            "define": "USING_PARTICLE_SYSTEM"
         }
     ],
     "noEngineReferences": false

--- a/package.json
+++ b/package.json
@@ -48,10 +48,12 @@
       "path": "Samples~/Runtime"
     }
   ],
-  "dependencies": {
-    "com.unity.settings-manager": "1.0.3",
-    "com.unity.modules.physics" :  "1.0.0"
-  },
+    "dependencies": {
+        "com.unity.settings-manager": "1.0.3",
+        "com.unity.modules.physics": "1.0.0",
+        "com.unity.modules.imgui": "1.0.0",
+        "com.unity.modules.particlesystem": "1.0.0"
+    },
   "repository": {
     "type": "git",
     "url": "https://github.com/Unity-Technologies/com.unity.probuilder.git",

--- a/package.json
+++ b/package.json
@@ -48,12 +48,11 @@
       "path": "Samples~/Runtime"
     }
   ],
-    "dependencies": {
-        "com.unity.settings-manager": "1.0.3",
-        "com.unity.modules.physics": "1.0.0",
-        "com.unity.modules.imgui": "1.0.0",
-        "com.unity.modules.particlesystem": "1.0.0"
-    },
+  "dependencies": {
+    "com.unity.settings-manager": "1.0.3",
+    "com.unity.modules.physics": "1.0.0",
+    "com.unity.modules.imgui": "1.0.0"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/Unity-Technologies/com.unity.probuilder.git",


### PR DESCRIPTION
### Purpose of this PR

Removing the module Particle System or IMGUI was causing compilation errors. Added both of those as dependencies. I validated that removing everything in the manifest file didn't cause any other errors.