### PR TITLE
Fixed shape creation when the camera perspective is set to Top (PBLD-19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - 2022-07-08
+
+### Bug Fixes
+
+- [case: PBLD-19] Fixed shape creation when the camera perspective is set to Top.
+
+### Changes
+
+
 ## [5.0.6] - 2022-06-30
 
 ### Bug Fixes

--- a/Editor/StateMachines/ShapeState_DrawHeightShape.cs
+++ b/Editor/StateMachines/ShapeState_DrawHeightShape.cs
@@ -77,8 +77,9 @@ namespace UnityEditor.ProBuilder
                             deltaPoint = Quaternion.Inverse(tool.m_PlaneRotation) * deltaPoint;
                             deltaPoint = tool.GetPoint(deltaPoint, evt.control);
                             tool.m_BB_HeightCorner = tool.m_PlaneRotation * deltaPoint + tool.m_BB_OppositeCorner;
+                            tool.RebuildShape();
                         }
-                        tool.RebuildShape();
+
                         break;
 
                     case EventType.MouseUp:

--- a/Editor/StateMachines/ShapeState_DrawHeightShape.cs
+++ b/Editor/StateMachines/ShapeState_DrawHeightShape.cs
@@ -71,11 +71,7 @@ namespace UnityEditor.ProBuilder
                         Vector3 heightPoint = Math.GetNearestPointRayRay(tool.m_BB_OppositeCorner, tool.m_Plane.normal, ray.origin, ray.direction);
                         var dot = Vector3.Dot(tool.m_Plane.normal, ray.direction);
                         var isHeightPointNaN = float.IsNaN(heightPoint.x) || float.IsNaN(heightPoint.y) || float.IsNaN(heightPoint.z);
-                        if (isHeightPointNaN)
-                        {
-                            tool.m_BB_HeightCorner = tool.m_PlaneRotation * Vector3.zero + tool.m_BB_OppositeCorner;
-                        }
-                        else
+                        if (!isHeightPointNaN)
                         {
                             var deltaPoint = (dot == 0 ? ray.origin - tool.m_Plane.ClosestPointOnPlane(ray.origin) : heightPoint - tool.m_BB_OppositeCorner);
                             deltaPoint = Quaternion.Inverse(tool.m_PlaneRotation) * deltaPoint;

--- a/Editor/StateMachines/ShapeState_DrawHeightShape.cs
+++ b/Editor/StateMachines/ShapeState_DrawHeightShape.cs
@@ -68,13 +68,20 @@ namespace UnityEditor.ProBuilder
                     case EventType.MouseMove:
                     case EventType.MouseDrag:
                         Ray ray = HandleUtility.GUIPointToWorldRay(evt.mousePosition);
-                        Vector3 heightPoint = Math.GetNearestPointRayRay(tool.m_BB_OppositeCorner, tool.m_Plane.normal,
-                            ray.origin, ray.direction);
-
-                        var deltaPoint = heightPoint - tool.m_BB_OppositeCorner;
-                        deltaPoint = Quaternion.Inverse(tool.m_PlaneRotation) * deltaPoint;
-                        deltaPoint = tool.GetPoint(deltaPoint, evt.control);
-                        tool.m_BB_HeightCorner = tool.m_PlaneRotation * deltaPoint + tool.m_BB_OppositeCorner;
+                        Vector3 heightPoint = Math.GetNearestPointRayRay(tool.m_BB_OppositeCorner, tool.m_Plane.normal, ray.origin, ray.direction);
+                        var dot = Vector3.Dot(tool.m_Plane.normal, ray.direction);
+                        var isHeightPointNaN = float.IsNaN(heightPoint.x) || float.IsNaN(heightPoint.y) || float.IsNaN(heightPoint.z);
+                        if (isHeightPointNaN)
+                        {
+                            tool.m_BB_HeightCorner = tool.m_PlaneRotation * Vector3.zero + tool.m_BB_OppositeCorner;
+                        }
+                        else
+                        {
+                            var deltaPoint = (dot == 0 ? ray.origin - tool.m_Plane.ClosestPointOnPlane(ray.origin) : heightPoint - tool.m_BB_OppositeCorner);
+                            deltaPoint = Quaternion.Inverse(tool.m_PlaneRotation) * deltaPoint;
+                            deltaPoint = tool.GetPoint(deltaPoint, evt.control);
+                            tool.m_BB_HeightCorner = tool.m_PlaneRotation * deltaPoint + tool.m_BB_OppositeCorner;
+                        }
                         tool.RebuildShape();
                         break;
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,20 @@
     "prototype",
     "probuilder"
   ],
+  "samples": [
+    {
+      "path": "Samples~/UniversalRenderPipeline"
+    },
+    {
+      "path": "Samples~/HDRP"
+    },
+    {
+      "path": "Samples~/Editor"
+    },
+    {
+      "path": "Samples~/Runtime"
+    }
+  ],
   "dependencies": {
     "com.unity.settings-manager": "1.0.3",
     "com.unity.modules.physics": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -28,15 +28,23 @@
   ],
   "samples": [
     {
+      "displayName": "Universal Render Pipeline Support",
+      "description": "Shaders and materials for the Light Weight Render Pipeline.",
       "path": "Samples~/UniversalRenderPipeline"
     },
     {
+      "displayName": "High Definition Render Pipeline Support",
+      "description": "Shaders and materials for the High Definition Render Pipeline.",
       "path": "Samples~/HDRP"
     },
     {
+      "displayName": "Editor Examples",
+      "description": "Scripts demonstrating how to integrate new functionality into the ProBuilder editor window.",
       "path": "Samples~/Editor"
     },
     {
+      "displayName": "Runtime Examples",
+      "description": "Scripts showing how to create and modify meshes at runtime.",
       "path": "Samples~/Runtime"
     }
   ],

--- a/package.json
+++ b/package.json
@@ -26,28 +26,6 @@
     "prototype",
     "probuilder"
   ],
-  "samples": [
-    {
-      "displayName": "Universal Render Pipeline Support",
-      "description": "Shaders and materials for the Light Weight Render Pipeline.",
-      "path": "Samples~/UniversalRenderPipeline"
-    },
-    {
-      "displayName": "High Definition Render Pipeline Support",
-      "description": "Shaders and materials for the High Definition Render Pipeline.",
-      "path": "Samples~/HDRP"
-    },
-    {
-      "displayName": "Editor Examples",
-      "description": "Scripts demonstrating how to integrate new functionality into the ProBuilder editor window.",
-      "path": "Samples~/Editor"
-    },
-    {
-      "displayName": "Runtime Examples",
-      "description": "Scripts showing how to create and modify meshes at runtime.",
-      "path": "Samples~/Runtime"
-    }
-  ],
   "dependencies": {
     "com.unity.settings-manager": "1.0.3",
     "com.unity.modules.physics": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -30,10 +30,5 @@
     "com.unity.settings-manager": "1.0.3",
     "com.unity.modules.physics": "1.0.0",
     "com.unity.modules.imgui": "1.0.0"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/Unity-Technologies/com.unity.probuilder.git",
-    "revision": "9754fff959cb431b2161f8cab02162717c396446"
   }
 }


### PR DESCRIPTION
### Purpose of this PR

This PR fixes an issue that happened when creating a shape with the camera perspective set to Top. Multiple errors were thrown when setting the height of the newly created shape.

This PR also removes a few duplicate properties in the `package.json` file.

### Links

**Jira:** 
- https://jira.unity3d.com/browse/PBLD-19 (Bug) 
- https://jira.unity3d.com/browse/PBLD-21 (Port)