### PR TITLE
Fix bug with prefabs not tracking serialized mesh

### DIFF
--- a/Runtime/Core/ProBuilderMesh.cs
+++ b/Runtime/Core/ProBuilderMesh.cs
@@ -963,7 +963,14 @@ namespace UnityEngine.ProBuilder
                 return m_Mesh;
             }
 
-            set { m_Mesh = value; }
+            set
+            { 
+                m_Mesh = value;
+#if UNITY_EDITOR
+                UnityEditor.EditorUtility.SetDirty(this);
+                UnityEditor.PrefabUtility.RecordPrefabInstancePropertyModifications(this);
+#endif
+            }
         }
 
         internal int id


### PR DESCRIPTION
Serialized field m_Mesh is modified on MonoBehaviour awake directly and in some instances prefabs were not being made aware of the change causing non-deterministic build behavior.

**DO NOT FORGET TO INCLUDE A CHANGELOG ENTRY**

### Purpose of this PR

Fixes an issue with non-deterministic build behaviour with older versions of ProBuilder components in prefabs in scenes. Here's the behavior noticed:
- ProBuilderMesh.cs in prior versions did not serialized out m_Mesh field.
- This scene has a prefab instance from that older version.
- This causes the mesh to be recreated every time.
- Reserializing out the scene does not cause the prefab instance to add that missing property modification.
So as a result the mesh will always be recreated every time as this field is not being picked up as a property modification after the upgrade even though ProBuilderMesh is changing that field.

This change notifies the object dirty system and the prefab system to this changed serialized field.

### Links

**Fogbugz:**
**Jira:**
**Slack:** https://unity.slack.com/archives/C7HJDB0A0/p1660261768092869

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]