### PR TITLE
Fix URP support in GameView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [case: PBLD-6] Fixed unnecessary reimport of all project textures on package install.
 - [case: PBLD-11] Fixed Poly Shape Tool missing an undo step after setting height.
 - [case: PBLD-13] Fixed a bug where a newly created shape would not be redrawn with Redo. 
-- [case: PBLD-15] Fixed URP support in the Game View.
+- [case: PBLD-15] Fixed a bug with URP that prevented some items from being selectable in the Game view. 
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [case: PBLD-7] Fixed ProBuilderize action not handling redo operation correctly.
 - [case: PBLD-6] Fixed unnecessary reimport of all project textures on package install.
 - [case: PBLD-11] Fixed Poly Shape Tool missing an undo step after setting height.
+- [case: PBLD-15] Fixed URP support in the Game View.
 
 ### Changes
 

--- a/Content/Shader/FacePicker.shader
+++ b/Content/Shader/FacePicker.shader
@@ -20,8 +20,6 @@ Shader "Hidden/ProBuilder/FacePicker"
             #pragma fragment frag
             #include "UnityCG.cginc"
 
-            float4 _Tint;
-
             struct appdata
             {
                 float4 vertex : POSITION;

--- a/Runtime/Core/SelectionPickerRendererStandard.cs
+++ b/Runtime/Core/SelectionPickerRendererStandard.cs
@@ -57,7 +57,7 @@ namespace UnityEngine.ProBuilder
                     volumeDepth = 1,
                     msaaSamples = 1
                 };
-              
+
                 RenderTexture rt = RenderTexture.GetTemporary(descriptor);
                 RenderTexture prev = RenderTexture.active;
                 renderCam.targetTexture = rt;
@@ -88,9 +88,12 @@ namespace UnityEngine.ProBuilder
                 // that switches rendering path if replacement shaders are in use, but I wasn't able to get that
                 // approach to work without also requiring that the drawing happen during a repaint event.
                 var currentRenderPipeline = GraphicsSettings.renderPipelineAsset;
+                var qualitySettingsRenderPipeline = QualitySettings.renderPipeline;
                 GraphicsSettings.renderPipelineAsset = null;
+                QualitySettings.renderPipeline = null;
                 renderCam.RenderWithShader(shader, tag);
                 GraphicsSettings.renderPipelineAsset = currentRenderPipeline;
+                QualitySettings.renderPipeline = qualitySettingsRenderPipeline;
 
                 Texture2D img = new Texture2D(_width, _height, textureFormat, false, false);
                 img.ReadPixels(new Rect(0, 0, _width, _height), 0, 0);


### PR DESCRIPTION
### Purpose of this PR

This PR fixes URP support in the Game View in the `SelectionPickerRendererStandard` file.
I also removed the `_Tint` variable from the `FacePicker` shader since it wasn't used.

### Links

**Jira:** https://jira.unity3d.com/browse/PBLD-15