### PR TITLE
Fixed issue where vertex manipulation tools would lock grid snapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix some styling issues with Overlays in 21.2
 - [case: 1350635] Fixed crash when using CSG operations.
 - [case: 1407039] Fixed stair creation tool missing the inner radius parameter.
+- [case: PBLD-3] Fixed vertex manipulation tools locking grid snapping settings on activation.
 
 ### Changes
 

--- a/Editor/EditorCore/VertexManipulationTool.cs
+++ b/Editor/EditorCore/VertexManipulationTool.cs
@@ -43,6 +43,8 @@ namespace UnityEditor.ProBuilder
             get { return s_ShowHandleSettingsInScene; }
         }
 
+        public override bool gridSnapEnabled => Tools.pivotRotation == PivotRotation.Global;
+
         // Store PivotRotation so that we can detect changes and update our handles appropriately
         static PivotRotation s_PivotRotation;
 


### PR DESCRIPTION
### Purpose of this PR

Fixed issue where entering any vertex manipulation tool would lock grid snapping settings (effectively leaving the user with no way to toggle it without exiting the tools).

### Links

**Jira:** https://jira.unity3d.com/browse/PBLD-3

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]