### PR TITLE
Bugfix/1331901 material auto removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - [case: 1332226] Fixed issue where some Gizmos menu items would be missing in projects that have ProBuilder package installed.
 - [case: 1324374] Fixed incorrect vertex/edge/face rect selection when mesh's parent is rotated and/or scaled.
+- [case: 1331901] Fixed issue where empty submesh materials would not be automatically removed from the renderer.
+
+### Changes
+
+- Added preference `Auto Remove Material` that's enabled by default and controls whether materials for empty submeshes should be removed automatically.
 
 ## [5.0.3] - 2021-04-01
 

--- a/Editor/EditorCore/EditorMeshUtility.cs
+++ b/Editor/EditorCore/EditorMeshUtility.cs
@@ -236,11 +236,13 @@ namespace UnityEditor.ProBuilder
 
         static void CleanupSubmeshesAndMaterials(ProBuilderMesh mesh)
         {
+            // Initially deem all submeshes as empty
             List<int> emptySubMeshIndices = new List<int>();
             var submeshCount = MaterialUtility.GetMaterialCount(mesh.renderer);
             for (int i = 0; i < submeshCount; i++)
                 emptySubMeshIndices.Add(i);
 
+            // Keep only the indices that aren't referenced by any of the faces
             foreach (var face in mesh.faces)
             {
                 if (emptySubMeshIndices.Contains(face.submeshIndex))
@@ -253,6 +255,7 @@ namespace UnityEditor.ProBuilder
 
             if (emptySubMeshIndices.Count > 0)
             {
+                // Lower the referenced submeshIndices based on how many empty submeshes there are
                 foreach (var face in mesh.faces)
                 {
                     foreach (var emptySubmeshIndex in emptySubMeshIndices)

--- a/Runtime/Core/MaterialUtility.cs
+++ b/Runtime/Core/MaterialUtility.cs
@@ -25,30 +25,25 @@ namespace UnityEngine.ProBuilder
             return s_MaterialArray[Math.Clamp(index, 0, count - 1)];
         }
 
-        /// <summary>
-        /// Given a sorted collection of material indices, removes renderer's shared materials
-        /// </summary>
-        /// <param name="renderer">Target renderer</param>
-        /// <param name="materialIndices">Sorted collection of material indices</param>
-        internal static void RemoveSharedMaterials(Renderer renderer, ICollection<int> materialIndices)
+        internal static void RemoveMaterialsAndTrimExcess(Renderer renderer, List<int> indicesToRemove, int submeshCount)
         {
+            indicesToRemove.Sort();
             s_MaterialArray.Clear();
             renderer.GetSharedMaterials(s_MaterialArray);
+            int startLength = s_MaterialArray.Count;
 
-            var materialsRemoved = 0;
-            foreach (var materialIndex in materialIndices)
+            for (int i = indicesToRemove.Count - 1; i >= 0; --i)
             {
-                var adjustedIndex = materialIndex - materialsRemoved;
-
-                if (adjustedIndex >= 0 && adjustedIndex < s_MaterialArray.Count)
-                {
-                    s_MaterialArray.RemoveAt(adjustedIndex);
-                    materialsRemoved++;
-                }
+                int indexToRemove = indicesToRemove[i];
+                if (indexToRemove < s_MaterialArray.Count)
+                    s_MaterialArray.RemoveAt(indexToRemove);
             }
 
-            if (materialsRemoved > 0)
-                renderer.sharedMaterials = s_MaterialArray.ToArray();
+            if (submeshCount < s_MaterialArray.Count)
+                s_MaterialArray.RemoveRange(submeshCount, s_MaterialArray.Count - submeshCount);
+
+            if (startLength != s_MaterialArray.Count)
+                renderer.materials = s_MaterialArray.ToArray();
         }
     }
 }

--- a/Runtime/Core/MaterialUtility.cs
+++ b/Runtime/Core/MaterialUtility.cs
@@ -24,5 +24,31 @@ namespace UnityEngine.ProBuilder
                 return null;
             return s_MaterialArray[Math.Clamp(index, 0, count - 1)];
         }
+
+        /// <summary>
+        /// Given a sorted collection of material indices, removes renderer's shared materials
+        /// </summary>
+        /// <param name="renderer">Target renderer</param>
+        /// <param name="materialIndices">Sorted collection of material indices</param>
+        internal static void RemoveSharedMaterials(Renderer renderer, ICollection<int> materialIndices)
+        {
+            s_MaterialArray.Clear();
+            renderer.GetSharedMaterials(s_MaterialArray);
+
+            var materialsRemoved = 0;
+            foreach (var materialIndex in materialIndices)
+            {
+                var adjustedIndex = materialIndex - materialsRemoved;
+
+                if (adjustedIndex >= 0 && adjustedIndex < s_MaterialArray.Count)
+                {
+                    s_MaterialArray.RemoveAt(adjustedIndex);
+                    materialsRemoved++;
+                }
+            }
+
+            if (materialsRemoved > 0)
+                renderer.sharedMaterials = s_MaterialArray.ToArray();
+        }
     }
 }

--- a/Runtime/Core/ProBuilderMeshFunction.cs
+++ b/Runtime/Core/ProBuilderMeshFunction.cs
@@ -321,12 +321,6 @@ namespace UnityEngine.ProBuilder
 
             m_MeshFormatVersion = k_MeshFormatVersion;
 
-            // Clean up empty submeshes and materials (TODO only if option is enable)
-            s_IndicesBuffer.Clear();
-            Submesh.GetEmptySubmeshes(faces, s_IndicesBuffer);
-            Submesh.RemoveSubmeshes(faces, s_IndicesBuffer);
-            MaterialUtility.RemoveMaterialsAndTrimExcess(renderer, s_IndicesBuffer, Submesh.GetSubmeshCount(faces));
-
             int materialCount = MaterialUtility.GetMaterialCount(renderer);
 
             Submesh[] submeshes = Submesh.GetSubmeshes(facesInternal, materialCount, preferredTopology);

--- a/Runtime/Core/ProBuilderMeshFunction.cs
+++ b/Runtime/Core/ProBuilderMeshFunction.cs
@@ -16,6 +16,7 @@ namespace UnityEngine.ProBuilder
 #endif
     {
         static HashSet<int> s_CachedHashSet = new HashSet<int>();
+        static List<int> s_IndicesBuffer = new List<int>();
 
 #if UNITY_EDITOR
         public void OnBeforeSerialize() {}
@@ -319,6 +320,12 @@ namespace UnityEngine.ProBuilder
             }
 
             m_MeshFormatVersion = k_MeshFormatVersion;
+
+            // Clean up empty submeshes and materials (TODO only if option is enable)
+            s_IndicesBuffer.Clear();
+            Submesh.GetEmptySubmeshes(faces, s_IndicesBuffer);
+            Submesh.RemoveSubmeshes(faces, s_IndicesBuffer);
+            MaterialUtility.RemoveMaterialsAndTrimExcess(renderer, s_IndicesBuffer, Submesh.GetSubmeshCount(faces));
 
             int materialCount = MaterialUtility.GetMaterialCount(renderer);
 

--- a/Runtime/Core/Submesh.cs
+++ b/Runtime/Core/Submesh.cs
@@ -84,17 +84,17 @@ namespace UnityEngine.ProBuilder
             return string.Format("{0}, {1}, {2}", m_SubmeshIndex, m_Topology.ToString(), m_Indexes != null ? m_Indexes.Length.ToString() : "0");
         }
 
-        internal static int GetSubmeshCount(ProBuilderMesh mesh)
-        {
-            return GetSubmeshCount(mesh.facesInternal);
-        }
-
-        internal static int GetSubmeshCount(IEnumerable<Face> faces)
+        internal static int GetSubmeshCount(IList<Face> faces)
         {
             int count = 0;
             foreach (var face in faces)
                 count = Mathf.Max(count, face.submeshIndex + 1);
             return count;
+        }
+
+        internal static int GetSubmeshCount(ProBuilderMesh mesh)
+        {
+            return GetSubmeshCount(mesh.facesInternal);
         }
 
         /// <summary>
@@ -218,29 +218,18 @@ namespace UnityEngine.ProBuilder
             }
         }
 
-        internal static void GetEmptySubmeshes(ICollection<Face> faces, List<int> emptySubmeshes)
+        internal static void GetEmptySubmeshes(Mesh umesh, List<int> emptySubMeshes)
         {
-            if (faces == null)
-                throw new ArgumentNullException(nameof(faces));
+            if (umesh == null)
+                throw new ArgumentNullException(nameof(umesh));
 
-            if (emptySubmeshes == null)
-                throw new ArgumentNullException(nameof(emptySubmeshes));
-
-            //Calculate the count of submeshes if no empty was present
-            int currentMaxIndex = GetSubmeshCount(faces) - 1;
-
-            emptySubmeshes.Clear();
-            emptySubmeshes.Capacity = Mathf.Max(emptySubmeshes.Capacity, currentMaxIndex + 1);
-            for (int i = 0; i <= currentMaxIndex; ++i)
-                emptySubmeshes.Add(i);
-
-            //Remove indices that are used to obtain only the empty ones 
-            foreach (var face in faces)
-            {
-                emptySubmeshes.Remove(face.submeshIndex);
-                if (emptySubmeshes.Count == 0)
-                    break;
-            }
+            if (emptySubMeshes == null)
+                throw new ArgumentNullException(nameof(emptySubMeshes));
+            
+            emptySubMeshes.Clear();
+            for (int i = 0, count = umesh.subMeshCount; i < count; ++i)
+                if (umesh.GetSubMesh(i).vertexCount == 0)
+                    emptySubMeshes.Add(i);
         }
 
         internal static void MapFaceMaterialsToSubmeshIndex(ProBuilderMesh mesh)

--- a/Tests/Editor/Resources.meta
+++ b/Tests/Editor/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4a49afc5b4e29c24880d18decd3277bc
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Resources/TestCube [Submesh-1  Material-1].prefab
+++ b/Tests/Editor/Resources/TestCube [Submesh-1  Material-1].prefab
@@ -1,0 +1,346 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &9073396411084579187
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6077879641644395331}
+  - component: {fileID: 2840348947466503286}
+  - component: {fileID: 3500683396312500386}
+  - component: {fileID: 1501957088326661658}
+  - component: {fileID: 791565109394257952}
+  - component: {fileID: 4482580796598031686}
+  m_Layer: 0
+  m_Name: TestCube [Submesh-1  Material-1]
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6077879641644395331
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9073396411084579187}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -549.81396, y: 0, z: -515.2969}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2840348947466503286
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9073396411084579187}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8233d90336aea43098adf6dbabd606a2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_MeshFormatVersion: 2
+  m_Faces:
+  - m_Indexes: 000000000100000002000000010000000300000002000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 0, y: 0}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 040000000500000006000000050000000700000006000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 0, y: 0}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 08000000090000000a000000090000000b0000000a000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 0, y: 0}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 0c0000000d0000000e0000000d0000000f0000000e000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 0, y: 0}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 100000001100000012000000110000001300000012000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 0, y: 0}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 140000001500000016000000150000001700000016000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 0, y: 0}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  m_SharedVertices:
+  - m_Vertices: 000000000d00000016000000
+  - m_Vertices: 010000000400000017000000
+  - m_Vertices: 020000000f00000010000000
+  - m_Vertices: 030000000600000011000000
+  - m_Vertices: 050000000800000015000000
+  - m_Vertices: 070000000a00000013000000
+  - m_Vertices: 090000000c00000014000000
+  - m_Vertices: 0b0000000e00000012000000
+  m_SharedTextures: []
+  m_Positions:
+  - {x: 47.231567, y: 107.68557, z: 260.755}
+  - {x: 48.231567, y: 107.68557, z: 260.755}
+  - {x: 47.231567, y: 108.68557, z: 260.755}
+  - {x: 48.231567, y: 108.68557, z: 260.755}
+  - {x: 48.231567, y: 107.68557, z: 260.755}
+  - {x: 48.231567, y: 107.68557, z: 259.755}
+  - {x: 48.231567, y: 108.68557, z: 260.755}
+  - {x: 48.231567, y: 108.68557, z: 259.755}
+  - {x: 48.231567, y: 107.68557, z: 259.755}
+  - {x: 47.231567, y: 107.68557, z: 259.755}
+  - {x: 48.231567, y: 108.68557, z: 259.755}
+  - {x: 47.231567, y: 108.68557, z: 259.755}
+  - {x: 47.231567, y: 107.68557, z: 259.755}
+  - {x: 47.231567, y: 107.68557, z: 260.755}
+  - {x: 47.231567, y: 108.68557, z: 259.755}
+  - {x: 47.231567, y: 108.68557, z: 260.755}
+  - {x: 47.231567, y: 108.68557, z: 260.755}
+  - {x: 48.231567, y: 108.68557, z: 260.755}
+  - {x: 47.231567, y: 108.68557, z: 259.755}
+  - {x: 48.231567, y: 108.68557, z: 259.755}
+  - {x: 47.231567, y: 107.68557, z: 259.755}
+  - {x: 48.231567, y: 107.68557, z: 259.755}
+  - {x: 47.231567, y: 107.68557, z: 260.755}
+  - {x: 48.231567, y: 107.68557, z: 260.755}
+  m_Textures0:
+  - {x: -47.231567, y: 107.68557}
+  - {x: -48.231567, y: 107.68557}
+  - {x: -47.231567, y: 108.68557}
+  - {x: -48.231567, y: 108.68557}
+  - {x: 260.755, y: 107.68557}
+  - {x: 259.755, y: 107.68557}
+  - {x: 260.755, y: 108.68557}
+  - {x: 259.755, y: 108.68557}
+  - {x: 48.231567, y: 107.68557}
+  - {x: 47.231567, y: 107.68557}
+  - {x: 48.231567, y: 108.68557}
+  - {x: 47.231567, y: 108.68557}
+  - {x: -259.755, y: 107.68557}
+  - {x: -260.755, y: 107.68557}
+  - {x: -259.755, y: 108.68557}
+  - {x: -260.755, y: 108.68557}
+  - {x: 47.231567, y: 260.755}
+  - {x: 48.231567, y: 260.755}
+  - {x: 47.231567, y: 259.755}
+  - {x: 48.231567, y: 259.755}
+  - {x: -47.231567, y: 259.755}
+  - {x: -48.231567, y: 259.755}
+  - {x: -47.231567, y: 260.755}
+  - {x: -48.231567, y: 260.755}
+  m_Textures2: []
+  m_Textures3: []
+  m_Tangents:
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: 0, y: 0, z: 1, w: -1}
+  - {x: 0, y: 0, z: 1, w: -1}
+  - {x: 0, y: 0, z: 1, w: -1}
+  - {x: 0, y: 0, z: 1, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 0, y: 0, z: -1, w: -1}
+  - {x: 0, y: 0, z: -1, w: -1}
+  - {x: 0, y: 0, z: -1, w: -1}
+  - {x: 0, y: 0, z: -1, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  m_Colors: []
+  m_UnwrapParameters:
+    m_HardAngle: 88
+    m_PackMargin: 20
+    m_AngleError: 8
+    m_AreaError: 15
+  m_PreserveMeshAssetOnDestroy: 0
+  assetGuid: 
+  m_Mesh: {fileID: 0}
+  m_VersionIndex: 160
+  m_IsSelectable: 1
+  m_SelectedFaces: 
+  m_SelectedEdges: []
+  m_SelectedVertices: 
+--- !u!114 &3500683396312500386
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9073396411084579187}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1ca002da428252441b92f28d83c8a65f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Shape:
+    rid: 3108136289641431369
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Rotation: {x: 0, y: 0, z: 0, w: 1}
+  m_PivotLocation: 1
+  m_PivotPosition: {x: 0, y: 0, z: 0}
+  m_UnmodifiedMeshVersion: 160
+  m_ShapeBox:
+    m_Center: {x: 47.731567, y: 108.18557, z: 260.255}
+    m_Extent: {x: 0.5, y: 0.5, z: 0.5}
+  references:
+    version: 2
+    RefIds:
+    - rid: 3108136289641431369
+      type: {class: Cube, ns: UnityEngine.ProBuilder.Shapes, asm: Unity.ProBuilder}
+--- !u!23 &1501957088326661658
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9073396411084579187}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 65c94bb87ddfef94fb1fa7de448d4678, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 2
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &791565109394257952
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9073396411084579187}
+  m_Mesh: {fileID: 0}
+--- !u!64 &4482580796598031686
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9073396411084579187}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 4
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 0}

--- a/Tests/Editor/Resources/TestCube [Submesh-1  Material-1].prefab.meta
+++ b/Tests/Editor/Resources/TestCube [Submesh-1  Material-1].prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c959741c4591c57438657e4da56e5984
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Resources/TestCube [Submesh-1  Material-2].prefab
+++ b/Tests/Editor/Resources/TestCube [Submesh-1  Material-2].prefab
@@ -1,0 +1,347 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &9073396411084579187
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6077879641644395331}
+  - component: {fileID: 2840348947466503286}
+  - component: {fileID: 3500683396312500386}
+  - component: {fileID: 1501957088326661658}
+  - component: {fileID: 791565109394257952}
+  - component: {fileID: 4482580796598031686}
+  m_Layer: 0
+  m_Name: TestCube [Submesh-1  Material-2]
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6077879641644395331
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9073396411084579187}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -549.81396, y: 0, z: -515.2969}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2840348947466503286
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9073396411084579187}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8233d90336aea43098adf6dbabd606a2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_MeshFormatVersion: 2
+  m_Faces:
+  - m_Indexes: 000000000100000002000000010000000300000002000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 0, y: 0}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 040000000500000006000000050000000700000006000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 0, y: 0}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 08000000090000000a000000090000000b0000000a000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 0, y: 0}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 0c0000000d0000000e0000000d0000000f0000000e000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 0, y: 0}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 100000001100000012000000110000001300000012000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 0, y: 0}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 140000001500000016000000150000001700000016000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 0, y: 0}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  m_SharedVertices:
+  - m_Vertices: 000000000d00000016000000
+  - m_Vertices: 010000000400000017000000
+  - m_Vertices: 020000000f00000010000000
+  - m_Vertices: 030000000600000011000000
+  - m_Vertices: 050000000800000015000000
+  - m_Vertices: 070000000a00000013000000
+  - m_Vertices: 090000000c00000014000000
+  - m_Vertices: 0b0000000e00000012000000
+  m_SharedTextures: []
+  m_Positions:
+  - {x: 47.231567, y: 107.68557, z: 260.755}
+  - {x: 48.231567, y: 107.68557, z: 260.755}
+  - {x: 47.231567, y: 108.68557, z: 260.755}
+  - {x: 48.231567, y: 108.68557, z: 260.755}
+  - {x: 48.231567, y: 107.68557, z: 260.755}
+  - {x: 48.231567, y: 107.68557, z: 259.755}
+  - {x: 48.231567, y: 108.68557, z: 260.755}
+  - {x: 48.231567, y: 108.68557, z: 259.755}
+  - {x: 48.231567, y: 107.68557, z: 259.755}
+  - {x: 47.231567, y: 107.68557, z: 259.755}
+  - {x: 48.231567, y: 108.68557, z: 259.755}
+  - {x: 47.231567, y: 108.68557, z: 259.755}
+  - {x: 47.231567, y: 107.68557, z: 259.755}
+  - {x: 47.231567, y: 107.68557, z: 260.755}
+  - {x: 47.231567, y: 108.68557, z: 259.755}
+  - {x: 47.231567, y: 108.68557, z: 260.755}
+  - {x: 47.231567, y: 108.68557, z: 260.755}
+  - {x: 48.231567, y: 108.68557, z: 260.755}
+  - {x: 47.231567, y: 108.68557, z: 259.755}
+  - {x: 48.231567, y: 108.68557, z: 259.755}
+  - {x: 47.231567, y: 107.68557, z: 259.755}
+  - {x: 48.231567, y: 107.68557, z: 259.755}
+  - {x: 47.231567, y: 107.68557, z: 260.755}
+  - {x: 48.231567, y: 107.68557, z: 260.755}
+  m_Textures0:
+  - {x: -47.231567, y: 107.68557}
+  - {x: -48.231567, y: 107.68557}
+  - {x: -47.231567, y: 108.68557}
+  - {x: -48.231567, y: 108.68557}
+  - {x: 260.755, y: 107.68557}
+  - {x: 259.755, y: 107.68557}
+  - {x: 260.755, y: 108.68557}
+  - {x: 259.755, y: 108.68557}
+  - {x: 48.231567, y: 107.68557}
+  - {x: 47.231567, y: 107.68557}
+  - {x: 48.231567, y: 108.68557}
+  - {x: 47.231567, y: 108.68557}
+  - {x: -259.755, y: 107.68557}
+  - {x: -260.755, y: 107.68557}
+  - {x: -259.755, y: 108.68557}
+  - {x: -260.755, y: 108.68557}
+  - {x: 47.231567, y: 260.755}
+  - {x: 48.231567, y: 260.755}
+  - {x: 47.231567, y: 259.755}
+  - {x: 48.231567, y: 259.755}
+  - {x: -47.231567, y: 259.755}
+  - {x: -48.231567, y: 259.755}
+  - {x: -47.231567, y: 260.755}
+  - {x: -48.231567, y: 260.755}
+  m_Textures2: []
+  m_Textures3: []
+  m_Tangents:
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: 0, y: 0, z: 1, w: -1}
+  - {x: 0, y: 0, z: 1, w: -1}
+  - {x: 0, y: 0, z: 1, w: -1}
+  - {x: 0, y: 0, z: 1, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 0, y: 0, z: -1, w: -1}
+  - {x: 0, y: 0, z: -1, w: -1}
+  - {x: 0, y: 0, z: -1, w: -1}
+  - {x: 0, y: 0, z: -1, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  m_Colors: []
+  m_UnwrapParameters:
+    m_HardAngle: 88
+    m_PackMargin: 20
+    m_AngleError: 8
+    m_AreaError: 15
+  m_PreserveMeshAssetOnDestroy: 0
+  assetGuid: 
+  m_Mesh: {fileID: 0}
+  m_VersionIndex: 160
+  m_IsSelectable: 1
+  m_SelectedFaces: 
+  m_SelectedEdges: []
+  m_SelectedVertices: 
+--- !u!114 &3500683396312500386
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9073396411084579187}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1ca002da428252441b92f28d83c8a65f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Shape:
+    rid: 3108136289641431369
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Rotation: {x: 0, y: 0, z: 0, w: 1}
+  m_PivotLocation: 1
+  m_PivotPosition: {x: 0, y: 0, z: 0}
+  m_UnmodifiedMeshVersion: 160
+  m_ShapeBox:
+    m_Center: {x: 47.731567, y: 108.18557, z: 260.255}
+    m_Extent: {x: 0.5, y: 0.5, z: 0.5}
+  references:
+    version: 2
+    RefIds:
+    - rid: 3108136289641431369
+      type: {class: Cube, ns: UnityEngine.ProBuilder.Shapes, asm: Unity.ProBuilder}
+--- !u!23 &1501957088326661658
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9073396411084579187}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 65c94bb87ddfef94fb1fa7de448d4678, type: 2}
+  - {fileID: 2100000, guid: a9b3b9b2745ca3e48b0ecc640bf8be52, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 2
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &791565109394257952
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9073396411084579187}
+  m_Mesh: {fileID: 0}
+--- !u!64 &4482580796598031686
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9073396411084579187}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 4
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 0}

--- a/Tests/Editor/Resources/TestCube [Submesh-1  Material-2].prefab.meta
+++ b/Tests/Editor/Resources/TestCube [Submesh-1  Material-2].prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3ad53e01e44fc4c4a9b1bf884c1f2dba
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Resources/TestCube [Submesh-2  Material-2].prefab
+++ b/Tests/Editor/Resources/TestCube [Submesh-2  Material-2].prefab
@@ -1,0 +1,347 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &7492029748503428616
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5641554575824417848}
+  - component: {fileID: 4429526610144779021}
+  - component: {fileID: 3064358330591090649}
+  - component: {fileID: 1065702373330233697}
+  - component: {fileID: 1219931171794528091}
+  - component: {fileID: 2605182670480738877}
+  m_Layer: 0
+  m_Name: TestCube [Submesh-2  Material-2]
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5641554575824417848
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7492029748503428616}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -549.81396, y: 0, z: -515.2969}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &4429526610144779021
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7492029748503428616}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8233d90336aea43098adf6dbabd606a2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_MeshFormatVersion: 2
+  m_Faces:
+  - m_Indexes: 000000000100000002000000010000000300000002000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 0, y: 0}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 040000000500000006000000050000000700000006000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 0, y: 0}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 08000000090000000a000000090000000b0000000a000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 0, y: 0}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 0c0000000d0000000e0000000d0000000f0000000e000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 0, y: 0}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 100000001100000012000000110000001300000012000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 0, y: 0}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 1
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 140000001500000016000000150000001700000016000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 0, y: 0}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  m_SharedVertices:
+  - m_Vertices: 000000000d00000016000000
+  - m_Vertices: 010000000400000017000000
+  - m_Vertices: 020000000f00000010000000
+  - m_Vertices: 030000000600000011000000
+  - m_Vertices: 050000000800000015000000
+  - m_Vertices: 070000000a00000013000000
+  - m_Vertices: 090000000c00000014000000
+  - m_Vertices: 0b0000000e00000012000000
+  m_SharedTextures: []
+  m_Positions:
+  - {x: 47.231567, y: 107.68557, z: 260.755}
+  - {x: 48.231567, y: 107.68557, z: 260.755}
+  - {x: 47.231567, y: 108.68557, z: 260.755}
+  - {x: 48.231567, y: 108.68557, z: 260.755}
+  - {x: 48.231567, y: 107.68557, z: 260.755}
+  - {x: 48.231567, y: 107.68557, z: 259.755}
+  - {x: 48.231567, y: 108.68557, z: 260.755}
+  - {x: 48.231567, y: 108.68557, z: 259.755}
+  - {x: 48.231567, y: 107.68557, z: 259.755}
+  - {x: 47.231567, y: 107.68557, z: 259.755}
+  - {x: 48.231567, y: 108.68557, z: 259.755}
+  - {x: 47.231567, y: 108.68557, z: 259.755}
+  - {x: 47.231567, y: 107.68557, z: 259.755}
+  - {x: 47.231567, y: 107.68557, z: 260.755}
+  - {x: 47.231567, y: 108.68557, z: 259.755}
+  - {x: 47.231567, y: 108.68557, z: 260.755}
+  - {x: 47.231567, y: 108.68557, z: 260.755}
+  - {x: 48.231567, y: 108.68557, z: 260.755}
+  - {x: 47.231567, y: 108.68557, z: 259.755}
+  - {x: 48.231567, y: 108.68557, z: 259.755}
+  - {x: 47.231567, y: 107.68557, z: 259.755}
+  - {x: 48.231567, y: 107.68557, z: 259.755}
+  - {x: 47.231567, y: 107.68557, z: 260.755}
+  - {x: 48.231567, y: 107.68557, z: 260.755}
+  m_Textures0:
+  - {x: -47.231567, y: 107.68557}
+  - {x: -48.231567, y: 107.68557}
+  - {x: -47.231567, y: 108.68557}
+  - {x: -48.231567, y: 108.68557}
+  - {x: 260.755, y: 107.68557}
+  - {x: 259.755, y: 107.68557}
+  - {x: 260.755, y: 108.68557}
+  - {x: 259.755, y: 108.68557}
+  - {x: 48.231567, y: 107.68557}
+  - {x: 47.231567, y: 107.68557}
+  - {x: 48.231567, y: 108.68557}
+  - {x: 47.231567, y: 108.68557}
+  - {x: -259.755, y: 107.68557}
+  - {x: -260.755, y: 107.68557}
+  - {x: -259.755, y: 108.68557}
+  - {x: -260.755, y: 108.68557}
+  - {x: 47.231567, y: 260.755}
+  - {x: 48.231567, y: 260.755}
+  - {x: 47.231567, y: 259.755}
+  - {x: 48.231567, y: 259.755}
+  - {x: -47.231567, y: 259.755}
+  - {x: -48.231567, y: 259.755}
+  - {x: -47.231567, y: 260.755}
+  - {x: -48.231567, y: 260.755}
+  m_Textures2: []
+  m_Textures3: []
+  m_Tangents:
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: 0, y: 0, z: 1, w: -1}
+  - {x: 0, y: 0, z: 1, w: -1}
+  - {x: 0, y: 0, z: 1, w: -1}
+  - {x: 0, y: 0, z: 1, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 0, y: 0, z: -1, w: -1}
+  - {x: 0, y: 0, z: -1, w: -1}
+  - {x: 0, y: 0, z: -1, w: -1}
+  - {x: 0, y: 0, z: -1, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  m_Colors: []
+  m_UnwrapParameters:
+    m_HardAngle: 88
+    m_PackMargin: 20
+    m_AngleError: 8
+    m_AreaError: 15
+  m_PreserveMeshAssetOnDestroy: 0
+  assetGuid: 
+  m_Mesh: {fileID: 0}
+  m_VersionIndex: 167
+  m_IsSelectable: 1
+  m_SelectedFaces: 
+  m_SelectedEdges: []
+  m_SelectedVertices: 
+--- !u!114 &3064358330591090649
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7492029748503428616}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1ca002da428252441b92f28d83c8a65f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Shape:
+    rid: 3108136289641431369
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Rotation: {x: 0, y: 0, z: 0, w: 1}
+  m_PivotLocation: 1
+  m_PivotPosition: {x: 0, y: 0, z: 0}
+  m_UnmodifiedMeshVersion: 160
+  m_ShapeBox:
+    m_Center: {x: 47.731567, y: 108.18557, z: 260.255}
+    m_Extent: {x: 0.5, y: 0.5, z: 0.5}
+  references:
+    version: 2
+    RefIds:
+    - rid: 3108136289641431369
+      type: {class: Cube, ns: UnityEngine.ProBuilder.Shapes, asm: Unity.ProBuilder}
+--- !u!23 &1065702373330233697
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7492029748503428616}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 65c94bb87ddfef94fb1fa7de448d4678, type: 2}
+  - {fileID: 2100000, guid: a9b3b9b2745ca3e48b0ecc640bf8be52, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 2
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1219931171794528091
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7492029748503428616}
+  m_Mesh: {fileID: 0}
+--- !u!64 &2605182670480738877
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7492029748503428616}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 4
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 0}

--- a/Tests/Editor/Resources/TestCube [Submesh-2  Material-2].prefab.meta
+++ b/Tests/Editor/Resources/TestCube [Submesh-2  Material-2].prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 050eab28567e01b47b20fb49c04b93a0
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Resources/TestCube [Submesh-2  Material-4].prefab
+++ b/Tests/Editor/Resources/TestCube [Submesh-2  Material-4].prefab
@@ -1,0 +1,349 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &7492029748503428616
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5641554575824417848}
+  - component: {fileID: 4429526610144779021}
+  - component: {fileID: 3064358330591090649}
+  - component: {fileID: 1065702373330233697}
+  - component: {fileID: 1219931171794528091}
+  - component: {fileID: 2605182670480738877}
+  m_Layer: 0
+  m_Name: TestCube [Submesh-2  Material-4]
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5641554575824417848
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7492029748503428616}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -549.81396, y: 0, z: -515.2969}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &4429526610144779021
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7492029748503428616}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8233d90336aea43098adf6dbabd606a2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_MeshFormatVersion: 2
+  m_Faces:
+  - m_Indexes: 000000000100000002000000010000000300000002000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 0, y: 0}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 040000000500000006000000050000000700000006000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 0, y: 0}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 08000000090000000a000000090000000b0000000a000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 0, y: 0}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 0c0000000d0000000e0000000d0000000f0000000e000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 0, y: 0}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 100000001100000012000000110000001300000012000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 0, y: 0}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 1
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 140000001500000016000000150000001700000016000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 0, y: 0}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  m_SharedVertices:
+  - m_Vertices: 000000000d00000016000000
+  - m_Vertices: 010000000400000017000000
+  - m_Vertices: 020000000f00000010000000
+  - m_Vertices: 030000000600000011000000
+  - m_Vertices: 050000000800000015000000
+  - m_Vertices: 070000000a00000013000000
+  - m_Vertices: 090000000c00000014000000
+  - m_Vertices: 0b0000000e00000012000000
+  m_SharedTextures: []
+  m_Positions:
+  - {x: 47.231567, y: 107.68557, z: 260.755}
+  - {x: 48.231567, y: 107.68557, z: 260.755}
+  - {x: 47.231567, y: 108.68557, z: 260.755}
+  - {x: 48.231567, y: 108.68557, z: 260.755}
+  - {x: 48.231567, y: 107.68557, z: 260.755}
+  - {x: 48.231567, y: 107.68557, z: 259.755}
+  - {x: 48.231567, y: 108.68557, z: 260.755}
+  - {x: 48.231567, y: 108.68557, z: 259.755}
+  - {x: 48.231567, y: 107.68557, z: 259.755}
+  - {x: 47.231567, y: 107.68557, z: 259.755}
+  - {x: 48.231567, y: 108.68557, z: 259.755}
+  - {x: 47.231567, y: 108.68557, z: 259.755}
+  - {x: 47.231567, y: 107.68557, z: 259.755}
+  - {x: 47.231567, y: 107.68557, z: 260.755}
+  - {x: 47.231567, y: 108.68557, z: 259.755}
+  - {x: 47.231567, y: 108.68557, z: 260.755}
+  - {x: 47.231567, y: 108.68557, z: 260.755}
+  - {x: 48.231567, y: 108.68557, z: 260.755}
+  - {x: 47.231567, y: 108.68557, z: 259.755}
+  - {x: 48.231567, y: 108.68557, z: 259.755}
+  - {x: 47.231567, y: 107.68557, z: 259.755}
+  - {x: 48.231567, y: 107.68557, z: 259.755}
+  - {x: 47.231567, y: 107.68557, z: 260.755}
+  - {x: 48.231567, y: 107.68557, z: 260.755}
+  m_Textures0:
+  - {x: -47.231567, y: 107.68557}
+  - {x: -48.231567, y: 107.68557}
+  - {x: -47.231567, y: 108.68557}
+  - {x: -48.231567, y: 108.68557}
+  - {x: 260.755, y: 107.68557}
+  - {x: 259.755, y: 107.68557}
+  - {x: 260.755, y: 108.68557}
+  - {x: 259.755, y: 108.68557}
+  - {x: 48.231567, y: 107.68557}
+  - {x: 47.231567, y: 107.68557}
+  - {x: 48.231567, y: 108.68557}
+  - {x: 47.231567, y: 108.68557}
+  - {x: -259.755, y: 107.68557}
+  - {x: -260.755, y: 107.68557}
+  - {x: -259.755, y: 108.68557}
+  - {x: -260.755, y: 108.68557}
+  - {x: 47.231567, y: 260.755}
+  - {x: 48.231567, y: 260.755}
+  - {x: 47.231567, y: 259.755}
+  - {x: 48.231567, y: 259.755}
+  - {x: -47.231567, y: 259.755}
+  - {x: -48.231567, y: 259.755}
+  - {x: -47.231567, y: 260.755}
+  - {x: -48.231567, y: 260.755}
+  m_Textures2: []
+  m_Textures3: []
+  m_Tangents:
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: 0, y: 0, z: 1, w: -1}
+  - {x: 0, y: 0, z: 1, w: -1}
+  - {x: 0, y: 0, z: 1, w: -1}
+  - {x: 0, y: 0, z: 1, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 0, y: 0, z: -1, w: -1}
+  - {x: 0, y: 0, z: -1, w: -1}
+  - {x: 0, y: 0, z: -1, w: -1}
+  - {x: 0, y: 0, z: -1, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  m_Colors: []
+  m_UnwrapParameters:
+    m_HardAngle: 88
+    m_PackMargin: 20
+    m_AngleError: 8
+    m_AreaError: 15
+  m_PreserveMeshAssetOnDestroy: 0
+  assetGuid: 
+  m_Mesh: {fileID: 0}
+  m_VersionIndex: 167
+  m_IsSelectable: 1
+  m_SelectedFaces: 
+  m_SelectedEdges: []
+  m_SelectedVertices: 
+--- !u!114 &3064358330591090649
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7492029748503428616}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1ca002da428252441b92f28d83c8a65f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Shape:
+    rid: 3108136289641431369
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Rotation: {x: 0, y: 0, z: 0, w: 1}
+  m_PivotLocation: 1
+  m_PivotPosition: {x: 0, y: 0, z: 0}
+  m_UnmodifiedMeshVersion: 160
+  m_ShapeBox:
+    m_Center: {x: 47.731567, y: 108.18557, z: 260.255}
+    m_Extent: {x: 0.5, y: 0.5, z: 0.5}
+  references:
+    version: 2
+    RefIds:
+    - rid: 3108136289641431369
+      type: {class: Cube, ns: UnityEngine.ProBuilder.Shapes, asm: Unity.ProBuilder}
+--- !u!23 &1065702373330233697
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7492029748503428616}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 65c94bb87ddfef94fb1fa7de448d4678, type: 2}
+  - {fileID: 2100000, guid: a9b3b9b2745ca3e48b0ecc640bf8be52, type: 2}
+  - {fileID: 2100000, guid: 5c706b668b651ee48978bdfa97369a2e, type: 2}
+  - {fileID: 2100000, guid: a9b3b9b2745ca3e48b0ecc640bf8be52, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 2
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1219931171794528091
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7492029748503428616}
+  m_Mesh: {fileID: 0}
+--- !u!64 &2605182670480738877
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7492029748503428616}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 4
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 0}

--- a/Tests/Editor/Resources/TestCube [Submesh-2  Material-4].prefab.meta
+++ b/Tests/Editor/Resources/TestCube [Submesh-2  Material-4].prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a067c6df56b82a54e9de690857d4eb85
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Resources/TestCube [Submesh-4  Material-4].prefab
+++ b/Tests/Editor/Resources/TestCube [Submesh-4  Material-4].prefab
@@ -1,0 +1,349 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3805691134640528190
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2117638847634395406}
+  - component: {fileID: 7949231897706462779}
+  - component: {fileID: 8768305178862072559}
+  - component: {fileID: 6765440290586954839}
+  - component: {fileID: 4884046451800506989}
+  - component: {fileID: 8579068560732368651}
+  m_Layer: 0
+  m_Name: TestCube [Submesh-4  Material-4]
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2117638847634395406
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3805691134640528190}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -549.81396, y: 0, z: -515.2969}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7949231897706462779
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3805691134640528190}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8233d90336aea43098adf6dbabd606a2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_MeshFormatVersion: 2
+  m_Faces:
+  - m_Indexes: 000000000100000002000000010000000300000002000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 0, y: 0}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 3
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 040000000500000006000000050000000700000006000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 0, y: 0}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 2
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 08000000090000000a000000090000000b0000000a000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 0, y: 0}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 0c0000000d0000000e0000000d0000000f0000000e000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 0, y: 0}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 100000001100000012000000110000001300000012000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 0, y: 0}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 1
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 140000001500000016000000150000001700000016000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 0, y: 0}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  m_SharedVertices:
+  - m_Vertices: 000000000d00000016000000
+  - m_Vertices: 010000000400000017000000
+  - m_Vertices: 020000000f00000010000000
+  - m_Vertices: 030000000600000011000000
+  - m_Vertices: 050000000800000015000000
+  - m_Vertices: 070000000a00000013000000
+  - m_Vertices: 090000000c00000014000000
+  - m_Vertices: 0b0000000e00000012000000
+  m_SharedTextures: []
+  m_Positions:
+  - {x: 47.231567, y: 107.68557, z: 260.755}
+  - {x: 48.231567, y: 107.68557, z: 260.755}
+  - {x: 47.231567, y: 108.68557, z: 260.755}
+  - {x: 48.231567, y: 108.68557, z: 260.755}
+  - {x: 48.231567, y: 107.68557, z: 260.755}
+  - {x: 48.231567, y: 107.68557, z: 259.755}
+  - {x: 48.231567, y: 108.68557, z: 260.755}
+  - {x: 48.231567, y: 108.68557, z: 259.755}
+  - {x: 48.231567, y: 107.68557, z: 259.755}
+  - {x: 47.231567, y: 107.68557, z: 259.755}
+  - {x: 48.231567, y: 108.68557, z: 259.755}
+  - {x: 47.231567, y: 108.68557, z: 259.755}
+  - {x: 47.231567, y: 107.68557, z: 259.755}
+  - {x: 47.231567, y: 107.68557, z: 260.755}
+  - {x: 47.231567, y: 108.68557, z: 259.755}
+  - {x: 47.231567, y: 108.68557, z: 260.755}
+  - {x: 47.231567, y: 108.68557, z: 260.755}
+  - {x: 48.231567, y: 108.68557, z: 260.755}
+  - {x: 47.231567, y: 108.68557, z: 259.755}
+  - {x: 48.231567, y: 108.68557, z: 259.755}
+  - {x: 47.231567, y: 107.68557, z: 259.755}
+  - {x: 48.231567, y: 107.68557, z: 259.755}
+  - {x: 47.231567, y: 107.68557, z: 260.755}
+  - {x: 48.231567, y: 107.68557, z: 260.755}
+  m_Textures0:
+  - {x: -47.231567, y: 107.68557}
+  - {x: -48.231567, y: 107.68557}
+  - {x: -47.231567, y: 108.68557}
+  - {x: -48.231567, y: 108.68557}
+  - {x: 260.755, y: 107.68557}
+  - {x: 259.755, y: 107.68557}
+  - {x: 260.755, y: 108.68557}
+  - {x: 259.755, y: 108.68557}
+  - {x: 48.231567, y: 107.68557}
+  - {x: 47.231567, y: 107.68557}
+  - {x: 48.231567, y: 108.68557}
+  - {x: 47.231567, y: 108.68557}
+  - {x: -259.755, y: 107.68557}
+  - {x: -260.755, y: 107.68557}
+  - {x: -259.755, y: 108.68557}
+  - {x: -260.755, y: 108.68557}
+  - {x: 47.231567, y: 260.755}
+  - {x: 48.231567, y: 260.755}
+  - {x: 47.231567, y: 259.755}
+  - {x: 48.231567, y: 259.755}
+  - {x: -47.231567, y: 259.755}
+  - {x: -48.231567, y: 259.755}
+  - {x: -47.231567, y: 260.755}
+  - {x: -48.231567, y: 260.755}
+  m_Textures2: []
+  m_Textures3: []
+  m_Tangents:
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: 0, y: 0, z: 1, w: -1}
+  - {x: 0, y: 0, z: 1, w: -1}
+  - {x: 0, y: 0, z: 1, w: -1}
+  - {x: 0, y: 0, z: 1, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 0, y: 0, z: -1, w: -1}
+  - {x: 0, y: 0, z: -1, w: -1}
+  - {x: 0, y: 0, z: -1, w: -1}
+  - {x: 0, y: 0, z: -1, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  m_Colors: []
+  m_UnwrapParameters:
+    m_HardAngle: 88
+    m_PackMargin: 20
+    m_AngleError: 8
+    m_AreaError: 15
+  m_PreserveMeshAssetOnDestroy: 0
+  assetGuid: 
+  m_Mesh: {fileID: 0}
+  m_VersionIndex: 179
+  m_IsSelectable: 1
+  m_SelectedFaces: 
+  m_SelectedEdges: []
+  m_SelectedVertices: 
+--- !u!114 &8768305178862072559
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3805691134640528190}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1ca002da428252441b92f28d83c8a65f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Shape:
+    rid: 3108136289641431369
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Rotation: {x: 0, y: 0, z: 0, w: 1}
+  m_PivotLocation: 1
+  m_PivotPosition: {x: 0, y: 0, z: 0}
+  m_UnmodifiedMeshVersion: 160
+  m_ShapeBox:
+    m_Center: {x: 47.731567, y: 108.18557, z: 260.255}
+    m_Extent: {x: 0.5, y: 0.5, z: 0.5}
+  references:
+    version: 2
+    RefIds:
+    - rid: 3108136289641431369
+      type: {class: Cube, ns: UnityEngine.ProBuilder.Shapes, asm: Unity.ProBuilder}
+--- !u!23 &6765440290586954839
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3805691134640528190}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 65c94bb87ddfef94fb1fa7de448d4678, type: 2}
+  - {fileID: 2100000, guid: a9b3b9b2745ca3e48b0ecc640bf8be52, type: 2}
+  - {fileID: 2100000, guid: cabbdbac5bd8e674aab22922df59fd8f, type: 2}
+  - {fileID: 2100000, guid: 5c706b668b651ee48978bdfa97369a2e, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 2
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &4884046451800506989
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3805691134640528190}
+  m_Mesh: {fileID: 0}
+--- !u!64 &8579068560732368651
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3805691134640528190}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 4
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 0}

--- a/Tests/Editor/Resources/TestCube [Submesh-4  Material-4].prefab.meta
+++ b/Tests/Editor/Resources/TestCube [Submesh-4  Material-4].prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6cafaafd91dc13c4b8090d5c4e08f4b4
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Utilities.meta
+++ b/Tests/Editor/Utilities.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 73ffed97de61939438a2b2cd79fc95a5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Utilities/MaterialUtilityTests.cs
+++ b/Tests/Editor/Utilities/MaterialUtilityTests.cs
@@ -1,0 +1,77 @@
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.ProBuilder;
+
+public class MaterialUtilityTests
+{
+    static IEnumerable<List<int>> s_MaterialIndexToRemove
+    {
+        get
+        {
+            yield return new List<int> { 0 };
+            yield return new List<int> { 1 };
+            yield return new List<int> { 1, 2 };
+            yield return new List<int> { 0, 2 };
+        }
+    }
+
+    static IEnumerable<string> s_PrefabResourcePaths
+    {
+        get
+        {
+            yield return "[Submesh-1  Material-1]";
+            yield return "[Submesh-1  Material-2]";
+            yield return "[Submesh-2  Material-2]";
+            yield return "[Submesh-2  Material-4]";
+            yield return "[Submesh-4  Material-4]";
+        }
+    }
+
+    [Test]
+    public void RemoveMaterialsAndTrimExcess_MaterialCountIsEqualToSubmeshCount(
+        [ValueSource(nameof(s_PrefabResourcePaths))] string prefabResourcePath)
+    {
+        var prefab = Resources.Load<GameObject>($"TestCube " + prefabResourcePath);
+        Assume.That(prefab, Is.Not.Null);
+
+        var renderer = Object.Instantiate(prefab).GetComponent<Renderer>();
+        Assume.That(renderer, Is.Not.Null);
+
+        var probuilderFilter = renderer.GetComponent<ProBuilderMesh>();
+        Assume.That(probuilderFilter, Is.Not.Null);
+        
+        MaterialUtility.RemoveMaterialsAndTrimExcess(renderer, new List<int>(), Submesh.GetSubmeshCount(probuilderFilter));
+
+        Assert.That(renderer.sharedMaterials.Length, Is.EqualTo(probuilderFilter.mesh.subMeshCount));
+    }
+
+    [Test]
+    public void RemoveMaterialsAndTrimExcess_RemoveMaterial_MaterialIsRemoved(
+        [ValueSource(nameof(s_MaterialIndexToRemove))] List<int> indicesToRemove,
+        [ValueSource(nameof(s_PrefabResourcePaths))] string prefabResourcePath)
+    {
+        var prefab = Resources.Load<GameObject>($"TestCube " + prefabResourcePath);
+        Assume.That(prefab, Is.Not.Null);
+
+        var renderer = Object.Instantiate(prefab).GetComponent<Renderer>();
+        Assume.That(renderer, Is.Not.Null);
+
+        var probuilderFilter = renderer.GetComponent<ProBuilderMesh>();
+        Assume.That(probuilderFilter, Is.Not.Null);
+
+        List<Material> expectedResult = new List<Material>(renderer.sharedMaterials);
+        for (int i = expectedResult.Count - 1; i >= 0; --i)
+            if (indicesToRemove.Contains(i))
+                expectedResult.RemoveAt(i);
+
+        var submeshCount = Submesh.GetSubmeshCount(probuilderFilter);
+        MaterialUtility.RemoveMaterialsAndTrimExcess(renderer, indicesToRemove, submeshCount);
+
+        var expectedMaterialCount = Mathf.Min(submeshCount, expectedResult.Count);
+        Assert.That(renderer.sharedMaterials.Length, Is.EqualTo(expectedMaterialCount));
+        for (int i = 0; i < expectedMaterialCount; ++i) 
+            Assert.That(renderer.sharedMaterials[i], Is.EqualTo(expectedResult[i]));
+    }
+}

--- a/Tests/Editor/Utilities/MaterialUtilityTests.cs.meta
+++ b/Tests/Editor/Utilities/MaterialUtilityTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 84fb3ddceb5f13343bdef4ec6e177210
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Materials/Orange.mat
+++ b/Tests/Materials/Orange.mat
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Orange
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 2800000, guid: d5a0536192c33b542ba8e3e9d5d274ce, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 0, b: 0.31770992, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}

--- a/Tests/Materials/Orange.mat.meta
+++ b/Tests/Materials/Orange.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cabbdbac5bd8e674aab22922df59fd8f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Runtime/Utilities/SubmeshUtilityTests.cs
+++ b/Tests/Runtime/Utilities/SubmeshUtilityTests.cs
@@ -1,0 +1,108 @@
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.ProBuilder;
+
+class SubmeshUtilityTests
+{
+    public class TestCase
+    {
+        readonly string m_Name;
+        public readonly IList<Face> faces;
+        public readonly int submeshes;
+        public int[] emptySubmeshes = new int[0];
+
+        public override string ToString() { return m_Name; }
+
+        public TestCase(string name, int submeshes, params Face[] faces)
+        {
+            m_Name = name;
+            this.faces = faces;
+            this.submeshes = submeshes;
+        }
+    }
+    
+    static IEnumerable<TestCase> s_TestCases
+    {
+        get
+        {
+            yield return new TestCase("0 Submesh", 0);
+
+            yield return new TestCase("1 Submesh", 1,
+                new Face {submeshIndex = 0});
+
+            yield return new TestCase("Multiple Submeshes", 3,
+                new Face { submeshIndex = 0 },
+                new Face { submeshIndex = 1 },
+                new Face { submeshIndex = 2 });
+
+            yield return new TestCase("Multiple Submeshes with 1 Empty", 3,
+                new Face { submeshIndex = 0 },
+                new Face { submeshIndex = 2 })
+                { emptySubmeshes = new []{1}};
+
+            yield return new TestCase("Multiple Submeshes with 3 Empty", 8,
+                    new Face { submeshIndex = 0 },
+                    new Face { submeshIndex = 2 },
+                    new Face { submeshIndex = 2 },
+                    new Face { submeshIndex = 4 },
+                    new Face { submeshIndex = 7 },
+                    new Face { submeshIndex = 7 },
+                    new Face { submeshIndex = 7 })
+                { emptySubmeshes = new[] { 1, 3, 5, 6 } };
+        }
+    }
+
+    [Test]
+    public void GetSubmeshCount_ReturnsExpectAmountOfSubmesh(
+        [ValueSource(nameof(s_TestCases))] TestCase testCase)
+    {
+        Assert.That(Submesh.GetSubmeshCount(testCase.faces), Is.EqualTo(testCase.submeshes));
+    }
+
+    [Test]
+    public void GetEmptySubmesh_ResultArrayHasCorrectSubmeshes(
+        [ValueSource(nameof(s_TestCases))] TestCase testCase)
+    {
+        List<int> emptySubmeshes = new List<int>();
+        Submesh.GetEmptySubmeshes(testCase.faces, emptySubmeshes);
+
+        Assert.That(emptySubmeshes.Count, Is.EqualTo(testCase.emptySubmeshes.Length));
+        foreach (var emptySubmesh in testCase.emptySubmeshes)
+            Assert.That(emptySubmeshes, Does.Contain(emptySubmesh));
+    }
+
+    [Test]
+    public void GetEmptySubmeshes_RemovesEmptySubmeshes_FaceArrayDoesntHaveEmptySubmeshes(
+        [ValueSource(nameof(s_TestCases))] TestCase testCase)
+    {
+        List<int> emptySubmeshes = new List<int>();
+        Submesh.GetEmptySubmeshes(testCase.faces, emptySubmeshes);
+
+        Assume.That(emptySubmeshes.Count, Is.EqualTo(testCase.emptySubmeshes.Length));
+        foreach (var emptySubmesh in testCase.emptySubmeshes)
+            Assume.That(emptySubmeshes, Does.Contain(emptySubmesh));
+
+        List<Face> faces = new List<Face>(testCase.faces);
+        Submesh.RemoveSubmeshes(faces, emptySubmeshes);
+
+        //Check that no empty submeshes remains
+        for (int i = 0, count = Submesh.GetSubmeshCount(faces); i < count; ++i)
+        {
+            bool found = false;
+            //Look for faces with that submesh index
+            foreach (var face in faces)
+            {
+                if (face.submeshIndex == i)
+                {
+                    found = true;
+                    break;
+                }   
+            }
+
+            if (!found)
+                Assert.Fail($"Submesh {0} is empty.");
+        }
+    }
+}

--- a/Tests/Runtime/Utilities/SubmeshUtilityTests.cs.meta
+++ b/Tests/Runtime/Utilities/SubmeshUtilityTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: af86481499b07c94ca0c3582c588ab66
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Purpose of this PR

Added an option to auto remove materials when a submesh is removed and trim excess materials. It also removes empty submeshes. This is done during Optimize.

![image](https://user-images.githubusercontent.com/44209648/128886297-8db4b95e-7961-4617-87da-ea7783196922.png)

### Links

**Fogbugz:** [1332789](https://fogbugz.unity3d.com/f/cases/1332789/) & [1332789](https://fogbugz.unity3d.com/f/cases/1332789/)