### PR TITLE
Fix for material reverting when subdividing an edge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Bug Fixes
 
+- [case: 1311258] Fixing material reverting when subdividing edge.
 - Added Particle System and IMGUI modules as a dependency.
 
 ## [5.0.0-pre.10] - 2021-01-22

--- a/Editor/EditorCore/CutTool.cs
+++ b/Editor/EditorCore/CutTool.cs
@@ -658,7 +658,7 @@ namespace UnityEditor.ProBuilder
                 return new ActionResult(ActionResult.Status.Failure, L10n.Tr("The current cut overlaps itself"));
             }
 
-            UndoUtility.RecordObject(m_Mesh, "Do Cut To Mesh");
+            UndoUtility.RecordObject(m_Mesh, "Execute Cut");
 
             List<Vertex> meshVertices = new List<Vertex>();
             m_Mesh.GetVerticesInList(meshVertices);
@@ -688,6 +688,7 @@ namespace UnityEditor.ProBuilder
             if (IsALoop)
             {
                 Face f = m_Mesh.CreatePolygon(cutIndexes, false);
+                f.submeshIndex = m_TargetFace.submeshIndex;
 
                 if(f == null)
                     return new ActionResult(ActionResult.Status.Failure, L10n.Tr("Cut Shape is not valid"));
@@ -793,6 +794,7 @@ namespace UnityEditor.ProBuilder
                      {
                          List<Face> toDelete;
                          Face newFace = ComputeFaceClosure(polygon, index, cutVertexSharedIndexes, out toDelete);
+                         newFace.submeshIndex = m_TargetFace.submeshIndex;
 
                          newFaces.Add(newFace);
                          facesToDelete.AddRange(toDelete);

--- a/Runtime/MeshOperations/AppendElements.cs
+++ b/Runtime/MeshOperations/AppendElements.cs
@@ -1448,6 +1448,8 @@ namespace UnityEngine.ProBuilder.MeshOperations
                 else
                     continue;
 
+                //Keep submesh index when rebuilding to maintain material references
+                data.face.submeshIndex = face.submeshIndex;
                 data.face.ShiftIndexes(vertexCount);
                 face.CopyFrom(data.face);
 

--- a/Runtime/MeshOperations/AppendElements.cs
+++ b/Runtime/MeshOperations/AppendElements.cs
@@ -1051,7 +1051,6 @@ namespace UnityEngine.ProBuilder.MeshOperations
 
                         modifiedFaces.Add(face, data);
 
-
                         //Ordering vertices in the new face
                         List<Vertex> orderedVertices = new List<Vertex>();
                         List<int> orderedSharedIndexes = new List<int>();
@@ -1168,6 +1167,8 @@ namespace UnityEngine.ProBuilder.MeshOperations
                 else
                     continue;
 
+                //Keep submesh index when rebuilding to maintain material references
+                data.face.submeshIndex = face.submeshIndex;
                 data.face.ShiftIndexes(vertexCount);
                 face.CopyFrom(data.face);
 


### PR DESCRIPTION
### Purpose of this PR

Fixing problem occurring when subdividing an edge on a PB Mesh with multiple materials assigned to the faces.
The fix ensure the submesh index is kept when duplicating the face.

Before the fix:
![materialProblem-before](https://user-images.githubusercontent.com/66317117/107373696-178c6a80-6ae7-11eb-9fc0-6b533e85ed67.gif)

After the fix:
![materialProblem-after](https://user-images.githubusercontent.com/66317117/107373702-18250100-6ae7-11eb-957e-d0c7b1561950.gif)

### Links

**Fogbugz:** https://fogbugz.unity3d.com/f/cases/1311258/

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]