### PR TITLE
Bugfixes 5x release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [5.0.2] - 2021-03-11
+
+### Bug Fixes
+
+- Fixed `Draw Shape` tool showing incorrect UVs when setting shape bounding box.
+- Fixed `Draw Shape` tool not clearing selection when changing the active shape type.
+- Fixed `Cut Tool` error when pressing `Backspace` with no vertices placed.
+- Fixed `Cut Tool` error when finishing a cut segment with less than 3 vertices.
+- Fixed `Draw Shape` tool truncating shape property fields in the Scene View Overlay.
+
+### Changes
+
+- Moved contents of warning box in `Draw Shape` tool to tooltips.
+
 ## [5.0.1] - 2021-03-09
 
 ### Bug Fixes

--- a/Debug/Editor/Guides.cs
+++ b/Debug/Editor/Guides.cs
@@ -1,0 +1,96 @@
+using UnityEditor;
+using UnityEditor.SettingsManagement;
+using UnityEngine;
+using UnityEngine.Rendering;
+
+namespace ProBuilder.Debug.Editor
+{
+    static class GuidesSettingsProvider
+    {
+        const string k_PreferencesPath = "Preferences/Scene Guides";
+        static Settings s_Settings;
+        public static Settings settings => s_Settings ??= new Settings("com.unity.scene-guides");
+
+        [SettingsProvider]
+        static SettingsProvider CreateSettingsProvider()
+        {
+            var provider = new UserSettingsProvider(k_PreferencesPath,
+                settings,
+                new[] { typeof(GuidesSettingsProvider).Assembly });
+
+            settings.afterSettingsSaved += HandleUtility.Repaint;
+
+            return provider;
+        }
+    }
+
+    class Pref<T> : UserSetting<T>
+    {
+        public Pref(string key, T value, SettingsScope scope = SettingsScope.Project)
+            : base(GuidesSettingsProvider.settings, key, value, scope) { }
+    }
+
+    static class Guides
+    {
+        static Pref<bool> s_SceneOrigin = new Pref<bool>("Guides.s_SceneOrigin", false);
+        static Pref<bool> s_SelectionPivot = new Pref<bool>("Guides.s_SelectionPivot", false);
+
+        static Vector3  zero = Vector3.zero,
+                        up = new Vector3(0f, 1f, 0f),
+                        right = new Vector3(1f, 0f, 0f),
+                        forward = new Vector3(0f, 0f, 1f);
+
+        [InitializeOnLoadMethod]
+        static void Init()
+        {
+            SceneView.duringSceneGui += view =>
+            {
+                var evt = Event.current;
+
+                if (evt.type != EventType.Repaint)
+                    return;
+
+                if (s_SceneOrigin)
+                {
+                    var dist = view.camera.farClipPlane / 10f;
+
+                    DrawLine(zero, right * dist, Handles.xAxisColor);
+                    DrawLine(zero, right * -dist, Handles.xAxisColor * .7f);
+
+                    DrawLine(zero, up * dist, Handles.yAxisColor);
+                    DrawLine(zero, up * -dist, Handles.yAxisColor * .7f);
+
+                    DrawLine(zero, forward * dist, Handles.zAxisColor);
+                    DrawLine(zero, forward * -dist, Handles.zAxisColor * .7f);
+                }
+
+                if (s_SelectionPivot)
+                {
+                    foreach (var transform in Selection.transforms)
+                        DrawPivot(transform);
+                }
+            };
+        }
+
+        static void DrawPivot(Transform transform)
+        {
+            using (new Handles.DrawingScope(transform.localToWorldMatrix))
+            {
+                DrawLine(zero, right * .2f, Handles.xAxisColor, 1f, 3f);
+                DrawLine(zero, up * .2f, Handles.yAxisColor, 1f, 3f);
+                DrawLine(zero, forward * .2f, Handles.zAxisColor, 1f, 3f);
+            }
+        }
+
+        static void DrawLine(Vector3 from, Vector3 to, Color color, float occludedTint = .7f, float thickness = 0f)
+        {
+            Handles.color = color;
+            Handles.zTest = CompareFunction.LessEqual;
+            Handles.DrawLine(from, to, thickness);
+
+            Handles.color = color * occludedTint;
+            Handles.zTest = CompareFunction.Greater;
+            Handles.DrawLine(from, to, thickness);
+        }
+    }
+}

--- a/Debug/Editor/Guides.cs
+++ b/Debug/Editor/Guides.cs
@@ -9,7 +9,7 @@ namespace ProBuilder.Debug.Editor
     {
         const string k_PreferencesPath = "Preferences/Scene Guides";
         static Settings s_Settings;
-        public static Settings settings => s_Settings ??= new Settings("com.unity.scene-guides");
+        public static Settings settings => s_Settings ?? (s_Settings = new Settings("com.unity.scene-guides"));
 
         [SettingsProvider]
         static SettingsProvider CreateSettingsProvider()
@@ -89,11 +89,19 @@ namespace ProBuilder.Debug.Editor
         {
             Handles.color = color;
             Handles.zTest = CompareFunction.LessEqual;
+#if UNITY_2021_1_OR_NEWER
             Handles.DrawLine(from, to, thickness);
+#else
+            Handles.DrawLine(from, to);
+#endif
 
             Handles.color = color * occludedTint;
             Handles.zTest = CompareFunction.Greater;
+#if UNITY_2021_1_OR_NEWER
             Handles.DrawLine(from, to, thickness);
+#else
+            Handles.DrawLine(from, to);
+#endif
         }
     }
 }

--- a/Debug/Editor/Guides.cs
+++ b/Debug/Editor/Guides.cs
@@ -32,7 +32,10 @@ namespace ProBuilder.Debug.Editor
 
     static class Guides
     {
+        [UserSetting("World Space", "Origin Axes", "Shows 3 axis guides from the scene view origin.")]
         static Pref<bool> s_SceneOrigin = new Pref<bool>("Guides.s_SceneOrigin", false);
+
+        [UserSetting("Selection", "Transform Pivot", "Draw a gizmo at the origin of each selected transform.")]
         static Pref<bool> s_SelectionPivot = new Pref<bool>("Guides.s_SelectionPivot", false);
 
         static Vector3  zero = Vector3.zero,

--- a/Debug/Editor/Guides.cs.meta
+++ b/Debug/Editor/Guides.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c4e5e4e8e8824aaca74c0f68b83b7cbb
+timeCreated: 1615494980

--- a/Debug/Editor/Unity.ProBuilder.Debug.Editor.asmdef
+++ b/Debug/Editor/Unity.ProBuilder.Debug.Editor.asmdef
@@ -1,11 +1,12 @@
 {
     "name": "Unity.ProBuilder.Debug.Editor",
+    "rootNamespace": "",
     "references": [
         "Unity.ProBuilder",
         "Unity.ProBuilder.Editor",
-        "Unity.ProBuilder.AssetIdRemapUtility"
+        "Unity.ProBuilder.AssetIdRemapUtility",
+        "Unity.Settings.Editor"
     ],
-    "optionalUnityReferences": [],
     "includePlatforms": [
         "Editor"
     ],
@@ -14,5 +15,7 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": false,
-    "defineConstraints": []
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Editor/EditorCore/CutTool.cs
+++ b/Editor/EditorCore/CutTool.cs
@@ -133,9 +133,8 @@ namespace UnityEditor.ProBuilder
             {
                 if (m_CutPath.Count < 3)
                     return false;
-                else
-                    return Math.Approx3(m_CutPath[0].position,
-                        m_CutPath[m_CutPath.Count - 1].position);
+
+                return Math.Approx3(m_CutPath[0].position, m_CutPath[m_CutPath.Count - 1].position);
             }
         }
 
@@ -517,9 +516,7 @@ namespace UnityEditor.ProBuilder
                      && evtType == EventType.MouseDown
                      && HandleUtility.nearestControl == m_ControlId)
             {
-                int polyCount = m_CutPath.Count;
-                if (!m_CurrentPosition.Equals(Vector3.positiveInfinity)
-                    && (polyCount == 0 || m_SelectedIndex != polyCount - 1))
+                if(CanAppendCurrentPointToPath())
                 {
                     AddCurrentPositionToPath();
                     evt.Use();
@@ -534,6 +531,26 @@ namespace UnityEditor.ProBuilder
             {
                 ProBuilderEditor.instance.HandleMouseEvent(SceneView.lastActiveSceneView, m_ControlId);
             }
+        }
+
+        bool CanAppendCurrentPointToPath()
+        {
+            int polyCount = m_CutPath.Count;
+
+            if (!Math.IsNumber(m_CurrentPosition))
+                return false;
+
+            if (!(polyCount == 0 || m_SelectedIndex != polyCount - 1))
+                return false;
+
+            // duplicate points are not permitted, except the special case where placing a final point on the starting
+            // point finishes the cut operation.
+            for(int i = 1; i < polyCount; i++)
+                if (Math.Approx3(m_CutPath[i].position, m_CurrentPosition))
+                    return false;
+
+            // when the existing vertex count is less than 3, don't allow the special duplicate first vertex position
+            return polyCount < 2 || !(polyCount < 3 && Math.Approx3(m_CutPath[0].position, m_CurrentPosition));
         }
 
         internal void AddCurrentPositionToPath(bool optimize = true)

--- a/Editor/EditorCore/CutTool.cs
+++ b/Editor/EditorCore/CutTool.cs
@@ -409,9 +409,13 @@ namespace UnityEditor.ProBuilder
             {
                 case KeyCode.Backspace:
                 {
-                    UndoUtility.RecordObject(m_Mesh, "Delete Selected Points");
-                    m_CutPath.RemoveAt(m_CutPath.Count-1);
-                    m_Dirty = true;
+                    if (m_CutPath.Count > 0)
+                    {
+                        UndoUtility.RecordObject(m_Mesh, "Delete Selected Points");
+                        m_CutPath.RemoveAt(m_CutPath.Count - 1);
+                        m_Dirty = true;
+                    }
+
                     evt.Use();
                     break;
                 }

--- a/Editor/EditorCore/DrawShapeTool.cs
+++ b/Editor/EditorCore/DrawShapeTool.cs
@@ -461,6 +461,7 @@ namespace UnityEditor.ProBuilder
                             m_LastShapeCreated = null;
 
                         UndoUtility.RegisterCompleteObjectUndo(currentShapeInOverlay, "Change Shape");
+                        Selection.activeObject = null;
                         currentShapeInOverlay.SetShape(EditorShapeUtility.CreateShape(type), currentShapeInOverlay.pivotLocation);
                         SetBounds(currentShapeInOverlay.size);
 

--- a/Editor/EditorCore/DrawShapeTool.cs
+++ b/Editor/EditorCore/DrawShapeTool.cs
@@ -390,8 +390,6 @@ namespace UnityEditor.ProBuilder
 
         void OnOverlayGUI(UObject overlayTarget, SceneView view)
         {
-            EditorGUILayout.HelpBox(L10n.Tr("Click and drag to place and scale the shape, or SHIFT+click once to duplicate last size settings."), MessageType.Info);
-
             DrawShapeGUI();
 
 #if !UNITY_2021_1_OR_NEWER

--- a/Editor/EditorCore/DrawShapeTool.cs
+++ b/Editor/EditorCore/DrawShapeTool.cs
@@ -291,7 +291,7 @@ namespace UnityEditor.ProBuilder
                         shape.GetComponent<MeshRenderer>().sharedMaterial = m_ShapePreviewMaterial;
 
                         EditorShapeUtility.CopyLastParams(shape.shape, shape.shape.GetType());
-                        shape.Rebuild(m_Bounds, m_PlaneRotation);
+                        shape.Rebuild(m_Bounds, m_PlaneRotation, m_BB_Origin);
                         ProBuilderEditor.Refresh(false);
                     }
 
@@ -363,7 +363,7 @@ namespace UnityEditor.ProBuilder
                 m_IsShapeInit = true;
             }
 
-            m_ProBuilderShape.Rebuild(m_Bounds, m_PlaneRotation);
+            m_ProBuilderShape.Rebuild(m_Bounds, m_PlaneRotation, m_BB_Origin);
             ProBuilderEditor.Refresh(false);
 
             SceneView.RepaintAll();

--- a/Editor/EditorCore/EditorShapeUtility.cs
+++ b/Editor/EditorCore/EditorShapeUtility.cs
@@ -12,8 +12,8 @@ namespace UnityEditor.ProBuilder
     {
         [UserSetting]
         public static Pref<bool> s_ResetUserPrefs = new Pref<bool>("ShapeComponent.ResetSettings", true);
-
         static Dictionary<string, Shape> s_Prefs = new Dictionary<string, Shape>();
+        static readonly string k_Tooltip = L10n.Tr("Click and drag to place and scale the shape, or SHIFT+click once to duplicate last size settings.");
 
         static Dictionary<string, Shape> prefs
         {
@@ -76,7 +76,7 @@ namespace UnityEditor.ProBuilder
                 if(s_ShapeTypesGUILists == null)
                 {
                     s_ShapeTypesGUILists = new List<GUIContent[]>();
-                    string[] shapeTypeNames = availableShapeTypes.Select(x => ((ShapeAttribute)System.Attribute.GetCustomAttribute(x, typeof(ShapeAttribute))).name).ToArray();
+                    string[] shapeTypeNames = availableShapeTypes.Select(x => ((ShapeAttribute) Attribute.GetCustomAttribute(x, typeof(ShapeAttribute))).name).ToArray();
                     GUIContent[] shapeTypesGUI = null;
 
                     int i;
@@ -91,9 +91,9 @@ namespace UnityEditor.ProBuilder
                         var name = shapeTypeNames[i];
                         var texture = IconUtility.GetIcon("Tools/ShapeTool/" + name);
                         if(texture != null)
-                            shapeTypesGUI[i % s_MaxContentPerGroup] = new GUIContent(texture, name);
+                            shapeTypesGUI[i % s_MaxContentPerGroup] = new GUIContent(texture, k_Tooltip);
                         else
-                            shapeTypesGUI[i % s_MaxContentPerGroup] = new GUIContent(name, name);
+                            shapeTypesGUI[i % s_MaxContentPerGroup] = new GUIContent(name, k_Tooltip);
                     }
 
                     if(shapeTypesGUI != null) s_ShapeTypesGUILists.Add(shapeTypesGUI);

--- a/Editor/EditorCore/EditorUtility.cs
+++ b/Editor/EditorCore/EditorUtility.cs
@@ -42,7 +42,7 @@ namespace UnityEditor.ProBuilder
         static Pref<bool> s_MeshColliderIsConvex = new Pref<bool>("mesh.meshColliderIsConvex", false);
 
         [UserSetting("Mesh Settings", "Pivot Location", "Determines the placement of new shape's pivot.")]
-        static Pref<PivotLocation> s_NewShapesPivotAtCenter = new Pref<PivotLocation>("mesh.newShapePivotLocation", PivotLocation.Center);
+        static Pref<PivotLocation> s_NewShapesPivotAtCenter = new Pref<PivotLocation>("mesh.newShapePivotLocation", PivotLocation.FirstCorner);
 
         [UserSetting("Mesh Settings", "Snap New Shape To Grid", "When enabled, new shapes will snap to the closest point on grid.")]
         static Pref<bool> s_SnapNewShapesToGrid = new Pref<bool>("mesh.newShapesSnapToGrid", true);

--- a/Editor/EditorCore/Experimental.cs
+++ b/Editor/EditorCore/Experimental.cs
@@ -31,6 +31,7 @@ namespace UnityEditor.ProBuilder
 
             EditorGUI.BeginChangeCheck();
 
+            EditorGUILayout.HelpBox("Enabling Experimental Features will cause Unity to recompile scripts.", MessageType.Warning);
             enabled = SettingsGUILayout.SearchableToggle("Experimental Features Enabled", enabled, searchContext);
 
             if (EditorGUI.EndChangeCheck())

--- a/Editor/EditorCore/TooltipEditor.cs
+++ b/Editor/EditorCore/TooltipEditor.cs
@@ -62,8 +62,13 @@ namespace UnityEditor.ProBuilder
 
         public static void Hide()
         {
-            if (s_Instance != null)
-                s_Instance.Close();
+            var all = Resources.FindObjectsOfTypeAll<TooltipEditor>();
+
+            for (int i = 0, c = all.Length; i < c; i++)
+            {
+                if (s_Instance != null)
+                    s_Instance.Close();
+            }
         }
 
         public static void Show(Rect rect, TooltipContent content)

--- a/Editor/StateMachines/ShapeState_DrawBaseShape.cs
+++ b/Editor/StateMachines/ShapeState_DrawBaseShape.cs
@@ -7,7 +7,7 @@ namespace UnityEditor.ProBuilder
     internal class ShapeState_DrawBaseShape : ShapeState
     {
         bool m_IsDragging = false;
-        
+
         protected override void InitState()
         {
             m_IsDragging = false;
@@ -86,7 +86,6 @@ namespace UnityEditor.ProBuilder
             deltaPoint = tool.GetPoint(deltaPoint, Event.current.control);
             tool.m_BB_OppositeCorner = tool.m_PlaneRotation * deltaPoint + tool.m_BB_Origin;
             tool.m_BB_HeightCorner = tool.m_BB_OppositeCorner;
-
             tool.RebuildShape();
         }
 
@@ -98,7 +97,7 @@ namespace UnityEditor.ProBuilder
             DrawShapeTool.ApplyPrefsSettings(shape);
 
             EditorShapeUtility.CopyLastParams(shape.shape, shape.shape.GetType());
-            shape.Rebuild(tool.m_Bounds, tool.m_PlaneRotation);
+            shape.Rebuild(tool.m_Bounds, tool.m_PlaneRotation, tool.m_BB_Origin);
 
             //Finish initializing object and collider once it's completed
             ProBuilderEditor.Refresh(false);

--- a/Editor/StateMachines/ShapeState_DrawBaseShape.cs
+++ b/Editor/StateMachines/ShapeState_DrawBaseShape.cs
@@ -7,9 +7,7 @@ namespace UnityEditor.ProBuilder
     internal class ShapeState_DrawBaseShape : ShapeState
     {
         bool m_IsDragging = false;
-
-        Quaternion m_currentShapeRotation = Quaternion.identity;
-
+        
         protected override void InitState()
         {
             m_IsDragging = false;

--- a/Editor/StateMachines/ShapeState_InitShape.cs
+++ b/Editor/StateMachines/ShapeState_InitShape.cs
@@ -98,10 +98,10 @@ namespace UnityEditor.ProBuilder
                 }
             }
 
-            if(GUIUtility.hotControl == 0 && evt.shift && !(evt.control || evt.command))
-                tool.DuplicatePreview(m_HitPosition);
-            else if(tool.m_DuplicateGO != null)
-                Object.DestroyImmediate(tool.m_DuplicateGO);
+            if (!Math.IsNumber(m_HitPosition))
+                return this;
+
+            tool.DoDuplicateShapePreviewHandle(m_HitPosition);
 
             // Repaint to visualize the placement preview dot
             if (evt.type == EventType.MouseMove && HandleUtility.nearestControl == tool.controlID)
@@ -117,13 +117,9 @@ namespace UnityEditor.ProBuilder
                             HandleUtility.GetHandleSize(m_HitPosition) * 0.05f, EventType.Repaint);
                     }
                 }
-
-                if(GUIUtility.hotControl == 0 && evt.shift && !(evt.control || evt.command))
-                    tool.DrawBoundingBox(false);
             }
 
             return this;
         }
-
     }
 }

--- a/Runtime/Core/MeshUtility.cs
+++ b/Runtime/Core/MeshUtility.cs
@@ -662,7 +662,7 @@ namespace UnityEngine.ProBuilder
 #endif
         }
 
-        public static Bounds GetBounds(this ProBuilderMesh mesh)
+        internal static Bounds GetBounds(this ProBuilderMesh mesh)
         {
             if (mesh.mesh != null)
                 return mesh.mesh.bounds;

--- a/Runtime/Core/MeshUtility.cs
+++ b/Runtime/Core/MeshUtility.cs
@@ -662,5 +662,11 @@ namespace UnityEngine.ProBuilder
 #endif
         }
 
+        public static Bounds GetBounds(this ProBuilderMesh mesh)
+        {
+            if (mesh.mesh != null)
+                return mesh.mesh.bounds;
+            return Math.GetBounds(mesh.positionsInternal);
+        }
     }
 }

--- a/Runtime/Core/ShapeGenerator.cs
+++ b/Runtime/Core/ShapeGenerator.cs
@@ -639,11 +639,16 @@ namespace UnityEngine.ProBuilder
             for (int i = 0; i < k_CubeTriangles.Length; i++)
                 points[i] = Vector3.Scale(k_CubeVertices[k_CubeTriangles[i]], size);
 
-            ProBuilderMesh pb = ProBuilderMesh.CreateInstanceWithPoints(points);
-            pb.gameObject.name = "Cube";
-            pb.SetPivot(pivotType);
+            ProBuilderMesh mesh = ProBuilderMesh.CreateInstanceWithPoints(points);
+            mesh.gameObject.name = "Cube";
 
-            return pb;
+            if(pivotType == PivotLocation.Center)
+                foreach (var face in mesh.facesInternal)
+                    face.uv = new AutoUnwrapSettings(face.uv) { offset = new Vector2(-.5f, -.5f) };
+
+            mesh.SetPivot(pivotType);
+
+            return mesh;
         }
 
         /// <summary>

--- a/Runtime/MeshOperations/MeshTransform.cs
+++ b/Runtime/MeshOperations/MeshTransform.cs
@@ -11,7 +11,7 @@ namespace UnityEngine.ProBuilder.MeshOperations
         /// <param name="mesh">The <see cref="ProBuilderMesh"/> to adjust vertices for a new pivot point.</param>
         /// <param name="pivotLocation">The new pivot point is either the center of the mesh bounding box, or
         /// the bounds center - extents.</param>
-        public static void SetPivot(this ProBuilderMesh mesh, PivotLocation pivotLocation)
+        internal static void SetPivot(this ProBuilderMesh mesh, PivotLocation pivotLocation)
         {
             var bounds = mesh.GetBounds();
             var pivot = pivotLocation == PivotLocation.Center ? bounds.center : bounds.center - bounds.extents;

--- a/Runtime/MeshOperations/MeshTransform.cs
+++ b/Runtime/MeshOperations/MeshTransform.cs
@@ -5,21 +5,17 @@ namespace UnityEngine.ProBuilder.MeshOperations
     /// </summary>
     public static class MeshTransform
     {
-        internal static void SetPivot(this ProBuilderMesh mesh, PivotLocation pivotType, Vector3? pivotPosition = null)
+        /// <summary>
+        /// Set the pivot point for a mesh to either the center, or a corner point of the bounding box.
+        /// </summary>
+        /// <param name="mesh">The <see cref="ProBuilderMesh"/> to adjust vertices for a new pivot point.</param>
+        /// <param name="pivotLocation">The new pivot point is either the center of the mesh bounding box, or
+        /// the bounds center - extents.</param>
+        public static void SetPivot(this ProBuilderMesh mesh, PivotLocation pivotLocation)
         {
-            if(mesh.vertexCount == 0)
-                return;
-
-            switch (pivotType)
-            {
-                case PivotLocation.Center:
-                    mesh.CenterPivot(null);
-                    break;
-
-                case PivotLocation.FirstCorner:
-                    mesh.SetPivot(pivotPosition == null ? Vector3.zero : (Vector3)pivotPosition);
-                    break;
-            }
+            var bounds = mesh.GetBounds();
+            var pivot = pivotLocation == PivotLocation.Center ? bounds.center : bounds.center - bounds.extents;
+            SetPivot(mesh, mesh.transform.TransformPoint(pivot));
         }
 
         /// <summary>
@@ -70,8 +66,10 @@ namespace UnityEngine.ProBuilder.MeshOperations
             if (mesh == null)
                 throw new System.ArgumentNullException("mesh");
 
-            Vector3 offset = mesh.transform.position - worldPosition;
-            mesh.transform.position = worldPosition;
+            var transform = mesh.transform;
+            Vector3 offset = transform.position - worldPosition;
+            transform.position = worldPosition;
+
             mesh.ToMesh();
             mesh.TranslateVerticesInWorldSpace(mesh.mesh.triangles, offset);
             mesh.Refresh();

--- a/Runtime/Shapes/ProBuilderShape.cs
+++ b/Runtime/Shapes/ProBuilderShape.cs
@@ -46,7 +46,7 @@ namespace UnityEngine.ProBuilder.Shapes
         public Vector3 pivotGlobalPosition
         {
             get => mesh.transform.TransformPoint(m_PivotPosition);
-            set => m_PivotPosition = mesh.transform.InverseTransformPoint(value);
+            set => pivotLocalPosition = mesh.transform.InverseTransformPoint(value);
         }
 
         public Vector3 size
@@ -131,11 +131,13 @@ namespace UnityEngine.ProBuilder.Shapes
             Rebuild();
         }
 
-        internal void Rebuild(Bounds bounds, Quaternion rotation)
+        internal void Rebuild(Bounds bounds, Quaternion rotation, Vector3 cornerPivot)
         {
+            var trs = transform;
+            trs.position = bounds.center;
+            trs.rotation = rotation;
             size = bounds.size;
-            transform.position = bounds.center;
-            transform.rotation = rotation;
+            pivotGlobalPosition = pivotLocation == PivotLocation.Center ? bounds.center : cornerPivot;
             Rebuild();
         }
 
@@ -217,7 +219,7 @@ namespace UnityEngine.ProBuilder.Shapes
             {
                 var bbCenter = mesh.transform.TransformPoint(m_ShapeBox.center);
                 var pivotWorldPos = mesh.transform.TransformPoint(m_PivotPosition);
-                mesh.SetPivot(m_PivotLocation, pivotWorldPos);
+                mesh.SetPivot(pivotWorldPos);
                 m_ShapeBox.center = mesh.transform.InverseTransformPoint(bbCenter);
                 m_PivotPosition = mesh.transform.InverseTransformPoint(pivotWorldPos);
                 m_ShapeBox = m_Shape.UpdateBounds(mesh, size, rotation, m_ShapeBox);

--- a/Tests/Editor/Actions/StripProBuilderScriptsTest.cs
+++ b/Tests/Editor/Actions/StripProBuilderScriptsTest.cs
@@ -53,7 +53,7 @@ public class StripProBuilderScriptsTest
     {
         var go = new GameObject();
         var shape = go.AddComponent<ProBuilderShape>();
-        shape.Rebuild(new Bounds(Vector3.zero, Vector3.one), Quaternion.identity);
+        shape.Rebuild(new Bounds(Vector3.zero, Vector3.one), Quaternion.identity, Vector3.zero);
 
         Assume.That(go.GetComponent<ProBuilderMesh>() != null);
         Assume.That(go.GetComponent<ProBuilderShape>() != null);
@@ -71,7 +71,7 @@ public class StripProBuilderScriptsTest
     {
         var go = new GameObject();
         var shape = go.AddComponent<ProBuilderShape>();
-        shape.Rebuild(new Bounds(Vector3.zero, Vector3.one), Quaternion.identity);
+        shape.Rebuild(new Bounds(Vector3.zero, Vector3.one), Quaternion.identity, Vector3.zero);
 
         Assume.That(go.GetComponent<ProBuilderMesh>() != null);
         Assume.That(go.GetComponent<ProBuilderShape>() != null);
@@ -97,7 +97,7 @@ public class StripProBuilderScriptsTest
     {
         var go = new GameObject("Parent GO");
         var shape = go.AddComponent<ProBuilderShape>();
-        shape.Rebuild(new Bounds(Vector3.zero, Vector3.one), Quaternion.identity);
+        shape.Rebuild(new Bounds(Vector3.zero, Vector3.one), Quaternion.identity, Vector3.zero);
 
         Assume.That(go.GetComponent<ProBuilderMesh>() != null);
         Assume.That(go.GetComponent<ProBuilderShape>() != null);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.probuilder",
   "displayName": "ProBuilder",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "unity": "2019.4",
   "description": "Build, edit, and texture custom geometry in Unity. Use ProBuilder for in-scene level design, prototyping, collision meshes, all with on-the-fly play-testing.\n\nAdvanced features include UV editing, vertex colors, parametric shapes, and texture blending. With ProBuilder's model export feature it's easy to tweak your levels in any external 3D modelling suite.",
   "keywords": [


### PR DESCRIPTION
### Bug Fixes

- Fixed `Draw Shape` tool showing incorrect UVs when setting shape bounding box.
- Fixed `Draw Shape` tool not clearing selection when changing the active shape type.
- Fixed `Cut Tool` error when pressing `Backspace` with no vertices placed.
- Fixed `Cut Tool` error when finishing a cut segment with less than 3 vertices.
- Fixed `Draw Shape` tool truncating shape property fields in the Scene View Overlay.

### Changes

- Moved contents of warning box in `Draw Shape` tool to tooltips.
