### PR TITLE
Fixing RMB behavior with Shape Tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- [case: PBLD-32] Fixed `New Shape` start location being incorrect after using right mouse button.
+
 ## [5.0.6] - 2022-06-30
 
 ### Bug Fixes

--- a/Editor/StateMachines/ShapeState_InitShape.cs
+++ b/Editor/StateMachines/ShapeState_InitShape.cs
@@ -53,7 +53,7 @@ namespace UnityEditor.ProBuilder
                 Ray ray = HandleUtility.GUIPointToWorldRay(evt.mousePosition);
                 float hit;
 
-                if(res.item1.Raycast(ray, out hit))
+                if(evt.button == 0 && res.item1.Raycast(ray, out hit))
                 {
                     //Plane init
                     tool.m_Plane = res.item1;
@@ -94,9 +94,7 @@ namespace UnityEditor.ProBuilder
                     }
                 }
                 else
-                {
-                    m_HitPosition = Vector3.negativeInfinity;
-                }
+                    m_HitPosition = Vector3.positiveInfinity;
             }
 
             if (!Math.IsNumber(m_HitPosition))


### PR DESCRIPTION
### Purpose of this PR

Fixing a bug where the RMB is setting the original position of the shape when using the Shape tool although only the LMB should be the correct one.

### Links

**Jira:** https://jira.unity3d.com/browse/PBLD-32

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]