### PR TITLE
Fixing PBShape export using FBX Exporter

### DIFF
--- a/Addons/Fbx.cs
+++ b/Addons/Fbx.cs
@@ -1,8 +1,9 @@
-// todo Once we drop support for 2018.3, use optional assembly definitions
-using System;
+#if FBX_EXPORTER
+
 using UnityEditor;
 using System.Reflection;
 using System.Linq;
+using UnityEditor.Formats.Fbx.Exporter;
 using UnityEditor.ProBuilder;
 using UnityEditor.ProBuilder.Actions;
 
@@ -27,22 +28,7 @@ namespace UnityEngine.ProBuilder.Addons.FBX
     [InitializeOnLoad]
     static class Fbx
     {
-        private static Assembly FbxExporterAssembly
-        {
-            get
-            {
-                try
-                {
-                    return Assembly.Load("Unity.Formats.Fbx.Editor");
-                }
-                catch (System.IO.FileNotFoundException)
-                {
-                    return null;
-                }
-            }
-        }
-
-        static FbxOptions m_FbxOptions = new FbxOptions() {
+        static FbxOptions s_FbxOptions = new FbxOptions() {
             quads = true
         };
 
@@ -53,46 +39,27 @@ namespace UnityEngine.ProBuilder.Addons.FBX
 
         static void TryLoadFbxSupport()
         {
-            if (FbxExporterAssembly == null)
-            {
-                return;
-            }
-
-            var modelExporter = FbxExporterAssembly.GetType("UnityEditor.Formats.Fbx.Exporter.ModelExporter");
-            var registerMeshCallback = modelExporter.GetMethods(BindingFlags.NonPublic | BindingFlags.Static).Where(x => x.Name == "RegisterMeshCallback").First(x => x.ContainsGenericParameters);
-            registerMeshCallback = registerMeshCallback.MakeGenericMethod(typeof(ProBuilderMesh));
-
-            var getMeshForComponent = FbxExporterAssembly.GetTypes()
-               .Where(t => t.BaseType == typeof(MulticastDelegate) && t.Name.StartsWith("GetMeshForComponent"))
-               .First(t => t.ContainsGenericParameters);
-
-            getMeshForComponent = getMeshForComponent.MakeGenericType(typeof(ProBuilderMesh));
-            var meshDelegate = Delegate.CreateDelegate(getMeshForComponent, typeof(Fbx).GetMethod("GetMeshForComponent", BindingFlags.NonPublic | BindingFlags.Static));
-
-            registerMeshCallback.Invoke(null, new object[] { meshDelegate, true });
-
-            m_FbxOptions.quads = ProBuilderSettings.Get<bool>("Export::m_FbxQuads", SettingsScope.User, true);
+            ModelExporter.RegisterMeshCallback<ProBuilderMesh>(GetMeshForPBComponent, true);
+            s_FbxOptions.quads = ProBuilderSettings.Get<bool>("Export::m_FbxQuads", SettingsScope.User, true);
         }
 
-        static bool GetMeshForComponent(object exporter, ProBuilderMesh pmesh, object node)
+        static bool GetMeshForPBComponent(ModelExporter exporter, ProBuilderMesh pmesh, Autodesk.Fbx.FbxNode node)
         {
             Mesh mesh = new Mesh();
-            MeshUtility.Compile(pmesh, mesh, m_FbxOptions.quads ? MeshTopology.Quads : MeshTopology.Triangles);
+            MeshUtility.Compile(pmesh, mesh, s_FbxOptions.quads ? MeshTopology.Quads : MeshTopology.Triangles);
 
-            // using reflection to call: exporter.ExportMesh(mesh, node, pmesh.GetComponent<MeshRenderer>().sharedMaterials)
             var pMeshRenderer = pmesh.GetComponent<MeshRenderer>();
             var sharedMaterials = pMeshRenderer ? pMeshRenderer.sharedMaterials : null;
-            var exportMeshMethod = exporter.GetType().GetMethod("ExportMesh", BindingFlags.NonPublic | BindingFlags.Instance, null, new Type[] { typeof(Mesh), node.GetType(), typeof(Material[]) }, null);
-            exportMeshMethod.Invoke(exporter, new object[] { mesh, node, sharedMaterials });
+
+            exporter.ExportMesh(mesh, node, sharedMaterials);
 
             Object.DestroyImmediate(mesh);
 
+            //Need to have ExportOptions accessible to remove this reflection
             var exporterType = exporter.GetType().GetMethods(BindingFlags.NonPublic | BindingFlags.Instance)
                 .First(x => x.Name == "get_ExportOptions").Invoke(exporter, null).GetType();
 
-            var prefabExporterType = FbxExporterAssembly.GetType("UnityEditor.Formats.Fbx.Exporter.ConvertToPrefabSettingsSerialize");
-
-            if(exporterType == prefabExporterType)
+            if(exporterType == typeof(ConvertToPrefabSettingsSerialize))
             {
                 // probuilder can't handle mesh assets that may be externally reloaded, just strip pb stuff for now.
                 StripProBuilderScripts.DoStrip(pmesh);
@@ -102,3 +69,5 @@ namespace UnityEngine.ProBuilder.Addons.FBX
         }
     }
 }
+
+#endif

--- a/Addons/Unity.ProBuilder.AddOns.Editor.asmdef
+++ b/Addons/Unity.ProBuilder.AddOns.Editor.asmdef
@@ -1,10 +1,12 @@
 {
     "name": "Unity.ProBuilder.AddOns.Editor",
+    "rootNamespace": "",
     "references": [
         "Unity.ProBuilder",
-        "Unity.ProBuilder.Editor"
+        "Unity.ProBuilder.Editor",
+        "Unity.Formats.Fbx.Editor",
+        "Autodesk.Fbx"
     ],
-    "optionalUnityReferences": [],
     "includePlatforms": [
         "Editor"
     ],
@@ -12,5 +14,14 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.formats.fbx",
+            "expression": "4.0.0",
+            "define": "FBX_EXPORTER"
+        }
+    ],
+    "noEngineReferences": false
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Bug Fixes
 
+- [case: 1334017] Fixed errors while exporting a PBShape using FBX Exporter and cleaning export.
 - [case: 1332226] Fixed issue where some Gizmos menu items would be missing in projects that have ProBuilder package installed.
 - [case: 1324374] Fixed incorrect vertex/edge/face rect selection when mesh's parent is rotated and/or scaled.
 


### PR DESCRIPTION
### Purpose of this PR

Fixing Probuilder mesh throwing errors with FBX Exporter due to the presence of ProBuilderShape that was not removed.
The PR calls the `StripProBuilderScripts` class now for more consistency and the code is now also aware of the difference between "FBX Export" that does not replace the PB Object and "Convert to prefab" that creates a prefab, strips PB objects and replace the object in the scene.

![FBXexportResolution](https://user-images.githubusercontent.com/66317117/118875396-027b6080-b8ba-11eb-8e5a-3803f11eb4af.gif)

### Links

**Fogbugz:** https://fogbugz.unity3d.com/f/cases/1334017/

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]