### PR TITLE
Fixed orthogonal element extrusions resulting in slight offset along normal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Bug Fixes
 
+- [case: 1368465] Fixed issue where extruding an element orthogonally to their normal would result in some additional extrusion along the normal.
 - [case: 1369443] Fixed SerializedObjectNotCreatableException errors in the console with Shape Tool.
 - [case: 1334017] Fixed errors while exporting a PBShape using FBX Exporter and cleaning export.
 - [case: 1332226] Fixed issue where some Gizmos menu items would be missing in projects that have ProBuilder package installed.

--- a/Editor/EditorCore/VertexManipulationTool.cs
+++ b/Editor/EditorCore/VertexManipulationTool.cs
@@ -317,7 +317,7 @@ namespace UnityEditor.ProBuilder
                             goto default;
 
                         Edge[] newEdges = mesh.Extrude(mesh.selectedEdges,
-                                0.0001f,
+                                0f,
                                 s_ExtrudeEdgesAsGroup,
                                 ProBuilderEditor.s_AllowNonManifoldActions);
 
@@ -333,7 +333,7 @@ namespace UnityEditor.ProBuilder
 
                         if (len > 0)
                         {
-                            mesh.Extrude(mesh.selectedFacesInternal, s_ExtrudeMethod, 0.0001f);
+                            mesh.Extrude(mesh.selectedFacesInternal, s_ExtrudeMethod, 0f);
                             mesh.SetSelectedFaces(mesh.selectedFacesInternal);
                             ef += len;
                         }

--- a/Tests/Editor/Geometry/VertexManipulationTests.cs
+++ b/Tests/Editor/Geometry/VertexManipulationTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;
 using UnityEngine;
+using System.Collections;
 using UnityEditor.ProBuilder;
 using UnityEngine.ProBuilder;
 using UnityEngine.TestTools;
@@ -11,8 +12,8 @@ using UObject = UnityEngine.Object;
 
 class VertexManipulationTests
 {
-    [Test]
-    public static void ExtrudeOrthogonally_OneElementManyTimes_NoYOffsetAccumulates()
+    [UnityTest]
+    public static IEnumerator ExtrudeOrthogonally_OneElementManyTimes_NoYOffsetAccumulates()
     {
         // Generate single face plane
         var pb = ShapeGenerator.GeneratePlane(PivotLocation.Center, 1f, 1f, 0, 0, Axis.Up);
@@ -51,6 +52,28 @@ class VertexManipulationTests
             var bounds = SceneView.focusedWindow.rootVisualElement.worldBound;
             var mousePos = (bounds.size * 0.5f + bounds.position) + new Vector2Int(1, 1);
 
+            e = new UnityEngine.Event()
+            {
+                type = EventType.MouseDown,
+                mousePosition = mousePos,
+                modifiers = EventModifiers.None,
+                clickCount = 1,
+                delta = Vector2.zero,
+            };
+            sceneView.SendEvent(e);
+
+            e = new UnityEngine.Event()
+            {
+                type = EventType.MouseUp,
+                mousePosition = mousePos,
+                modifiers = EventModifiers.None,
+                clickCount = 0,
+                delta = Vector2.zero,
+            };
+            sceneView.SendEvent(e);
+
+            yield return null;
+
             const int k_ExtrudeCount = 100;
             for (int i = 0; i < k_ExtrudeCount; i++)
             {
@@ -80,6 +103,8 @@ class VertexManipulationTests
                 e.mousePosition = mousePos;
                 e.delta = Vector2.zero;
                 sceneView.SendEvent(e);
+
+                yield return null;
             }
 
             // Check that our face count is correct after all extrusions

--- a/Tests/Editor/Geometry/VertexManipulationTests.cs
+++ b/Tests/Editor/Geometry/VertexManipulationTests.cs
@@ -1,0 +1,80 @@
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+using UnityEditor.ProBuilder;
+using UnityEngine.ProBuilder;
+using UnityEngine.TestTools;
+using NUnit.Framework;
+using UObject = UnityEngine.Object;
+
+class VertexManipulationTests
+{
+    [Test]
+    public static void ExtrudeOrthogonally_OneElementManyTimes_NoYOffsetAccumulates()
+    {
+        // Generate 1 face plane
+        var pb = ShapeGenerator.GeneratePlane(PivotLocation.Center, 1f, 1f, 0, 0, Axis.Up);
+        try
+        {
+            Assume.That(pb.facesInternal.Length, Is.EqualTo(1));
+            var face = pb.facesInternal[0];
+
+            // Select face
+            var selectedFaces = new List<Face>();
+            selectedFaces.Add(face);
+            ProBuilderEditor.toolManager.SetSelectMode(SelectMode.Face);
+            pb.SetSelectedFaces(selectedFaces);
+            MeshSelection.SetSelection(pb.gameObject);
+
+            // Look directly at the plane and focus scene view
+            var sceneView = SceneView.lastActiveSceneView;
+            sceneView.LookAtDirect(pb.transform.position, Quaternion.LookRotation(Vector3.down), 1f);
+            sceneView.Focus();
+
+            var mousePos = sceneView.position.size * .5f;
+            mousePos.y += sceneView.rootVisualElement.worldBound.y;
+
+            const int k_ExtrudeCount = 100;
+            for (int i = 0; i < k_ExtrudeCount; i++)
+            {
+                // Press down at the center of the face
+                UnityEngine.Event e = new UnityEngine.Event()
+                {
+                    type = EventType.MouseDown,
+                    mousePosition = mousePos,
+                    modifiers = EventModifiers.Shift,
+                    clickCount = 1,
+                    delta = Vector2.zero,
+                };
+                sceneView.SendEvent(e);
+
+                // Do lateral 1px drag and release
+                e.type = EventType.MouseDrag;
+                e.delta = new Vector2(1f, 0f);
+                mousePos += e.delta;
+                e.mousePosition = mousePos;
+                sceneView.SendEvent(e);
+                e.type = EventType.MouseUp;
+                sceneView.SendEvent(e);
+            }
+
+            // Check that our face count is correct after all extrusions
+            Assume.That(pb.facesInternal.Length, Is.EqualTo(k_ExtrudeCount * 4 + 1));
+
+            // We should have the last extruded face in selection
+            var postExtrudeSelectedFaces = pb.GetSelectedFaces();
+            Assume.That(postExtrudeSelectedFaces.Length, Is.EqualTo(1));
+            var lastExtrudedFace = postExtrudeSelectedFaces[0];
+            var faceVertices = pb.GetVertices(lastExtrudedFace.indexes);
+
+            // After many orthogonal extrusions, the last face should still be at y=0 coordinate
+            for (int i = 0; i < faceVertices.Length; i++)
+                Assert.That(faceVertices[i].position.y, Is.EqualTo(0));
+        }
+        finally
+        {
+            UObject.DestroyImmediate(pb.gameObject);
+        }
+    }
+}

--- a/Tests/Editor/Geometry/VertexManipulationTests.cs
+++ b/Tests/Editor/Geometry/VertexManipulationTests.cs
@@ -6,6 +6,7 @@ using UnityEditor.ProBuilder;
 using UnityEngine.ProBuilder;
 using UnityEngine.TestTools;
 using NUnit.Framework;
+using UnityEditor.EditorTools;
 using UObject = UnityEngine.Object;
 
 class VertexManipulationTests
@@ -13,10 +14,28 @@ class VertexManipulationTests
     [Test]
     public static void ExtrudeOrthogonally_OneElementManyTimes_NoYOffsetAccumulates()
     {
-        // Generate 1 face plane
+        // Generate single face plane
         var pb = ShapeGenerator.GeneratePlane(PivotLocation.Center, 1f, 1f, 0, 0, Axis.Up);
         try
         {
+            pb.transform.position = Vector3.zero;
+            pb.transform.rotation = Quaternion.identity;
+
+            ProBuilderEditor.MenuOpenWindow();
+            EditorApplication.ExecuteMenuItem("Window/General/Scene");
+
+            var sceneView = UnityEngine.Resources.FindObjectsOfTypeAll<UnityEditor.SceneView>()[0];
+            sceneView.orthographic = true;
+            sceneView.drawGizmos = false;
+            sceneView.pivot = new Vector3(0, 0, 0);
+            sceneView.rotation = Quaternion.AngleAxis(90f, Vector3.right);
+            sceneView.size = 2.0f;
+            sceneView.Focus();
+
+            var e = new Event();
+            e.type = EventType.MouseEnterWindow;
+            sceneView.SendEvent(e);
+
             Assume.That(pb.facesInternal.Length, Is.EqualTo(1));
             var face = pb.facesInternal[0];
 
@@ -24,38 +43,42 @@ class VertexManipulationTests
             var selectedFaces = new List<Face>();
             selectedFaces.Add(face);
             ProBuilderEditor.toolManager.SetSelectMode(SelectMode.Face);
+            ToolManager.SetActiveTool(typeof(ProbuilderMoveTool));
             pb.SetSelectedFaces(selectedFaces);
             MeshSelection.SetSelection(pb.gameObject);
 
-            // Look directly at the plane and focus scene view
-            var sceneView = SceneView.lastActiveSceneView;
-            sceneView.LookAtDirect(pb.transform.position, Quaternion.LookRotation(Vector3.down), 1f);
-            sceneView.Focus();
-
-            var mousePos = sceneView.position.size * .5f;
-            mousePos.y += sceneView.rootVisualElement.worldBound.y;
+            // Center mouse position
+            var bounds = SceneView.focusedWindow.rootVisualElement.worldBound;
+            var mousePos = (bounds.size * 0.5f + bounds.position) + new Vector2Int(1, 1);
 
             const int k_ExtrudeCount = 100;
             for (int i = 0; i < k_ExtrudeCount; i++)
             {
                 // Press down at the center of the face
-                UnityEngine.Event e = new UnityEngine.Event()
+                e = new UnityEngine.Event()
                 {
                     type = EventType.MouseDown,
                     mousePosition = mousePos,
-                    modifiers = EventModifiers.Shift,
+                    modifiers = EventModifiers.None,
                     clickCount = 1,
                     delta = Vector2.zero,
                 };
                 sceneView.SendEvent(e);
 
                 // Do lateral 1px drag and release
+                var mouseDelta =  new Vector2(i % 2 == 0 ? 1f : -1f, 0f);
+                mousePos += mouseDelta;
+
                 e.type = EventType.MouseDrag;
-                e.delta = new Vector2(1f, 0f);
-                mousePos += e.delta;
                 e.mousePosition = mousePos;
+                e.modifiers = EventModifiers.Shift;
+                e.clickCount = 0;
+                e.delta = mouseDelta;
                 sceneView.SendEvent(e);
+
                 e.type = EventType.MouseUp;
+                e.mousePosition = mousePos;
+                e.delta = Vector2.zero;
                 sceneView.SendEvent(e);
             }
 
@@ -70,7 +93,7 @@ class VertexManipulationTests
 
             // After many orthogonal extrusions, the last face should still be at y=0 coordinate
             for (int i = 0; i < faceVertices.Length; i++)
-                Assert.That(faceVertices[i].position.y, Is.EqualTo(0));
+                Assert.That(faceVertices[i].position.y, Is.EqualTo(0f));
         }
         finally
         {

--- a/Tests/Editor/Geometry/VertexManipulationTests.cs
+++ b/Tests/Editor/Geometry/VertexManipulationTests.cs
@@ -42,8 +42,8 @@ class VertexManipulationTests
             // Select face
             var selectedFaces = new List<Face>();
             selectedFaces.Add(face);
+            Tools.current = Tool.Move;
             ProBuilderEditor.toolManager.SetSelectMode(SelectMode.Face);
-            ToolManager.SetActiveTool(typeof(ProbuilderMoveTool));
             pb.SetSelectedFaces(selectedFaces);
             MeshSelection.SetSelection(pb.gameObject);
 

--- a/Tests/Editor/Geometry/VertexManipulationTests.cs.meta
+++ b/Tests/Editor/Geometry/VertexManipulationTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f8d05693a69744c91a6e98b8bac1661c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Purpose of this PR

This PR fixes an issue where performing an element extrusion that is orthogonal to the element's normal would result in that element being additionally extruded along its normal by 0.0001. 

Added new test.

### Links

**Fogbugz:** https://fogbugz.unity3d.com/f/cases/1368465/

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]