### PR TITLE
Plane generation consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Bug Fixes
+
+- [case: 1403852] Fixing Plane generation that was not consistent regarding Width/Length.
+
 ## [4.5.3] - 2021-07-23
 
 ### Bug Fixes

--- a/Runtime/Core/ShapeGenerator.cs
+++ b/Runtime/Core/ShapeGenerator.cs
@@ -980,14 +980,15 @@ namespace UnityEngine.ProBuilder
                         p[i + 2] = new Vector2(x0,    y1);
                         p[i + 3] = new Vector2(x1,    y1);
 
+                        var invertFace = axis == Axis.Left || axis == Axis.Down || axis == Axis.Forward;
                         f[j++] = new Face(new int[6]
                         {
                             i + 0,
+                            invertFace? i + 2 : i + 1,
+                            invertFace? i + 1 : i + 2,
                             i + 1,
-                            i + 2,
-                            i + 1,
-                            i + 3,
-                            i + 2
+                            invertFace? i + 2 : i + 3,
+                            invertFace? i + 3 : i + 2,
                         });
 
                         i += 4;
@@ -998,25 +999,16 @@ namespace UnityEngine.ProBuilder
             switch (axis)
             {
                 case Axis.Right:
+                case Axis.Left:
                     for (i = 0; i < v.Length; i++)
                         v[i] = new Vector3(0f, p[i].x, p[i].y);
                     break;
-                case Axis.Left:
-                    for (i = 0; i < v.Length; i++)
-                        v[i] = new Vector3(0f, p[i].y, p[i].x);
-                    break;
                 case Axis.Up:
+                case Axis.Down:
                     for (i = 0; i < v.Length; i++)
                         v[i] = new Vector3(p[i].y, 0f, p[i].x);
                     break;
-                case Axis.Down:
-                    for (i = 0; i < v.Length; i++)
-                        v[i] = new Vector3(p[i].x, 0f, p[i].y);
-                    break;
                 case Axis.Forward:
-                    for (i = 0; i < v.Length; i++)
-                        v[i] = new Vector3(p[i].x, p[i].y, 0f);
-                    break;
                 case Axis.Backward:
                     for (i = 0; i < v.Length; i++)
                         v[i] = new Vector3(p[i].y, p[i].x, 0f);


### PR DESCRIPTION
### Purpose of this PR

Improving consistency of the Width/Length parameters in the Plane generation.
Changing orientation from Forward to Backward for instance was also inverting the aspect ratio height/width.

Previous behavior:
![plane-bug](https://user-images.githubusercontent.com/66317117/155387097-9cdf2ceb-d876-4bfd-b6d9-e86a991d5284.gif)


New behavior:
![plane-fix](https://user-images.githubusercontent.com/66317117/155387090-c3ed0dfd-40be-4474-8cbd-4a07c7a94c6b.gif)

### Links

**Fogbugz:** https://fogbugz.unity3d.com/f/cases/1403852/

### Comments to Reviewers
