### PR TITLE
Updating Unity versions for editor tests

### DIFF
--- a/.yamato/promotion.yml
+++ b/.yamato/promotion.yml
@@ -1,7 +1,8 @@
 test_editors:
   - version: 2019.4
-  - version: 2020.1
-  - version: 2020.2
+  - version: 2020.3
+  - version: 2021.2
+  - version: 2022.1
   - version: trunk
 test_platforms:
   - name: win

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -1,7 +1,7 @@
 test_editors:
   - version: 2019.4
-  - version: 2020.1
-  - version: 2020.2
+  - version: 2020.3
+  - version: 2021.2
   - version: trunk
 test_platforms:
   - name: win

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -2,6 +2,7 @@ test_editors:
   - version: 2019.4
   - version: 2020.3
   - version: 2021.2
+  - version: 2022.1
   - version: trunk
 test_platforms:
   - name: win


### PR DESCRIPTION
### Purpose of this PR

Updating Unity versions for editor tests;
Removing 2020.1 and 2020.2
Adding 2020.3 (LTS), 2021.2 (LTS) and 2022.1
