### PR TITLE
Bugfix/1369443 shapetool errors domainreload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Bug Fixes
 
+- [case: 1369443] Fixed SerializedObjectNotCreatableException errors in the console with Shape Tool.
 - [case: 1334017] Fixed errors while exporting a PBShape using FBX Exporter and cleaning export.
 - [case: 1332226] Fixed issue where some Gizmos menu items would be missing in projects that have ProBuilder package installed.
 - [case: 1324374] Fixed incorrect vertex/edge/face rect selection when mesh's parent is rotated and/or scaled.

--- a/Editor/EditorCore/DrawShapeTool.cs
+++ b/Editor/EditorCore/DrawShapeTool.cs
@@ -186,7 +186,7 @@ namespace UnityEditor.ProBuilder
                 m_CurrentState = ShapeState.ResetState();
         }
 
-        public void OnSelectionChanged()
+        void OnSelectionChanged()
         {
             if(ToolManager.IsActiveTool(this))
             {

--- a/Editor/EditorCore/MenuToolToggle.cs
+++ b/Editor/EditorCore/MenuToolToggle.cs
@@ -59,7 +59,7 @@ namespace UnityEditor.ProBuilder
             bool wasEnabled = GUI.enabled;
             bool buttonEnabled = (menuActionState & MenuActionState.Enabled) == MenuActionState.Enabled;
 
-            bool isActiveTool = m_Tool != null && ToolManager.IsActiveTool(m_Tool);
+            bool isActiveTool = m_Tool != null && (ToolManager.IsActiveTool(m_Tool) || ToolManager.activeToolType == m_Tool.GetType());
 
             GUI.enabled = buttonEnabled;
 

--- a/Editor/EditorCore/ProBuilderMeshEditor.cs
+++ b/Editor/EditorCore/ProBuilderMeshEditor.cs
@@ -49,13 +49,12 @@ namespace UnityEditor.ProBuilder
 
         Renderer m_MeshRenderer = null;
 
-        protected override void OnHeaderGUI()
-        {
-        }
-
         void OnEnable()
         {
             if (EditorApplication.isPlayingOrWillChangePlaymode)
+                return;
+
+            if(target == null)
                 return;
 
             m_Mesh = (ProBuilderMesh)target;

--- a/Editor/EditorCore/ProBuilderShapeEditor.cs
+++ b/Editor/EditorCore/ProBuilderShapeEditor.cs
@@ -14,9 +14,38 @@ namespace UnityEditor.ProBuilder
     [CustomEditor(typeof(ProBuilderShape))]
     class ProBuilderShapeEditor : Editor
     {
-        SerializedProperty m_ShapeProperty;
-        SerializedProperty m_ShapePivotProperty;
-        SerializedProperty m_ShapeSizeProperty;
+        SerializedProperty m_ShapeProperty = null;
+        SerializedProperty shapeProperty
+        {
+            get
+            {
+                if(m_ShapeProperty == null)
+                    m_ShapeProperty = serializedObject.FindProperty("m_Shape");
+                return m_ShapeProperty;
+            }
+        }
+
+        SerializedProperty m_ShapePivotProperty = null;
+        SerializedProperty shapePivotProperty
+        {
+            get
+            {
+                if(m_ShapePivotProperty == null)
+                    m_ShapePivotProperty = serializedObject.FindProperty("m_PivotLocation");
+                return m_ShapePivotProperty;
+            }
+        }
+
+        SerializedProperty m_ShapeSizeProperty = null;
+        SerializedProperty shapeSizeProperty
+        {
+            get
+            {
+                if(m_ShapeSizeProperty == null)
+                    m_ShapeSizeProperty = serializedObject.FindProperty("m_Size");
+                return m_ShapeSizeProperty;
+            }
+        }
 
         int m_ActiveShapeIndex = 0;
 
@@ -46,13 +75,6 @@ namespace UnityEditor.ProBuilder
         }
 
         Type m_CurrentShapeType;
-
-        void OnEnable()
-        {
-            m_ShapeProperty = serializedObject.FindProperty("m_Shape");
-            m_ShapePivotProperty = serializedObject.FindProperty("m_PivotLocation");
-            m_ShapeSizeProperty = serializedObject.FindProperty("m_Size");
-        }
 
         public override void OnInspectorGUI()
         {
@@ -149,20 +171,21 @@ namespace UnityEditor.ProBuilder
                             UndoUtility.RecordComponents<Transform, ProBuilderMesh, ProBuilderShape>(new [] { proBuilderShape },"Change Shape");
                             proBuilderShape.SetShape(EditorShapeUtility.CreateShape(type), proBuilderShape.pivotLocation);
                             ProBuilderEditor.Refresh();
+
                         }
                     }
                 }
 
                 if(tool)
-                    EditorGUILayout.PropertyField(m_ShapePivotProperty, k_ShapePivotLabel);
+                    EditorGUILayout.PropertyField(shapePivotProperty, k_ShapePivotLabel);
 
-                EditorGUILayout.PropertyField(m_ShapeSizeProperty);
+                EditorGUILayout.PropertyField(shapeSizeProperty);
 
                 EditorGUI.indentLevel--;
             }
 
             if(!HasMultipleShapeTypes)
-                EditorGUILayout.PropertyField(m_ShapeProperty, new GUIContent("Shape Properties"), true);
+                EditorGUILayout.PropertyField(shapeProperty, new GUIContent("Shape Properties"), true);
 
             if (serializedObject.ApplyModifiedProperties())
             {

--- a/Editor/EditorCore/ProBuilderShapeEditor.cs
+++ b/Editor/EditorCore/ProBuilderShapeEditor.cs
@@ -171,7 +171,6 @@ namespace UnityEditor.ProBuilder
                             UndoUtility.RecordComponents<Transform, ProBuilderMesh, ProBuilderShape>(new [] { proBuilderShape },"Change Shape");
                             proBuilderShape.SetShape(EditorShapeUtility.CreateShape(type), proBuilderShape.pivotLocation);
                             ProBuilderEditor.Refresh();
-
                         }
                     }
                 }

--- a/Editor/MenuActions/Editors/NewPolyShapeToggle.cs
+++ b/Editor/MenuActions/Editors/NewPolyShapeToggle.cs
@@ -94,7 +94,7 @@ namespace UnityEditor.ProBuilder.Actions
              ToolManager.SetActiveTool(m_Tool);
 
             MenuAction.onPerformAction += ActionPerformed;
-            ToolManager.activeToolChanging += OnActiveToolChanging;
+            ToolManager.activeToolChanged += OnActiveToolChanged;
             ProBuilderEditor.selectModeChanged += OnSelectModeChanged;
 
             MeshSelection.objectSelectionChanged += OnObjectSelectionChanged;
@@ -106,7 +106,7 @@ namespace UnityEditor.ProBuilder.Actions
         {
             m_Tool = null;
             MenuAction.onPerformAction -= ActionPerformed;
-            ToolManager.activeToolChanging -= OnActiveToolChanging;
+            ToolManager.activeToolChanged -= OnActiveToolChanged;
             ProBuilderEditor.selectModeChanged -= OnSelectModeChanged;
             MeshSelection.objectSelectionChanged -= OnObjectSelectionChanged;
 
@@ -137,7 +137,7 @@ namespace UnityEditor.ProBuilder.Actions
             if( m_Tool == null )
                 return;
 
-            if(MeshSelection.activeMesh.GetComponent<PolyShape>() == null)
+            if(MeshSelection.activeMesh == null || MeshSelection.activeMesh.GetComponent<PolyShape>() == null)
                 EditorApplication.delayCall += () => LeaveTool();
         }
 
@@ -146,9 +146,9 @@ namespace UnityEditor.ProBuilder.Actions
             LeaveTool();
         }
 
-        void OnActiveToolChanging()
+        void OnActiveToolChanged()
         {
-            if(m_Tool != null && ToolManager.IsActiveTool(m_Tool))
+            if(m_Tool != null && ToolManager.activeToolType != m_Tool.GetType())
                  LeaveTool();
         }
 

--- a/Editor/StateMachines/ShapeState_DrawBaseShape.cs
+++ b/Editor/StateMachines/ShapeState_DrawBaseShape.cs
@@ -91,6 +91,7 @@ namespace UnityEditor.ProBuilder
 
         public void CreateLastShape()
         {
+            tool.handleSelectionChange = false;
             var shape = ShapeFactory.Instantiate(DrawShapeTool.activeShapeType, (PivotLocation)DrawShapeTool.s_LastPivotLocation.value).GetComponent<ProBuilderShape>();
             UndoUtility.RegisterCreatedObjectUndo(shape.gameObject, $"Create Shape");
             EditorUtility.InitObject(shape.mesh);

--- a/Editor/StateMachines/ShapeState_DrawHeightShape.cs
+++ b/Editor/StateMachines/ShapeState_DrawHeightShape.cs
@@ -16,11 +16,15 @@ namespace UnityEditor.ProBuilder
 
         ShapeState ValidateShape()
         {
+            tool.handleSelectionChange = false;
+
             tool.RebuildShape();
             tool.m_ProBuilderShape.pivotGlobalPosition = tool.m_BB_Origin;
             tool.m_ProBuilderShape.gameObject.hideFlags = HideFlags.None;
 
-            DrawShapeTool.s_ActiveShapeIndex.value = Array.IndexOf(EditorShapeUtility.availableShapeTypes,tool.m_ProBuilderShape.shape.GetType());
+            EditorUtility.InitObject(tool.m_ProBuilderShape.mesh);
+
+            DrawShapeTool.s_ActiveShapeIndex.value = Array.IndexOf(EditorShapeUtility.availableShapeTypes, tool.m_ProBuilderShape.shape.GetType());
             DrawShapeTool.SaveShapeParams(tool.m_ProBuilderShape);
 
             // make sure that the whole shape creation process is a single undo group

--- a/Editor/StateMachines/ShapeState_InitShape.cs
+++ b/Editor/StateMachines/ShapeState_InitShape.cs
@@ -32,6 +32,7 @@ namespace UnityEditor.ProBuilder
 
         public override ShapeState DoState(Event evt)
         {
+            tool.handleSelectionChange = true;
             if(evt.type == EventType.KeyDown)
             {
                 switch(evt.keyCode)

--- a/Runtime/Core/ActionResult.cs
+++ b/Runtime/Core/ActionResult.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 
 namespace UnityEngine.ProBuilder
@@ -61,12 +62,21 @@ namespace UnityEngine.ProBuilder
             return res != null && res.status == Status.Success;
         }
 
+        /// <summary>
+        /// Convert the ActionResult to a boolean value, true if successful and false if not.
+        /// </summary>
+        /// <returns>True if action was successful, false otherwise.</returns>
         public bool ToBool()
         {
             return status == Status.Success;
         }
 
-        public static bool FromBool(bool success)
+        /// <summary>
+        /// Convert a boolean value to an ActionResult, Success if true and Failure if false.
+        /// </summary>
+        /// <param name="success">The bool value to convert</param>
+        /// <returns>Success if success is true and Failure if false.</returns>
+        public static ActionResult FromBool(bool success)
         {
             return success ? ActionResult.Success : new ActionResult(ActionResult.Status.Failure, "Failure");
         }

--- a/Runtime/Core/ShapeGenerator.cs
+++ b/Runtime/Core/ShapeGenerator.cs
@@ -1344,9 +1344,6 @@ namespace UnityEngine.ProBuilder
         /// <summary>
         /// Create a new icosphere shape.
         /// </summary>
-        /// <remarks>
-        /// This method does not build UVs, so after generating BoxProject for UVs.
-        /// </remarks>
         /// <param name="pivotType">Where the shape's pivot will be.</param>
         /// <param name="radius">The radius of the sphere.</param>
         /// <param name="subdivisions">How many subdivisions to perform.</param>

--- a/Tests/Editor/Editor/ReflectedMethodsExist.cs
+++ b/Tests/Editor/Editor/ReflectedMethodsExist.cs
@@ -5,6 +5,10 @@ using System;
 using System.Reflection;
 using UnityEngine.ProBuilder;
 
+#if ENABLE_DRIVEN_PROPERTIES
+using SerializationUtility = UnityEngine.ProBuilder.SerializationUtility;
+#endif
+
 static class ReflectedMethodsExist
 {
     const BindingFlags k_BindingFlagsAll = BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic;
@@ -31,6 +35,7 @@ static class ReflectedMethodsExist
     [Test]
     public static void HandleUtility_ApplyWireMaterial()
     {
+
         var m_ApplyWireMaterial = typeof(UnityEditor.HandleUtility).GetMethod(
                 "ApplyWireMaterial",
                 BindingFlags.Static | BindingFlags.NonPublic,


### PR DESCRIPTION
### Purpose of this PR

The main purpose of this PR is to fix SerializedObjectNotCreatableException errors thrown in the console when using the Shape Tool and when triggering a Domain reload.

This is coming with a few modification in the way Selection is handled in the Shape tool as well as how (and when) the created shape is shown in the Inspector. For instance, the inspector is not displayed anymore when the shape is being traced in the SceneView as this could mislead the user to think that we can modifies the GameObject (pos, rotation...) while tracing the shape, which is not the case.

This PR is also fixing a few other elements :
- Polyshape MenuAction toggle  not enabled when entering in Polyshape mode
- Some API problems in the ActionResult class

### Links

https://fogbugz.unity3d.com/f/cases/1369443/

### Comments to Reviewers

Checked to be working with 2022.1, 2021.2, 2020.3 and 2019.4