### PR TITLE
[Backport 4.5] Fixed ProBuilderize redo issue 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - [case: 1403852] Fixing Plane generation that was not consistent regarding Width/Length.
 - [case: 1403850] Fixing UVs for mirrored stairs.
+- [case: PBLD-8] Fixed ProBuilderize action not handling redo operation correctly.
 
 ## [4.5.3] - 2021-07-23
 

--- a/Editor/EditorCore/MeshSelection.cs
+++ b/Editor/EditorCore/MeshSelection.cs
@@ -229,13 +229,22 @@ namespace UnityEditor.ProBuilder
         /// </summary>
         internal static void EnsureMeshSelectionIsValid()
         {
+            var willInvokeChangeCallback = false;
             for (int i = 0; i < topInternal.Count; i++)
             {
                 if (topInternal[i] == null || !Selection.Contains(topInternal[i].gameObject))
                 {
                     EditorApplication.delayCall += OnObjectSelectionChanged;
+                    willInvokeChangeCallback = true;
                     break;
                 }
+            }
+
+            if (!willInvokeChangeCallback)
+            {
+                var activeMesh = Selection.activeGameObject != null ? Selection.activeGameObject.GetComponent<ProBuilderMesh>() : null;
+                if (activeMesh != null && !topInternal.Contains(activeMesh))
+                    EditorApplication.delayCall += OnObjectSelectionChanged;
             }
         }
 

--- a/Editor/EditorCore/MeshSelection.cs
+++ b/Editor/EditorCore/MeshSelection.cs
@@ -243,7 +243,7 @@ namespace UnityEditor.ProBuilder
             if (!willInvokeChangeCallback)
             {
                 var activeMesh = Selection.activeGameObject != null ? Selection.activeGameObject.GetComponent<ProBuilderMesh>() : null;
-                if (activeMesh != null && !topInternal.Contains(activeMesh))
+                if (activeMesh != null && !topInternal.Contains(activeMesh) || (activeMesh == null && topInternal.Count == 0))
                     EditorApplication.delayCall += OnObjectSelectionChanged;
             }
         }


### PR DESCRIPTION
### Purpose of this PR

Fixed issue where ProBuilderize action would not Redo properly and would lead to a state where the selected GO would have a `ProBuilderMesh` component but `MeshSelection.topInternal` selection would be empty. Effectively this would result in the ProBuilder window being in a state as if the GO did not have `ProBuilderMesh` component added.

### Links

**Jira:** https://jira.unity3d.com/browse/PBLD-8

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]