### PR TITLE
Fix for missing Gizmos Menu items for projects that have ProBuilder installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
-## [Unreleased]
+
+## [5.0.3] - 2021-04-01
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+## [Unreleased]
+
+### Bug Fixes
+
+- [case: 1332226] Fixed issue where some Gizmos menu items would be missing in projects that have ProBuilder package installed.
+
 ## [5.0.3] - 2021-04-01
 
 ### Bug Fixes

--- a/Editor/EditorCore/HierarchyListener.cs
+++ b/Editor/EditorCore/HierarchyListener.cs
@@ -12,14 +12,7 @@ namespace UnityEditor.ProBuilder
     {
         static HierarchyListener()
         {
-            // The inspector icon for ProBuilderMesh is set in the component metadata. However, this also serves as the
-            // scene view gizmo icon, which we do not want. To avoid drawing an icon for every mesh in the Scene View,
-            // we simply tell the AnnotationManager to not render the icon. This _does_ put ProBuilderMesh in the
-            // "Recently Changed" list, but only when it is modified the first time.
-            // The alternative method of setting an icon is to place it in a folder named "Editor Default Resources/Icons",
-            // however that requires that the resources directory be in "Assets", which we do not want to do.
-            EditorUtility.SetGizmoIconEnabled(typeof(ProBuilderMesh), false);
-
+            AssemblyReloadEvents.afterAssemblyReload += OnAfterAssemblyReload;
             // When a prefab is updated, this is raised.  For some reason it's
             // called twice?
             EditorApplication.hierarchyChanged += HierarchyWindowChanged;
@@ -27,6 +20,17 @@ namespace UnityEditor.ProBuilder
             // prefabInstanceUpdated is not called when dragging out of Project view,
             // or when creating a prefab or reverting.  OnHierarchyChange captures those.
             PrefabUtility.prefabInstanceUpdated += PrefabInstanceUpdated;
+        }
+
+        static void OnAfterAssemblyReload()
+        {
+            // The inspector icon for ProBuilderMesh is set in the component metadata. However, this also serves as the
+            // scene view gizmo icon, which we do not want. To avoid drawing an icon for every mesh in the Scene View,
+            // we simply tell the AnnotationManager to not render the icon. This _does_ put ProBuilderMesh in the
+            // "Recently Changed" list, but only when it is modified the first time.
+            // The alternative method of setting an icon is to place it in a folder named "Editor Default Resources/Icons",
+            // however that requires that the resources directory be in "Assets", which we do not want to do.
+            EditorApplication.delayCall += () => EditorUtility.SetGizmoIconEnabled(typeof(ProBuilderMesh), false);
         }
 
         static void PrefabInstanceUpdated(GameObject go)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.probuilder",
   "displayName": "ProBuilder",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "unity": "2019.4",
   "description": "Build, edit, and texture custom geometry in Unity. Use ProBuilder for in-scene level design, prototyping, collision meshes, all with on-the-fly play-testing.\n\nAdvanced features include UV editing, vertex colors, parametric shapes, and texture blending. With ProBuilder's model export feature it's easy to tweak your levels in any external 3D modelling suite.\n\nIf you are using URP/HDRP, be careful to also import the corresponding sample project in the section below to get the proper materials.",
   "keywords": [

--- a/validationExceptions.json
+++ b/validationExceptions.json
@@ -1,0 +1,9 @@
+{
+    "Exceptions":
+    [
+        {
+             "ValidationTest": "API Validation",
+             "PackageVersion": "5.0.3"
+       }
+    ]
+}

--- a/validationExceptions.json.meta
+++ b/validationExceptions.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a1430a41101d44a61a313b6897f438c0
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Purpose of this PR

 This PR fixes an issue where some Gizmos Menu items would be missing in projects that have the ProBuilder package installed.

### Links

**Fogbugz:** https://fogbugz.unity3d.com/f/cases/1332226

### Comments to Reviewers

Sequence of events causing this issue:

- User selects to install PB package or opens a project that contains PB
- Domain reload is triggered
- `GizmoSetup` (C++) receives `OnBeforeDomainReload` and clears all gizmo renderers and setups
- `AnnotationManager` (C++) receives `OnDomainReload` and sets its dirty flag
- `[InitializeOnLoad]` attributes are processed and PB `HierarchyListener`'s constructor is called which in turn calls `AnnotationUtility.GetAnnotations()`
- `AnnotationManager.GetAnotations()` internally calls `AnnotationManager.Refresh()` which, due to the dirty flag being set previously, attempts to rebuild annotations from an empty `GizmoSetup` and clears the dirty flag
- When eventually `OnDidReloadDomain` triggers, `GizmoSetup` rebuilds gizmo renderers and setups
- User opens Gizmos Menu
- `AnnotationManager.Refresh()` (C++) is called but it early exits due to the previously cleared dirty flag. This is when `AnnotationManager` would normally rebuild annotations but, due to `HierarchyListener` forcing an early `AnnotationManager.Refresh()`, the dirty flag has the wrong state. 

Proposed fix:

Delay `HierarchyListener`'s call to `AnnotationUtility.GetAnnotations()` by registering for `AssemblyReloadEvents.afterAssemblyReload` callback during `HierarchyListener`'s initialization. Using `EditorApplication.delayCall` delays it further and ensures there's no race condition between `HierarchyListener` and `GizmoSetup`'s handling of `OnDidReloadDomain`.

Tested opening existing projects that contain PB and adding/removing PB in open projects with 2019.4, 2020.3 and 2021.2.012a