### PR TITLE
Bugfix/edges picking not working unity20.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Bug Fixes
 
+- [case: 1317148] Fixing edge picking problem with some Unity versions. 
 - [case: 1311258] Fixing material reverting when subdividing edge.
 - Added Particle System and IMGUI modules as a dependency.
 

--- a/Content/Shader/EdgePicker.shader
+++ b/Content/Shader/EdgePicker.shader
@@ -43,7 +43,13 @@ CGPROGRAM
             v2f vert (appdata v)
             {
                 v2f o;
-                o.pos = UnityObjectToClipPos(v.vertex);
+                o.pos = float4(UnityObjectToViewPos(v.vertex.xyz), 1);
+                //Offsetting the edges to avoid z-fighting problems occuring with Unity 20.2
+                o.pos.xy *= lerp(.99, 1, unity_OrthoParams.w);
+                //Moving edges closer when using orthographic camera
+                o.pos.z *= lerp(.99, .95, unity_OrthoParams.w);
+                o.pos = mul(UNITY_MATRIX_P, o.pos);
+
                 o.color = v.color;
 
                 return o;

--- a/Content/Shader/EdgePicker.shader
+++ b/Content/Shader/EdgePicker.shader
@@ -27,6 +27,7 @@ CGPROGRAM
             #pragma vertex vert
             #pragma fragment frag
             #include "UnityCG.cginc"
+            #include "ProBuilderCG.cginc"
 
             struct appdata
             {
@@ -43,15 +44,8 @@ CGPROGRAM
             v2f vert (appdata v)
             {
                 v2f o;
-                o.pos = float4(UnityObjectToViewPos(v.vertex.xyz), 1);
-                //Offsetting the edges to avoid z-fighting problems occuring with Unity 20.2
-                o.pos.xy *= lerp(.99, 1, unity_OrthoParams.w);
-                //Moving edges closer when using orthographic camera
-                o.pos.z *= lerp(.99, .95, unity_OrthoParams.w);
-                o.pos = mul(UNITY_MATRIX_P, o.pos);
-
+				o.pos = UnityObjectToClipPosWithOffset(v.vertex.xyz);
                 o.color = v.color;
-
                 return o;
             }
 

--- a/Content/Shader/FaceHighlight.shader
+++ b/Content/Shader/FaceHighlight.shader
@@ -23,6 +23,7 @@ Shader "Hidden/ProBuilder/FaceHighlight"
             #pragma vertex vert
             #pragma fragment frag
             #include "UnityCG.cginc"
+            #include "ProBuilderCG.cginc"
 
             float4 _Color;
             float _Dither;
@@ -40,11 +41,7 @@ Shader "Hidden/ProBuilder/FaceHighlight"
             v2f vert (appdata v)
             {
                 v2f o;
-                o.pos = float4(UnityObjectToViewPos(v.vertex.xyz), 1);
-                o.pos.xy *= lerp(.99, 1, unity_OrthoParams.w);
-                o.pos.z *= .99;
-                o.pos = mul(UNITY_MATRIX_P, o.pos);
-
+				o.pos = UnityObjectToClipPosWithOffset(v.vertex.xyz);
                 return o;
             }
 

--- a/Content/Shader/LineBillboardMetal.shader
+++ b/Content/Shader/LineBillboardMetal.shader
@@ -52,7 +52,7 @@ Shader "Hidden/ProBuilder/LineBillboardMetal"
             {
                 v2f o;
 
-                o.pos = UnityObjectToClipPosWithOffset(v.vertex.xyz);
+                o.pos = UnityObjectToClipPosWithOffsetMetal(v.vertex.xyz);
 
                 // convert vertex to screen space, add pixel-unit xy to vertex, then transform back to clip space.
                 float4 clip = o.pos;

--- a/Content/Shader/ProBuilderCG.cginc
+++ b/Content/Shader/ProBuilderCG.cginc
@@ -24,6 +24,19 @@ inline float4 ScreenToClip(float4 v)
 inline float4 UnityObjectToClipPosWithOffset(float3 pos)
 {
     float4 ret = float4(UnityObjectToViewPos(pos), 1);
+    //Offsetting the edges to avoid z-fighting problems
+	//Do not offset when using orthographic camera as XY are
+    //screen coords, this would shift the rendering
+    ret.xy *= lerp(.99, 1, unity_OrthoParams.w);
+    //Moving edges closer
+	//.99 is not suffisient for Orthographic Camera
+    ret.z *= 0.95;
+    return mul(UNITY_MATRIX_P, ret);
+}
+
+inline float4 UnityObjectToClipPosWithOffsetMetal(float3 pos)
+{
+    float4 ret = float4(UnityObjectToViewPos(pos), 1);
     ret *= lerp(.99, .95, ORTHO);
     return mul(UNITY_MATRIX_P, ret);
 }

--- a/Content/Shader/ProBuilderCG.cginc
+++ b/Content/Shader/ProBuilderCG.cginc
@@ -27,10 +27,10 @@ inline float4 UnityObjectToClipPosWithOffset(float3 pos)
     //Offsetting the edges to avoid z-fighting problems
 	//Do not offset when using orthographic camera as XY are
     //screen coords, this would shift the rendering
-    ret.xy *= lerp(.99, 1, unity_OrthoParams.w);
+    ret.xyz *= lerp(.99, 1, unity_OrthoParams.w);
     //Moving edges closer
-	//.99 is not suffisient for Orthographic Camera
-    ret.z *= 0.95;
+	//.99 is not sufficient for Orthographic Camera
+    ret.z *= lerp(1, 0.95, unity_OrthoParams.w);
     return mul(UNITY_MATRIX_P, ret);
 }
 


### PR DESCRIPTION
### Purpose of this PR

Fixing edge selection using rect box selection that was broken with some Unity version.
The fix is using the same principle that the highlight shader is using : the edge picker shader is bringing edges a little closer to the camera plane to avoid z-fighting problem. This z-fighting was causing the problematic rendering in the texture.

However the problem was really inconsistent and reproduction was not always possible.

It seems the problem was coming from a problem with depth precision and was present on some Unity 20.2 versions.
Here is an example of the broken selection :
![edge-selection-broken](https://user-images.githubusercontent.com/66317117/109011633-66263100-76b1-11eb-9af6-9f92bad22237.gif)

Here is the result after applying the fix :
![edge-selection-fixed](https://user-images.githubusercontent.com/66317117/109011628-64f50400-76b1-11eb-8038-f21d3e05bf81.gif)

### Links

**Fogbugz:** https://fogbugz.unity3d.com/f/cases/1317148/

### Comments to Reviewers
This fix is only needed for a few Unity versions, but it's working for all of Unity version, so I would advice to use this new shader version for all Unity versions from now.