### PR TITLE
[Backport] Fixed a bug where Experimental Features Enabled was not activating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Bug Fixes
 
+- [case: PBLD-35] Fixed a bug where `Experimental Features Enabled` was not activating when using `Dedicated Server` platform.
 - [case: PBLD-10] Fixed issue where adding and then removing Collider or Trigger behaviours would cause meshes to not render in builds.
 - [case: 1403852] Fixing Plane generation that was not consistent regarding Width/Length.
 - [case: 1403850] Fixing UVs for mirrored stairs.

--- a/Editor/EditorCore/ScriptingSymbolManager.cs
+++ b/Editor/EditorCore/ScriptingSymbolManager.cs
@@ -1,17 +1,35 @@
 using System;
+#if UNITY_2021_2_OR_NEWER
+using UnityEditor.Build;
+#endif
 
 namespace UnityEditor.ProBuilder
 {
     static class ScriptingSymbolManager
     {
+#if !UNITY_2021_2_OR_NEWER
         static bool IsObsolete(BuildTargetGroup group)
         {
             var attrs = typeof(BuildTargetGroup).GetField(group.ToString()).GetCustomAttributes(typeof(ObsoleteAttribute), false);
             return attrs.Length > 0;
         }
+#endif
 
         internal static bool ContainsDefine(string define)
         {
+#if UNITY_2021_2_OR_NEWER
+            var validPlatforms = BuildPlatforms.instance.GetValidPlatforms(true);
+            foreach (BuildPlatform targetPlatform in validPlatforms)
+            {
+                if (targetPlatform.namedBuildTarget == NamedBuildTarget.Unknown)
+                    continue;
+
+                string defineSymbols = PlayerSettings.GetScriptingDefineSymbols(targetPlatform.namedBuildTarget);
+
+                if (!defineSymbols.Contains(define))
+                    return false;
+            }
+#else
             foreach (BuildTargetGroup targetGroup in System.Enum.GetValues(typeof(BuildTargetGroup)))
             {
                 if (targetGroup == BuildTargetGroup.Unknown || IsObsolete(targetGroup))
@@ -22,7 +40,7 @@ namespace UnityEditor.ProBuilder
                 if (!defineSymbols.Contains(define))
                     return false;
             }
-
+#endif
             return true;
         }
 
@@ -32,6 +50,28 @@ namespace UnityEditor.ProBuilder
         /// <param name="define"></param>
         public static void AddScriptingDefine(string define)
         {
+#if UNITY_2021_2_OR_NEWER
+            var validPlatforms = BuildPlatforms.instance.GetValidPlatforms(true);
+            foreach (BuildPlatform targetPlatform in validPlatforms)
+            {
+                if (targetPlatform.namedBuildTarget == NamedBuildTarget.Unknown)
+                    continue;
+
+                string defineSymbols = PlayerSettings.GetScriptingDefineSymbols(targetPlatform.namedBuildTarget);
+
+                if (!defineSymbols.Contains(define))
+                {
+                    if (defineSymbols.Length < 1)
+                        defineSymbols = define;
+                    else if (defineSymbols.EndsWith(";"))
+                        defineSymbols = string.Format("{0}{1}", defineSymbols, define);
+                    else
+                        defineSymbols = string.Format("{0};{1}", defineSymbols, define);
+
+                    PlayerSettings.SetScriptingDefineSymbols(targetPlatform.namedBuildTarget, defineSymbols);
+                }
+            }
+#else
             foreach (BuildTargetGroup targetGroup in System.Enum.GetValues(typeof(BuildTargetGroup)))
             {
                 if (targetGroup == BuildTargetGroup.Unknown || IsObsolete(targetGroup))
@@ -51,6 +91,7 @@ namespace UnityEditor.ProBuilder
                     PlayerSettings.SetScriptingDefineSymbolsForGroup(targetGroup, defineSymbols);
                 }
             }
+#endif
         }
 
         /// <summary>
@@ -59,6 +100,24 @@ namespace UnityEditor.ProBuilder
         /// <param name="define"></param>
         public static void RemoveScriptingDefine(string define)
         {
+#if UNITY_2021_2_OR_NEWER
+            var validPlatforms = BuildPlatforms.instance.GetValidPlatforms(true);
+            foreach (BuildPlatform targetPlatform in validPlatforms)
+            {
+                if (targetPlatform.namedBuildTarget == NamedBuildTarget.Unknown)
+                    continue;
+
+                string defineSymbols = PlayerSettings.GetScriptingDefineSymbols(targetPlatform.namedBuildTarget);
+
+                if (defineSymbols.Contains(define))
+                {
+                    defineSymbols = defineSymbols.Replace(string.Format("{0};", define), "");
+                    defineSymbols = defineSymbols.Replace(define, "");
+
+                    PlayerSettings.SetScriptingDefineSymbols(targetPlatform.namedBuildTarget, defineSymbols);
+                }
+            }
+#else
             foreach (BuildTargetGroup targetGroup in System.Enum.GetValues(typeof(BuildTargetGroup)))
             {
                 if (targetGroup == BuildTargetGroup.Unknown || IsObsolete(targetGroup))
@@ -74,6 +133,7 @@ namespace UnityEditor.ProBuilder
                     PlayerSettings.SetScriptingDefineSymbolsForGroup(targetGroup, defineSymbols);
                 }
             }
+#endif
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -50,10 +50,5 @@
   ],
   "dependencies": {
     "com.unity.settings-manager": "1.0.3"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/Unity-Technologies/com.unity.probuilder.git",
-    "revision": "ea0bd0c969779f359c7ca6e065338ac39a93c86a"
   }
 }


### PR DESCRIPTION
### Purpose of this PR

Fixed a bug where Experimental Features Enabled was not activating when using Dedicated Server platform.
Basically the user was clicking on "Experimental Features Enabled" and nothing was happening.
After investigation, he is using the Dedicated server as a platform. The problem is coming from the fact that this platform as not been added in the BuildTargetGroup enum and thus was not impacted by the Settings adding the Scripting Define Symbol as this symbol was not added for that specific target.

Moreover the Symbols were set by ProBuilder using PlayerSettings.[Get/Set]ScriptingDefineSymbolsForGroup which have been deprecated since. This PR update this as well for Unity 2021.2 and after where PlayerSettings.[Get/Set]ScriptingDefineSymbols have been introduced.
This is now getting the valid platforms from BuildPlatforms.instance.GetValidPlatforms rather than going through System.Enum.GetValues(typeof(BuildTargetGroup))

Tested against Unity 2023.1.0a13, 2022.2.0a18, 2022.1.3f1, 2021.3.7f1 and 2021.2.0b12

### Links

**Jira:** https://jira.unity3d.com/browse/PBLD-35

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]