### PR TITLE
[Backport 4.5] Fixed Collider/Trigger entity behaviours causing meshes to not render in builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Bug Fixes
 
+- [case: PBLD-10] Fixed issue where adding and then removing Collider or Trigger behaviours would cause meshes to not render in builds.
 - [case: 1403852] Fixing Plane generation that was not consistent regarding Width/Length.
 - [case: 1403850] Fixing UVs for mirrored stairs.
 

--- a/Editor/EditorCore/UnityScenePostProcessor.cs
+++ b/Editor/EditorCore/UnityScenePostProcessor.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEditor;
 using UnityEditor.Callbacks;
@@ -44,10 +45,14 @@ namespace UnityEditor.ProBuilder
             if (EditorApplication.isPlayingOrWillChangePlaymode)
                 return;
 
+            var renderersToStrip = new List<Renderer>();
             foreach (var entity in Resources.FindObjectsOfTypeAll<EntityBehaviour>())
             {
                 if (entity.manageVisibility)
                     entity.OnEnterPlayMode();
+
+                if ((entity is TriggerBehaviour or ColliderBehaviour) && entity.gameObject.TryGetComponent(out MeshRenderer renderer))
+                    renderersToStrip.Add(renderer);
             }
 
             foreach (var mesh in Object.FindObjectsOfType<ProBuilderMesh>())
@@ -88,6 +93,9 @@ namespace UnityEditor.ProBuilder
                 Object.DestroyImmediate(mesh);
                 Object.DestroyImmediate(entity);
             }
+
+            foreach (var renderer in renderersToStrip)
+                Undo.DestroyObjectImmediate(renderer);
         }
 
         static Entity ProcessLegacyEntity(GameObject go)

--- a/Editor/EditorCore/UnityScenePostProcessor.cs
+++ b/Editor/EditorCore/UnityScenePostProcessor.cs
@@ -51,7 +51,7 @@ namespace UnityEditor.ProBuilder
                 if (entity.manageVisibility)
                     entity.OnEnterPlayMode();
 
-                if ((entity is TriggerBehaviour or ColliderBehaviour) && entity.gameObject.TryGetComponent(out MeshRenderer renderer))
+                if ((entity is TriggerBehaviour || entity is ColliderBehaviour) && entity.gameObject.TryGetComponent(out MeshRenderer renderer))
                     renderersToStrip.Add(renderer);
             }
 

--- a/Runtime/Core/ColliderBehaviour.cs
+++ b/Runtime/Core/ColliderBehaviour.cs
@@ -18,9 +18,6 @@ namespace UnityEngine.ProBuilder
                 collision = gameObject.AddComponent<MeshCollider>();
             collision.isTrigger = false;
             SetMaterial(BuiltinMaterials.colliderMaterial);
-            var r = GetComponent<Renderer>();
-            if (r != null)
-                r.hideFlags = HideFlags.DontSaveInBuild;
         }
 
         public override void OnEnterPlayMode()

--- a/Runtime/Core/TriggerBehaviour.cs
+++ b/Runtime/Core/TriggerBehaviour.cs
@@ -24,11 +24,6 @@ namespace UnityEngine.ProBuilder
             collision.isTrigger = true;
 
             SetMaterial(BuiltinMaterials.triggerMaterial);
-
-            var r = GetComponent<Renderer>();
-
-            if (r != null)
-                r.hideFlags = HideFlags.DontSaveInBuild;
         }
 
         public override void OnEnterPlayMode()


### PR DESCRIPTION
Backport of https://github.com/Unity-Technologies/com.unity.probuilder/pull/425

### Purpose of this PR

Fixes an issue where adding and then subsequently removing a Collider or Trigger entity behaviour would have the side effect of PB mesh no longer rendering in builds. The cause of the issue was the fact that these behaviours would set the renderer's hide flags to `DontSaveInBuild` on Initialize but would not restore it to `None` on removal. 

The user's scene attached to the bug report had a number of PB meshes that did not have the behaviours attached but the renderers had their hideFlags set to `DontSaveInBuild`.

### Links

**Jira:** https://jira.unity3d.com/browse/PBLD-10

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]