### PR TITLE
Bugfix/fixing mesh collider error with unity21.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Bug Fixes
 
+- [case: 1323666] Preventing to assign an empty mesh as MeshCollider.
 - [case: 1320936] Fixing 'ProBuilderize' action creating empty submeshes.
 
 ### Changes

--- a/Runtime/Core/ProBuilderMeshFunction.cs
+++ b/Runtime/Core/ProBuilderMeshFunction.cs
@@ -426,7 +426,7 @@ namespace UnityEngine.ProBuilder
                 SerializationUtility.RegisterDrivenProperty(this, collider, "m_Mesh");
 #endif
 
-                collider.sharedMesh = mesh;
+                collider.sharedMesh = (mesh != null && mesh.vertexCount > 0) ? mesh : null;
             }
         }
 

--- a/Runtime/Core/ProBuilderMeshFunction.cs
+++ b/Runtime/Core/ProBuilderMeshFunction.cs
@@ -425,7 +425,6 @@ namespace UnityEngine.ProBuilder
 #if ENABLE_DRIVEN_PROPERTIES
                 SerializationUtility.RegisterDrivenProperty(this, collider, "m_Mesh");
 #endif
-
                 collider.sharedMesh = (mesh != null && mesh.vertexCount > 0) ? mesh : null;
             }
         }


### PR DESCRIPTION
### Purpose of this PR

Using Unity 21.2 a new error message appear wile drawing the shape:

![pb-emptymesh](https://user-images.githubusercontent.com/66317117/112165890-88827000-8bc5-11eb-897c-78088e767821.gif)

This is actually caused when trying to assign a mesh that doesn't have any vertex to the meshcollider.
This is fixed in this PR by just checking that vertexCount > 0 before assigning it to the collider and assigning a null mesh if it's the case.

![pb-emptymesh-fixed](https://user-images.githubusercontent.com/66317117/112167917-3a6e6c00-8bc7-11eb-8ded-8365c506990c.gif)

### Links

**Fogbugz:** https://fogbugz.unity3d.com/f/cases/1323666/
