### PR TITLE
[Backport] Fix for missing Gizmos Menu items for projects that have ProBuilder installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Bug Fixes
+
+- [case: 1332226] Fixed issue where some Gizmos menu items would be missing in projects that have ProBuilder package installed.
+
 ## [4.5.1] - 2021-02-04
 
 ### Bug Fixes

--- a/Editor/EditorCore/HierarchyListener.cs
+++ b/Editor/EditorCore/HierarchyListener.cs
@@ -12,14 +12,7 @@ namespace UnityEditor.ProBuilder
     {
         static HierarchyListener()
         {
-            // The inspector icon for ProBuilderMesh is set in the component metadata. However, this also serves as the
-            // scene view gizmo icon, which we do not want. To avoid drawing an icon for every mesh in the Scene View,
-            // we simply tell the AnnotationManager to not render the icon. This _does_ put ProBuilderMesh in the
-            // "Recently Changed" list, but only when it is modified the first time.
-            // The alternative method of setting an icon is to place it in a folder named "Editor Default Resources/Icons",
-            // however that requires that the resources directory be in "Assets", which we do not want to do.
-            EditorUtility.SetGizmoIconEnabled(typeof(ProBuilderMesh), false);
-
+            AssemblyReloadEvents.afterAssemblyReload += OnAfterAssemblyReload;
             // When a prefab is updated, this is raised.  For some reason it's
             // called twice?
  #if UNITY_2018_1_OR_NEWER
@@ -31,6 +24,17 @@ namespace UnityEditor.ProBuilder
             // prefabInstanceUpdated is not called when dragging out of Project view,
             // or when creating a prefab or reverting.  OnHierarchyChange captures those.
             PrefabUtility.prefabInstanceUpdated += PrefabInstanceUpdated;
+        }
+
+        static void OnAfterAssemblyReload()
+        {
+            // The inspector icon for ProBuilderMesh is set in the component metadata. However, this also serves as the
+            // scene view gizmo icon, which we do not want. To avoid drawing an icon for every mesh in the Scene View,
+            // we simply tell the AnnotationManager to not render the icon. This _does_ put ProBuilderMesh in the
+            // "Recently Changed" list, but only when it is modified the first time.
+            // The alternative method of setting an icon is to place it in a folder named "Editor Default Resources/Icons",
+            // however that requires that the resources directory be in "Assets", which we do not want to do.
+            EditorApplication.delayCall += () => EditorUtility.SetGizmoIconEnabled(typeof(ProBuilderMesh), false);
         }
 
         static void PrefabInstanceUpdated(GameObject go)


### PR DESCRIPTION
### Purpose of this PR

Backport of this PR: https://github.com/Unity-Technologies/com.unity.probuilder/pull/392

### Links

**Fogbugz:** https://fogbugz.unity3d.com/f/cases/1332226