### PR TITLE
DOCATT-346: Added Installing ProBuilder link to index.md

### DIFF
--- a/Documentation~/index.md
+++ b/Documentation~/index.md
@@ -4,6 +4,8 @@ You can build, edit, and texture custom geometry in Unity with the actions and t
 
 ProBuilder also comes with a [Scripting API](api.md), so that you can write C# scripts to make your own tools and customizations.
 
+To add ProBuilder to Unity, refer to [Installing ProBuilder](installing.md). 
+
 ![ProBuilder and Unity](images/probuilder_unitylogo.png)
 
 Some of the advanced features include:


### PR DESCRIPTION

### Purpose of this PR

Repeated user-generated bugs suggest some users cannot find the Installing ProBuilder link in the sidebar. I added another link to the installation steps to the About ProBuilder page to assist these users. A lot of packages include installation steps on the first page of the package's documentation, so this change will bring ProBuilder more in line with what user's expectations might be.

### Links

**Fogbugz:**
**Jira:** https://jira.unity3d.com/browse/DOCATT-346

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]