### PR TITLE
Changed the Wording on the Detach Faces Setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [case: 1317148] Fixing edge picking problem with some Unity versions. 
 - [case: 1312537] Fixing script stripping on disabled objects when building.
 - [case: 1311258] Fixing material reverting when subdividing edge.
+- [case: 1315335] Fixing the wording of the detach faces to be less confusing.
 - Added Particle System and IMGUI modules as a dependency.
 
 ## [5.0.0-pre.10] - 2021-01-22

--- a/Editor/MenuActions/Geometry/DetachFaces.cs
+++ b/Editor/MenuActions/Geometry/DetachFaces.cs
@@ -43,12 +43,12 @@ namespace UnityEditor.ProBuilder.Actions
         protected override void OnSettingsGUI()
         {
             GUILayout.Label("Detach Face Settings", EditorStyles.boldLabel);
-
-            EditorGUILayout.HelpBox("Detach Faces can separate the selection into either a new GameObject or a submesh.", MessageType.Info);
-
+            
             EditorGUI.BeginChangeCheck();
 
-            m_DetachSetting.value = (DetachSetting)EditorGUILayout.EnumPopup("Detach To", m_DetachSetting);
+            m_DetachSetting.value = EditorGUILayout.Toggle("Separate GameObject", m_DetachSetting.value == DetachSetting.GameObject)
+                ? DetachSetting.GameObject
+                : DetachSetting.Submesh;
 
             if (EditorGUI.EndChangeCheck())
                 ProBuilderSettings.Save();


### PR DESCRIPTION
### Purpose of this PR

The setting for detach to face used to have the option of detaching to a submesh. By design, this didn't refer to the unity definition of a submesh which could be confusing to users. The option is now a toggle for separate gameobject:
![image](https://user-images.githubusercontent.com/44209648/110860965-73cfdf00-828b-11eb-9f70-61c3e82b0ffa.png)

### Links

**Fogbugz: [case#1315335](https://fogbugz.unity3d.com/f/cases/1315335/)**