### PR TITLE
Bugfix/1393809 move small scales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Bug Fixes
 
-- [case: 1393809] Fixing move tool when working with small scales.
+- [case: 1393809] Fixed move tool when working with small scales.
 - [case: 1395936] Fixed Editor crash when opening a EditorWindow dropdown (MacOS).
 - [case: 1389642] Fixed Grid snapping not working properly with EditShape Tool.
 - [case: 1368465] Fixed issue where extruding an element orthogonally to their normal would result in some additional extrusion along the normal.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Bug Fixes
 
+- [case: 1393809] Fixing move tool when working with small scales.
 - [case: 1395936] Fixed Editor crash when opening a EditorWindow dropdown (MacOS).
 - [case: 1389642] Fixed Grid snapping not working properly with EditShape Tool.
 - [case: 1368465] Fixed issue where extruding an element orthogonally to their normal would result in some additional extrusion along the normal.

--- a/Editor/EditorCore/ProbuilderMoveTool.cs
+++ b/Editor/EditorCore/ProbuilderMoveTool.cs
@@ -6,7 +6,7 @@ namespace UnityEditor.ProBuilder
     class ProbuilderMoveTool : PositionTool
     {
         const float k_CardinalAxisError = .001f;
-        const float k_MinTranslateDeltaSqrMagnitude = .00001f;
+        const float k_MinTranslateDeltaSqrMagnitude = .0001f;
         Vector3 m_Position;
         Vector3 m_RawHandleDelta;
         Vector3Mask m_ActiveAxesModel;
@@ -51,8 +51,7 @@ namespace UnityEditor.ProBuilder
             m_RawHandleDelta = m_Position - handlePositionOrigin;
 
             var delta = m_RawHandleDelta;
-
-            if (EditorGUI.EndChangeCheck() && delta.sqrMagnitude > k_MinTranslateDeltaSqrMagnitude)
+            if (EditorGUI.EndChangeCheck() && delta.sqrMagnitude > k_MinTranslateDeltaSqrMagnitude * HandleUtility.GetHandleSize(m_Position))
             {
                 if (!isEditing)
                     BeginEdit("Translate Selection");


### PR DESCRIPTION
### Purpose of this PR

Fixing move tool not working when zooming on the vertices. This was caused by a constant which was limiting the minimum offset to 0.0001f. Instead of that, taking into account the Size handle (`HandleUtility.GetHandleSize(m_Position)`) to scale this constant value.

Default behavior :
![pb-small-scale-bug](https://user-images.githubusercontent.com/66317117/158246867-c7bc9b54-9009-4e14-8f7d-147fb9b8cdec.gif)

Behavior after fix:
![pb-small-scale-fix](https://user-images.githubusercontent.com/66317117/158246882-c3e32818-45a1-420f-a85f-c5b819e7cf05.gif)

### Links

**Fogbugz:** https://fogbugz.unity3d.com/f/cases/1393809/

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]