### PR TITLE
Fixing sphere and torus UV generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- [case: 1322150] Fixing torus and sphere UV generation when creating New Shape.
+
 ### Changes
 
 - Add `GameObject/ProBuilder` menu to create primitives with default dimensions.

--- a/Runtime/Shapes/Torus.cs
+++ b/Runtime/Shapes/Torus.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using UnityEditor;
+using UnityEngine.ProBuilder.MeshOperations;
 
 namespace UnityEngine.ProBuilder.Shapes
 {
@@ -118,6 +119,8 @@ namespace UnityEngine.ProBuilder.Shapes
 
             mesh.TranslateVerticesInWorldSpace(mesh.mesh.triangles, mesh.transform.TransformDirection(-mesh.mesh.bounds.center));
             mesh.Refresh();
+
+            UVEditing.ProjectFacesBox(mesh, mesh.facesInternal);
 
             return UpdateBounds(mesh, size, rotation, new Bounds());
         }


### PR DESCRIPTION
### Purpose of this PR

This PR fixes a problem in UV generation for the New Shape tool for Spheres and Torus shapes.
The PR corrects that by using the same projection parameters that were used for PB4.4

Previous UVs:
![image](https://user-images.githubusercontent.com/66317117/112041371-b6f84080-8b1c-11eb-9369-4b36f88908ed.png)

New UVs:
![image](https://user-images.githubusercontent.com/66317117/112041193-7ac4e000-8b1c-11eb-92ee-865271f60e58.png)

### Links

**Fogbugz:** https://fogbugz.unity3d.com/f/cases/1322150/

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]