### PR TITLE
EditShapeTool bugfix

### DIFF
--- a/Editor/EditorCore/EditShapeTool.cs
+++ b/Editor/EditorCore/EditShapeTool.cs
@@ -99,8 +99,8 @@ namespace UnityEditor.ProBuilder
 
 #if !UNITY_2020_2_OR_NEWER
             ToolManager.activeToolChanging += ActiveToolChanging;
-#endif
             ProBuilderEditor.selectModeChanged += OnSelectModeChanged;
+#endif
 
         }
 
@@ -108,8 +108,8 @@ namespace UnityEditor.ProBuilder
         {
 #if !UNITY_2020_2_OR_NEWER
             ToolManager.activeToolChanging -= ActiveToolChanging;
-#endif
             ProBuilderEditor.selectModeChanged -= OnSelectModeChanged;
+#endif
             if(m_ShapeEditor != null)
                 DestroyImmediate(m_ShapeEditor);
         }
@@ -131,13 +131,21 @@ namespace UnityEditor.ProBuilder
         public override void OnActivated()
         {
             base.OnActivated();
+            ProBuilderEditor.selectModeChanged += OnSelectModeChanged;
             EditorApplication.delayCall += () => ProBuilderEditor.selectMode = SelectMode.Object;
         }
 
         public override void OnWillBeDeactivated()
         {
             base.OnWillBeDeactivated();
-            EditorApplication.delayCall += () => ProBuilderEditor.ResetToLastSelectMode();
+            ProBuilderEditor.selectModeChanged -= OnSelectModeChanged;
+            EditorApplication.delayCall += () => ResetToLastSelectMode();
+        }
+
+        public void ResetToLastSelectMode()
+        {
+            if(ProBuilderToolManager.activeTool != Tool.Custom)
+                ProBuilderEditor.ResetToLastSelectMode();
         }
 #endif
 

--- a/Editor/EditorCore/ProBuilderEditor.cs
+++ b/Editor/EditorCore/ProBuilderEditor.cs
@@ -46,7 +46,7 @@ namespace UnityEditor.ProBuilder
 
         EditorToolbar m_Toolbar;
         ProBuilderToolManager m_ToolManager; // never use this directly! use toolManager getter to avoid problems with multiple editor instances
-        static ProBuilderToolManager toolManager => s_Instance != null ? s_Instance.m_ToolManager : null;
+        internal static ProBuilderToolManager toolManager => s_Instance != null ? s_Instance.m_ToolManager : null;
         internal EditorToolbar toolbar => m_Toolbar; // used by unit tests
         static ProBuilderEditor s_Instance;
 


### PR DESCRIPTION
### Purpose of this PR

Fix for PB EditShape Tool.
When using PB5 with Unity 20.2 and after (use of EditorToolContext) using the EditShapeTool does not allow to start New Shape or New Polyshape tools and automatically returns to 
The PR fixes that.

### Links
EditShapeTool bug:
![editshapetool-bug](https://user-images.githubusercontent.com/66317117/112545339-7dc70700-8d8e-11eb-9235-eb584d2ce9ce.gif)

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]