### PR TITLE
Removing old reflection calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- [case: 1395936] Fixed Editor crash when opening a EditorWindow dropdown (MacOS).
+
 ### Changes
 
 * Updates to API documentation

--- a/Editor/EditorCore/MenuOption.cs
+++ b/Editor/EditorCore/MenuOption.cs
@@ -30,12 +30,6 @@ namespace UnityEditor.ProBuilder
 
             win.onSettingsGUI = onSettingsGUI;
 
-            // don't let window hang around after a script reload nukes the pb_MenuAction instances
-            object parent = ReflectionUtility.GetValue(win, typeof(EditorWindow), "m_Parent");
-            object window = ReflectionUtility.GetValue(parent, typeof(EditorWindow), "window");
-            ReflectionUtility.SetValue(parent, "mouseRayInvisible", true);
-            ReflectionUtility.SetValue(window, "m_DontSaveToLayout", true);
-
             win.Show();
 
             return win;


### PR DESCRIPTION
### Purpose of this PR

Removing old reflection now causing Editor crashes on Mac.
The comment was saying:
"don't let window hang around after a script reload nukes the pb_MenuAction instances"
However, this is now handled on domain reload by a delayed call to : `EditorApplication.delayCall += CloseAll;` 

### Links

**Fogbugz:** https://fogbugz.unity3d.com/f/cases/1395936/

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]