### PR TITLE
Fix for asset export unnecessarily using UInt32 mesh index format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Bug Fixes
 
 - [case: PBLD-19] Fixed shape creation when the camera perspective is set to Top.
+- [case: PBLD-38] Fixed asset export unnecessarily using UInt32 mesh index format.
 
 ### Changes
 

--- a/Runtime/Core/Vertex.cs
+++ b/Runtime/Core/Vertex.cs
@@ -765,6 +765,7 @@ namespace UnityEngine.ProBuilder
                 if (uv4s != null)
                     mesh.SetUVs(3, uv4s);
 #endif
+            mesh.indexFormat = mesh.vertexCount > ushort.MaxValue ? Rendering.IndexFormat.UInt32 : Rendering.IndexFormat.UInt16;
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose of this PR

PR fixes an issue where the asset export would sometimes unnecessarily use the UInt32 mesh index format for meshes that are below  65535 vertex count. The cause of the issue was that the mesh index format would be set before the mesh optimization which affect the final vertex count.

### Links

**Jira:** https://jira.unity3d.com/browse/PBLD-38

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]