### PR TITLE
Fixed a bug where `Experimental Features Enabled` was not activating 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- [case: PBLD-34] Fixed a bug where `Experimental Features Enabled` was not activating when using `Dedicated Server` platform. 
 - [case: PBLD-32] Fixed `New Shape` start location being incorrect after using right mouse button.
 - [case: PBLD-19] Fixed shape creation when the camera perspective is set to Top.
 

--- a/Editor/EditorCore/ScriptingSymbolManager.cs
+++ b/Editor/EditorCore/ScriptingSymbolManager.cs
@@ -1,17 +1,48 @@
 using System;
+#if UNITY_2021_2_OR_NEWER
+using UnityEditor.Build;
+#endif
 
 namespace UnityEditor.ProBuilder
 {
     static class ScriptingSymbolManager
     {
+#if UNITY_2021_2_OR_NEWER
+        static BuildPlatform[] k_ValidPlatforms = null;
+        static BuildPlatform[] ValidPlatforms
+        {
+            get
+            {
+                if (k_ValidPlatforms == null)
+                    k_ValidPlatforms = BuildPlatforms.instance.GetValidPlatforms(true).ToArray();
+
+                return k_ValidPlatforms;
+            }
+        }
+#else
         static bool IsObsolete(BuildTargetGroup group)
         {
             var attrs = typeof(BuildTargetGroup).GetField(group.ToString()).GetCustomAttributes(typeof(ObsoleteAttribute), false);
             return attrs.Length > 0;
         }
+#endif
 
         internal static bool ContainsDefine(string define)
         {
+#if UNITY_2021_2_OR_NEWER
+            foreach (BuildPlatform targetPlatform in ValidPlatforms)
+            {
+                if (targetPlatform.namedBuildTarget == NamedBuildTarget.Unknown)
+                    continue;
+
+                string defineSymbols = PlayerSettings.GetScriptingDefineSymbols(targetPlatform.namedBuildTarget);
+
+                if (!defineSymbols.Contains(define))
+                    return false;
+            }
+
+            return true;
+#else
             foreach (BuildTargetGroup targetGroup in System.Enum.GetValues(typeof(BuildTargetGroup)))
             {
                 if (targetGroup == BuildTargetGroup.Unknown || IsObsolete(targetGroup))
@@ -24,6 +55,7 @@ namespace UnityEditor.ProBuilder
             }
 
             return true;
+#endif
         }
 
         /// <summary>
@@ -32,6 +64,27 @@ namespace UnityEditor.ProBuilder
         /// <param name="define"></param>
         public static void AddScriptingDefine(string define)
         {
+#if UNITY_2021_2_OR_NEWER
+            foreach (BuildPlatform targetPlatform in ValidPlatforms)
+            {
+                if (targetPlatform.namedBuildTarget == NamedBuildTarget.Unknown)
+                    continue;
+
+                string defineSymbols = PlayerSettings.GetScriptingDefineSymbols(targetPlatform.namedBuildTarget);
+
+                if (!defineSymbols.Contains(define))
+                {
+                    if (defineSymbols.Length < 1)
+                        defineSymbols = define;
+                    else if (defineSymbols.EndsWith(";"))
+                        defineSymbols = string.Format("{0}{1}", defineSymbols, define);
+                    else
+                        defineSymbols = string.Format("{0};{1}", defineSymbols, define);
+
+                    PlayerSettings.SetScriptingDefineSymbols(targetPlatform.namedBuildTarget, defineSymbols);
+                }
+            }
+#else
             foreach (BuildTargetGroup targetGroup in System.Enum.GetValues(typeof(BuildTargetGroup)))
             {
                 if (targetGroup == BuildTargetGroup.Unknown || IsObsolete(targetGroup))
@@ -51,6 +104,7 @@ namespace UnityEditor.ProBuilder
                     PlayerSettings.SetScriptingDefineSymbolsForGroup(targetGroup, defineSymbols);
                 }
             }
+#endif
         }
 
         /// <summary>
@@ -59,6 +113,23 @@ namespace UnityEditor.ProBuilder
         /// <param name="define"></param>
         public static void RemoveScriptingDefine(string define)
         {
+#if UNITY_2021_2_OR_NEWER
+            foreach (BuildPlatform targetPlatform in ValidPlatforms)
+            {
+                if (targetPlatform.namedBuildTarget == NamedBuildTarget.Unknown)
+                    continue;
+
+                string defineSymbols = PlayerSettings.GetScriptingDefineSymbols(targetPlatform.namedBuildTarget);
+
+                if (defineSymbols.Contains(define))
+                {
+                    defineSymbols = defineSymbols.Replace(string.Format("{0};", define), "");
+                    defineSymbols = defineSymbols.Replace(define, "");
+
+                    PlayerSettings.SetScriptingDefineSymbols(targetPlatform.namedBuildTarget, defineSymbols);
+                }
+            }
+#else
             foreach (BuildTargetGroup targetGroup in System.Enum.GetValues(typeof(BuildTargetGroup)))
             {
                 if (targetGroup == BuildTargetGroup.Unknown || IsObsolete(targetGroup))
@@ -74,6 +145,7 @@ namespace UnityEditor.ProBuilder
                     PlayerSettings.SetScriptingDefineSymbolsForGroup(targetGroup, defineSymbols);
                 }
             }
+#endif
         }
     }
 }

--- a/Editor/EditorCore/ScriptingSymbolManager.cs
+++ b/Editor/EditorCore/ScriptingSymbolManager.cs
@@ -7,19 +7,7 @@ namespace UnityEditor.ProBuilder
 {
     static class ScriptingSymbolManager
     {
-#if UNITY_2021_2_OR_NEWER
-        static BuildPlatform[] k_ValidPlatforms = null;
-        static BuildPlatform[] ValidPlatforms
-        {
-            get
-            {
-                if (k_ValidPlatforms == null)
-                    k_ValidPlatforms = BuildPlatforms.instance.GetValidPlatforms(true).ToArray();
-
-                return k_ValidPlatforms;
-            }
-        }
-#else
+#if !UNITY_2021_2_OR_NEWER
         static bool IsObsolete(BuildTargetGroup group)
         {
             var attrs = typeof(BuildTargetGroup).GetField(group.ToString()).GetCustomAttributes(typeof(ObsoleteAttribute), false);
@@ -30,7 +18,8 @@ namespace UnityEditor.ProBuilder
         internal static bool ContainsDefine(string define)
         {
 #if UNITY_2021_2_OR_NEWER
-            foreach (BuildPlatform targetPlatform in ValidPlatforms)
+            var validPlatforms = BuildPlatforms.instance.GetValidPlatforms(true);
+            foreach (BuildPlatform targetPlatform in validPlatforms)
             {
                 if (targetPlatform.namedBuildTarget == NamedBuildTarget.Unknown)
                     continue;
@@ -65,7 +54,8 @@ namespace UnityEditor.ProBuilder
         public static void AddScriptingDefine(string define)
         {
 #if UNITY_2021_2_OR_NEWER
-            foreach (BuildPlatform targetPlatform in ValidPlatforms)
+            var validPlatforms = BuildPlatforms.instance.GetValidPlatforms(true);
+            foreach (BuildPlatform targetPlatform in validPlatforms)
             {
                 if (targetPlatform.namedBuildTarget == NamedBuildTarget.Unknown)
                     continue;
@@ -114,7 +104,8 @@ namespace UnityEditor.ProBuilder
         public static void RemoveScriptingDefine(string define)
         {
 #if UNITY_2021_2_OR_NEWER
-            foreach (BuildPlatform targetPlatform in ValidPlatforms)
+            var validPlatforms = BuildPlatforms.instance.GetValidPlatforms(true);
+            foreach (BuildPlatform targetPlatform in validPlatforms)
             {
                 if (targetPlatform.namedBuildTarget == NamedBuildTarget.Unknown)
                     continue;


### PR DESCRIPTION
### Purpose of this PR

Fixed a bug where `Experimental Features Enabled` was not activating  when using `Dedicated Server` platform.
Basically the user was clicking on "Experimental Features Enabled" and nothing was happening.
After investigation, he is using the Dedicated server as a platform. The problem is coming from the fact that this platform as not been added in the `BuildTargetGroup` enum and thus was not impacted by the Settings adding the Scripting Define Symbol as this symbol was not added for that specific target.

Moreover the Symbols were set by ProBuilder using `PlayerSettings.[Get/Set]ScriptingDefineSymbolsForGroup` which have been deprecated since. This PR update this as well for Unity 2021.2 and after where `PlayerSettings.[Get/Set]ScriptingDefineSymbols` have been introduced.
This is now getting the valid platforms from `BuildPlatforms.instance.GetValidPlatforms` rather than going through `System.Enum.GetValues(typeof(BuildTargetGroup))`

Tested against Unity 2023.1.0a13, 2022.2.0a18, 2022.1.3f1, 2021.3.7f1 and 2021.2.0b12

### Links

**Jira:** https://jira.unity3d.com/browse/PBLD-34

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]