### PR TITLE
fix unecessary reflection to get nearest vertex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [UNRELEASED]
+## [4.5.3] - 2021-07-23
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Bug Fixes
 
 - Fixed exception when using vertex snapping in Unity 2019.4 and newer.
+- Fixed API Updater warning when opening in Unity 2021 and newer.
 
 ## [4.5.2] - 2021-06-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+
+### Bug Fixes
+
+- Fixed exception when using vertex snapping in Unity 2019.4 and newer.
+
 ## [4.5.2] - 2021-06-08
 
 ### Bug Fixes

--- a/Editor/EditorCore/EditorUtility.cs
+++ b/Editor/EditorCore/EditorUtility.cs
@@ -3,13 +3,18 @@
 using UnityEngine;
 using System.Linq;
 using System;
-using UnityEditor.Experimental.SceneManagement;
+
 using UnityEngine.ProBuilder;
 using UnityEngine.Rendering;
 using UObject = UnityEngine.Object;
 using UnityEditor.SettingsManagement;
 using UnityEditorInternal;
+#if UNITY_2021_1_OR_NEWER
 using UnityEngine.SceneManagement;
+#else
+using UnityEngine.SceneManagement;
+using UnityEditor.Experimental.SceneManagement;
+#endif
 #if !UNITY_2019_1_OR_NEWER
 using System.Reflection;
 #endif

--- a/Editor/EditorCore/EditorUtility.cs
+++ b/Editor/EditorCore/EditorUtility.cs
@@ -11,6 +11,7 @@ using UnityEditor.SettingsManagement;
 using UnityEditorInternal;
 #if UNITY_2021_1_OR_NEWER
 using UnityEngine.SceneManagement;
+using UnityEditor.SceneManagement;
 #else
 using UnityEngine.SceneManagement;
 using UnityEditor.Experimental.SceneManagement;

--- a/Editor/EditorCore/ShapeEditor.cs
+++ b/Editor/EditorCore/ShapeEditor.cs
@@ -1,12 +1,16 @@
 using System.Linq;
 using System.Reflection;
-using UnityEditor.Experimental.SceneManagement;
 using UnityEngine;
 using UnityEngine.ProBuilder;
 using PMath = UnityEngine.ProBuilder.Math;
 using UnityEditor.SettingsManagement;
 using UnityEngine.ProBuilder.MeshOperations;
+#if UNITY_2021_1_OR_NEWER
 using UnityEngine.SceneManagement;
+#else
+using UnityEngine.SceneManagement;
+using UnityEditor.Experimental.SceneManagement;
+#endif
 
 namespace UnityEditor.ProBuilder
 {

--- a/Editor/EditorCore/ShapeEditor.cs
+++ b/Editor/EditorCore/ShapeEditor.cs
@@ -7,6 +7,7 @@ using UnityEditor.SettingsManagement;
 using UnityEngine.ProBuilder.MeshOperations;
 #if UNITY_2021_1_OR_NEWER
 using UnityEngine.SceneManagement;
+using UnityEditor.SceneManagement;
 #else
 using UnityEngine.SceneManagement;
 using UnityEditor.Experimental.SceneManagement;

--- a/Editor/EditorCore/VertexManipulationTool.cs
+++ b/Editor/EditorCore/VertexManipulationTool.cs
@@ -395,6 +395,9 @@ namespace UnityEditor.ProBuilder
         /// <returns></returns>
         protected static bool FindNearestVertex(Vector2 mousePosition, out Vector3 vertex)
         {
+#if UNITY_2019_1_OR_NEWER
+            return HandleUtility.FindNearestVertex(mousePosition, null, out vertex);
+#else            
             s_FindNearestVertexArguments[0] = mousePosition;
 
             if (s_FindNearestVertex == null)
@@ -404,6 +407,7 @@ namespace UnityEditor.ProBuilder
             object result = s_FindNearestVertex.Invoke(null, s_FindNearestVertexArguments);
             vertex = (bool)result ? (Vector3)s_FindNearestVertexArguments[2] : Vector3.zero;
             return (bool)result;
+#endif
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.probuilder",
   "displayName": "ProBuilder",
-  "version": "4.5.2",
+  "version": "4.5.3",
   "unity": "2018.4",
   "description": "Build, edit, and texture custom geometry in Unity. Use ProBuilder for in-scene level design, prototyping, collision meshes, all with on-the-fly play-testing.\n\nAdvanced features include UV editing, vertex colors, parametric shapes, and texture blending. With ProBuilder's model export feature it's easy to tweak your levels in any external 3D modelling suite.",
   "keywords": [


### PR DESCRIPTION
**DO NOT FORGET TO INCLUDE A CHANGELOG ENTRY**

### Purpose of this PR

- Fixed exception when using vertex snapping in Unity 2019.4 and newer.
- Fixed API Updater warning when opening in Unity 2021 and newer.
