### PR TITLE
Fixing errors popping in console when building scenes with prefabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Bug Fixes
 
+- [case: 1324399] Fixing errors when building with prefabs in scene.
 - [case: 1323666] Preventing to assign an empty mesh as MeshCollider.
 - [case: 1322032] Fixing wrong ProBuilderMesh colors on domain reload when null.
 - [case: 1322150] Fixing torus and sphere UV generation when creating New Shape.

--- a/Editor/EditorCore/UnityScenePostProcessor.cs
+++ b/Editor/EditorCore/UnityScenePostProcessor.cs
@@ -27,7 +27,7 @@ namespace UnityEditor.ProBuilder
             // Hide nodraw faces if present.
             foreach (var pb in pbMeshes)
             {
-                if (pb.GetComponent<MeshRenderer>() == null)
+                if (pb.GetComponent<MeshRenderer>() == null || UnityEditor.EditorUtility.IsPersistent(pb))
                     continue;
 
                 if (pb.GetComponent<MeshRenderer>().sharedMaterials.Any(x => x != null && x.name.Contains("NoDraw")))
@@ -55,6 +55,9 @@ namespace UnityEditor.ProBuilder
 
             foreach (var mesh in pbMeshes)
             {
+                if (UnityEditor.EditorUtility.IsPersistent(mesh))
+                    continue;
+
                 EditorUtility.SynchronizeWithMeshFilter(mesh);
 
                 if (mesh.mesh == null)
@@ -82,6 +85,7 @@ namespace UnityEditor.ProBuilder
                     continue;
 
                 StripProBuilderScripts.DestroyProBuilderMeshAndDependencies(gameObject, mesh, true);
+
             }
         }
 


### PR DESCRIPTION
### Purpose of this PR

Building scenes with prefabs was causing errors in the console during script scripting. This was due to the use of FindObjectsOfTypeAll introduced previously to strip scripts on objects that were disabled in the scene. As this function also retrieves prefabs, this PR checks if the actual object is a prefab or an instantiated object before stripping. 

### Links

**Fogbugz:** https://fogbugz.unity3d.com/f/cases/1324399/

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]