### PR TITLE
Bugfix/1403850 mirrored stairs uv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+## Unreleased
+
+### Bug Fixes
+
+- [case: 1403850] Fixing UVs for mirrored stairs.
+
 ## [4.5.3] - 2021-07-23
 
 ### Bug Fixes

--- a/Runtime/Core/ShapeGenerator.cs
+++ b/Runtime/Core/ShapeGenerator.cs
@@ -438,6 +438,8 @@ namespace UnityEngine.ProBuilder
                 }
 
                 float uvRotation = ((inc1 + inc0) * -.5f) * Mathf.Rad2Deg;
+                if(circumference < 0)
+                    uvRotation = -uvRotation;
                 uvRotation %= 360f;
                 if (uvRotation < 0f)
                     uvRotation = 360f + uvRotation;
@@ -544,8 +546,14 @@ namespace UnityEngine.ProBuilder
                 for (int i = 0; i < positions.Length; i++)
                     positions[i].Scale(flip);
 
-                foreach (Face f in faces)
+                foreach(Face f in faces)
+                {
+                    var uv = f.uv;
+                    uv.flipU = circumference < 0;
+                    f.uv = uv;
+
                     f.Reverse();
+                }
             }
 
             ProBuilderMesh pb = ProBuilderMesh.Create(positions, faces);


### PR DESCRIPTION
### Purpose of this PR

Fix for the UVs being incorrect when generating mirrored curved stairs.

Previous behavior:
![pb-uvs-bug](https://user-images.githubusercontent.com/66317117/155762197-e89c4fbc-bce8-49e6-bb24-421458da99e6.gif)

Fixed behavior:
![pb-uvs-fixed](https://user-images.githubusercontent.com/66317117/155762207-6c029d8a-bdd9-48a4-929d-53a2a2273963.gif)

### Links

**Fogbugz:** https://fogbugz.unity3d.com/f/cases/1403850/

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]