### PR TITLE
Preventing creation of empty submeshes when probuilderizing 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- [case: 1320936] Fixing 'ProBuilderize' action creating empty submeshes.
+
 ### Changes
 
 - Add `GameObject/ProBuilder` menu to create primitives with default dimensions.

--- a/Runtime/Core/ProBuilderMeshFunction.cs
+++ b/Runtime/Core/ProBuilderMeshFunction.cs
@@ -324,7 +324,7 @@ namespace UnityEngine.ProBuilder
 
             Submesh[] submeshes = Submesh.GetSubmeshes(facesInternal, materialCount, preferredTopology);
 
-            mesh.subMeshCount = materialCount;
+            mesh.subMeshCount = submeshes.Length;
 
             for (int i = 0; i < mesh.subMeshCount; i++)
             {

--- a/Runtime/Core/Submesh.cs
+++ b/Runtime/Core/Submesh.cs
@@ -186,6 +186,8 @@ namespace UnityEngine.ProBuilder
                 }
             }
 
+            //Removing submeshes that does not contain vertices
+            submeshes = submeshes.Where(submesh => submesh.m_Indexes.Length != 0).ToArray();
             return submeshes;
         }
 

--- a/Runtime/Core/Submesh.cs
+++ b/Runtime/Core/Submesh.cs
@@ -113,6 +113,7 @@ namespace UnityEngine.ProBuilder
             List<int>[] quads = wantsQuads ? new List<int>[submeshCount] : null;
             List<int>[] tris = new List<int>[submeshCount];
             int maxSubmeshIndex = submeshCount - 1;
+            int maxSubmeshIndexUsed = -1;
 
             for (int i = 0; i < submeshCount; i++)
             {
@@ -128,13 +129,14 @@ namespace UnityEngine.ProBuilder
                     continue;
 
                 int submeshIndex = Math.Clamp(face.submeshIndex, 0, maxSubmeshIndex);
-
+                maxSubmeshIndexUsed = UnityEngine.Mathf.Max(submeshIndex,maxSubmeshIndexUsed);
                 if (wantsQuads && face.IsQuad())
                     quads[submeshIndex].AddRange(face.ToQuad());
                 else
                     tris[submeshIndex].AddRange(face.indexesInternal);
             }
 
+            submeshCount = maxSubmeshIndexUsed + 1;
             var submeshes = new Submesh[submeshCount];
 
             switch (preferredTopology)
@@ -186,8 +188,6 @@ namespace UnityEngine.ProBuilder
                 }
             }
 
-            //Removing submeshes that does not contain vertices
-            submeshes = submeshes.Where(submesh => submesh.m_Indexes.Length != 0).ToArray();
             return submeshes;
         }
 


### PR DESCRIPTION
### Purpose of this PR

Preventing creation of empty submeshes when probuilderizing meshes with multiple materials but no submeshes.

### Links

https://fogbugz.unity3d.com/f/cases/1320936/
