### PR TITLE
Fixing 'Gen Shadow Obj' tool from ProBuilder window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Bug Fixes
 
+- [case: 1322032] Fixing wrong ProBuilderMesh colors on domain reload when null.
 - [case: 1317148] Fixing edge picking problem with some Unity versions. 
 - [case: 1312537] Fixing script stripping on disabled objects when building.
 - [case: 1311258] Fixing material reverting when subdividing edge.

--- a/Runtime/Core/ProBuilderMesh.cs
+++ b/Runtime/Core/ProBuilderMesh.cs
@@ -647,7 +647,7 @@ namespace UnityEngine.ProBuilder
 
             set
             {
-                if (value == null)
+                if (value == null || value.Count() == 0)
                     m_Colors = null;
                 else if (value.Count() != vertexCount)
                     throw new ArgumentOutOfRangeException("value", "Array length must match vertex count.");


### PR DESCRIPTION
### Purpose of this PR
Fixing Gen Shadow Obj tool from ProBuilder window.

The problem was due to a bad initialization of ProBuilderMesh colors table on domain reload.
In the case were colors table is null, this would result in a table of 0 elements on domain reload and create the current problem with a count difference between the vertex and the color count.
Preventing this by settings colors table to null if no elements are in the table.

### Links

**Fogbugz:** https://fogbugz.unity3d.com/f/cases/1322032/

### Comments to Reviewers
