### PR TITLE
FogBugz 1429897: Fix MeshUtility.CollapseSharedVertices(quad) example in api.md

### DIFF
--- a/Documentation~/api.md
+++ b/Documentation~/api.md
@@ -72,8 +72,11 @@ quad.Refresh();
 // If in editor, generate UV2 and collapse duplicate vertices with
 EditorMeshUtility.Optimize(quad, true);
 
-// If at runtime, collapse duplicate vertices with
-MeshUtility.CollapseSharedVertices(quad);
+// At runtime, `EditorMeshUtility` is not available. To collapse duplicate
+// vertices in runtime, modify the MeshFilter.sharedMesh directly.
+// Note that any subsequent changes to `quad` will overwrite the sharedMesh.
+var umesh = quad.GetComponent<MeshFilter>().sharedMesh;
+MeshUtility.CollapseSharedVertices(umesh);
 ```
 
 Note that you should never directly modify the `MeshFilter.sharedMesh`. ProBuilder controls updating the Unity Mesh with [ProBuilderMesh::ToMesh](xref:UnityEngine.ProBuilder.ProBuilderMesh.ToMesh(UnityEngine.MeshTopology)) and [ProBuilderMesh::Refresh](xref:UnityEngine.ProBuilder.ProBuilderMesh.Refresh(UnityEngine.ProBuilder.RefreshMask)) functions.


### PR DESCRIPTION
### Purpose of this PR

On the **About the ProBuilder Scripting API** page, the example code in the **Modify a Mesh** section is incorrect. The `MeshUtility.CollapseSharedVertices(quad);` won't work as written. The function requires a `UnityEngine.Mesh` and the example uses a `UnityEngine.ProBuilder.ProBuilderMesh`. This was reported in FogBugz 1429897. 

I consulted with @karl- for these changes. 

### Links

**Fogbugz:** https://fogbugz.unity3d.com/f/cases/1429897/
