### PR TITLE
Preserve existing mesh data in ProBuilderMesh.MakeUnique.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - [case: PBLD-32] Fixed `New Shape` start location being incorrect after using right mouse button.
 - [case: PBLD-19] Fixed shape creation when the camera perspective is set to Top.
+- `ProBuilderMesh.MakeUnique` now preserves existing mesh data when possible.
 
 ### Changes
 

--- a/Runtime/Core/ProBuilderMeshFunction.cs
+++ b/Runtime/Core/ProBuilderMeshFunction.cs
@@ -381,6 +381,14 @@ namespace UnityEngine.ProBuilder
         /// </summary>
         internal void MakeUnique()
         {
+            // if a mesh already exists, it can be instantiated
+            if (mesh != null)
+            {
+                mesh = Instantiate(mesh);
+                mesh.name = $"pb_Mesh{id}";
+                return;
+            }
+
             // set a new UnityEngine.Mesh instance
             mesh = new Mesh();
             ToMesh();


### PR DESCRIPTION
### Purpose of this PR
This fixes a rather strange issue that we encountered at New Blood while using ProBuilder in Gloomwood.

We would frequently find that after baking lightmaps, a random selection of ProBuilder meshes would have their lightmap UVs wiped. Notably, this UV issue would not manifest until either the objects in question were selected in the editor, or a build was produced.

After some investigation, we managed to track the issue down to the `MakeUnique` function on `ProBuilderMesh`, which seems to re-generate the mesh even if one already exists, thus discarding the lightmap UV channel and anything else not stored directly on the component.

It's not clear to me why these objects had `MakeUnique` called on them after a lightmap bake, so there is likely another issue at play _in addition_ to this one.