### PR TITLE
Fix for Detach Faces undo issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Bug Fixes
 
+- [case: 1407518] Fixed issue where 'Detach Faces' action would not undo correctly.
 - [case: 1395936] Fixed Editor crash when opening a EditorWindow dropdown (MacOS).
 - [case: 1389642] Fixed Grid snapping not working properly with EditShape Tool.
 - [case: 1368465] Fixed issue where extruding an element orthogonally to their normal would result in some additional extrusion along the normal.

--- a/Editor/MenuActions/Geometry/DetachFaces.cs
+++ b/Editor/MenuActions/Geometry/DetachFaces.cs
@@ -127,8 +127,6 @@ namespace UnityEditor.ProBuilder.Actions
                         EditorUtility.SynchronizeWithMeshFilter(child);
                 }
 
-                Undo.RegisterCreatedObjectUndo(copy.gameObject, "Detach Selection");
-
                 mesh.DeleteFaces(primary);
                 copy.DeleteFaces(inverse);
 
@@ -142,6 +140,8 @@ namespace UnityEditor.ProBuilder.Actions
                 copy.ClearSelection();
 
                 copy.SetSelectedFaces(copy.faces);
+
+                Undo.RegisterCreatedObjectUndo(copy.gameObject, "Detach Selection");
 
                 copy.gameObject.name = GameObjectUtility.GetUniqueNameForSibling(mesh.transform.parent, mesh.gameObject.name); ;
                 detached.Add(copy.gameObject);

--- a/Tests/Editor/Undo/TestUndo.cs
+++ b/Tests/Editor/Undo/TestUndo.cs
@@ -1,9 +1,11 @@
 using UnityEngine;
 using NUnit.Framework;
+using UnityEditor.ProBuilder;
 using UnityEngine.ProBuilder;
 using UnityEngine.ProBuilder.MeshOperations;
 using UnityEngine.ProBuilder.Shapes;
 using UnityEngine.ProBuilder.Tests.Framework;
+using UnityEditor.ProBuilder.Actions;
 
 static class UndoTests
 {

--- a/Tests/Editor/Undo/TestUndo.cs
+++ b/Tests/Editor/Undo/TestUndo.cs
@@ -36,4 +36,40 @@ static class UndoTests
         UnityEngine.Object.DestroyImmediate(cube.gameObject);
         UnityEngine.Object.DestroyImmediate(duplicate.gameObject);
     }
+
+    [Test]
+    public static void DetachFaceUndoTest()
+    {
+        var cube = ShapeFactory.Instantiate<Cube>();
+        var duplicate = UnityEngine.Object.Instantiate(cube.gameObject).GetComponent<ProBuilderMesh>();
+        duplicate.MakeUnique();
+
+        // Select the mesh
+        MeshSelection.SetSelection(cube.gameObject);
+        MeshSelection.OnObjectSelectionChanged();
+        Assume.That(MeshSelection.selectedObjectCount, Is.EqualTo(1));
+
+        // Select a face
+        cube.SetSelectedFaces(new Face[]{cube.facesInternal[0]});
+        Assume.That(cube.selectedFacesInternal.Length, Is.EqualTo(1));
+
+        // Perform `Detach Faces` action
+        var detachAction = new DetachFaces();
+        var result = detachAction.PerformAction();
+        Assume.That(result.status, Is.EqualTo(ActionResult.Status.Success));
+
+        UnityEditor.Undo.PerformUndo();
+
+        // this is usually caught by UndoUtility
+        cube.InvalidateCaches();
+
+        cube.ToMesh();
+        cube.Refresh();
+
+        // After undo, previously edited mesh should match the duplicate
+        TestUtility.AssertAreEqual(duplicate.mesh, cube.mesh);
+
+        UnityEngine.Object.DestroyImmediate(cube.gameObject);
+        UnityEngine.Object.DestroyImmediate(duplicate.gameObject);
+    }
 }


### PR DESCRIPTION
**DO NOT FORGET TO INCLUDE A CHANGELOG ENTRY**

### Purpose of this PR

Fixes a bug where undoing after a "Detach faces" operation with the "Separate GameObject" option on would not restore the detached faces - leaving the mesh with missing faces. Behaviour before:

![BeforeFix](https://user-images.githubusercontent.com/14927700/156258666-8d02fb64-28b4-4376-829e-20a2f7294d92.gif)

Behaviour after:

![AfterFix](https://user-images.githubusercontent.com/14927700/156258685-86ae696d-1616-4e47-a760-90ac07b1e039.gif)

The issue was that the call to `Undo.RegisterCreatedObjectUndo(copy.gameObject, "Detach Selection");` was issued too early without giving the chance for the prior call to  `UndoUtility.RecordSelection("Detach Face(s)");` to register original mesh's face changes.

Tested with small meshes and meshes with >512 vert count as `UndoUtility.RecordSelection` takes different code paths depending on vertex count. In each case, fix worked correctly.

Added automated test.

### Links

**Fogbugz:** https://fogbugz.unity3d.com/f/cases/1407518/

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]