### PR TITLE
Improved CPU performance

### DIFF
--- a/AssetIdRemapUtility/Editor/AssetId.cs
+++ b/AssetIdRemapUtility/Editor/AssetId.cs
@@ -105,7 +105,7 @@ namespace UnityEngine.ProBuilder.AssetIdRemapUtility
             var src = arr.Where(x => AssetId.IsValid(x.source) && !AssetId.IsValid(x.destination)).ToArray();
             var dst = arr.Where(x => AssetId.IsValid(x.destination)).ToArray();
 
-            if (dst.Count() != 1)
+            if (dst.Length != 1)
             {
                 Debug.LogError("Merging AssetId entries requires only one valid destination entry be selected.");
                 return;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [case: PBLD-34] Fixed a bug where `Experimental Features Enabled` was not activating when using `Dedicated Server` platform. 
 - [case: PBLD-32] Fixed `New Shape` start location being incorrect after using right mouse button.
 - [case: PBLD-19] Fixed shape creation when the camera perspective is set to Top.
-- Improved CPU performance
+- Minor performance improvements and reduced allocations when querying for components.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Changelog
+Nu# Changelog
 
 All notable changes to this project will be documented in this file.
 
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [case: PBLD-34] Fixed a bug where `Experimental Features Enabled` was not activating when using `Dedicated Server` platform. 
 - [case: PBLD-32] Fixed `New Shape` start location being incorrect after using right mouse button.
 - [case: PBLD-19] Fixed shape creation when the camera perspective is set to Top.
-- Minor performance improvements and reduced allocations when querying for components.
+- Made minor performance improvements and reduced allocations when querying for components.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [case: PBLD-34] Fixed a bug where `Experimental Features Enabled` was not activating when using `Dedicated Server` platform. 
 - [case: PBLD-32] Fixed `New Shape` start location being incorrect after using right mouse button.
 - [case: PBLD-19] Fixed shape creation when the camera perspective is set to Top.
+- Improved CPU performance
 
 ### Changes
 

--- a/Editor/EditorCore/DrawShapeTool.cs
+++ b/Editor/EditorCore/DrawShapeTool.cs
@@ -324,10 +324,9 @@ namespace UnityEditor.ProBuilder
 
             var pivot = GetPoint(position);
             if (pivotLocation == PivotLocation.Center)
-                pivot += m_Plane.normal * size.y * .5f;
+                pivot += .5f * size.y * m_Plane.normal;
 
-            m_DuplicateGO.transform.position = pivot;
-            m_DuplicateGO.transform.rotation = Quaternion.LookRotation(m_PlaneForward, m_Plane.normal);
+            m_DuplicateGO.transform.SetPositionAndRotation(pivot, Quaternion.LookRotation(m_PlaneForward, m_Plane.normal));
 
             DrawBoundingBox(false);
         }

--- a/Editor/EditorCore/EditorHandleUtility.cs
+++ b/Editor/EditorCore/EditorHandleUtility.cs
@@ -254,19 +254,19 @@ namespace UnityEditor.ProBuilder
             if (evt.type == EventType.Repaint)
             {
                 Handles.color = k_HandleColorUp;
-                Handles.DrawLine(position, position - Vector2.up * size * scale.y);
+                Handles.DrawLine(position, position - scale.y * size * Vector2.up);
 
                 if (position.y - size > 0f)
                     Handles.CubeHandleCap(0,
-                        ((Vector3) ((position - Vector2.up * scale.y * size))) - Vector3.forward * 16, QuaternionUp,
+                        ((Vector3) ((position - scale.y * size * Vector2.up))) - Vector3.forward * 16, QuaternionUp,
                         width / 3, evt.type);
 
                 Handles.color = k_HandleColorRight;
-                Handles.DrawLine(position, position + Vector2.right * size * scale.x);
+                Handles.DrawLine(position, position + scale.x * size * Vector2.right);
 
                 if (position.y > 0f)
                     Handles.CubeHandleCap(0,
-                        ((Vector3) ((position + Vector2.right * scale.x * size))) - Vector3.forward * 16,
+                        ((Vector3) ((position + scale.x * size * Vector2.right))) - Vector3.forward * 16,
                         Quaternion.Euler(Vector3.up * 90f),
                         width / 3f,
                         evt.type);

--- a/Editor/EditorCore/EditorSceneViewPicker.cs
+++ b/Editor/EditorCore/EditorSceneViewPicker.cs
@@ -311,7 +311,7 @@ namespace UnityEditor.ProBuilder
                             common = kvp.Value;
                         }
 
-                        elementsInDragRect |= kvp.Value.Any();
+                        elementsInDragRect |= kvp.Value.Count > 0;
                         mesh.SetSelectedVertices(common.SelectMany(x => sharedIndexes[x]));
                     }
 
@@ -348,7 +348,7 @@ namespace UnityEditor.ProBuilder
                             current = kvp.Value;
                         }
 
-                        elementsInDragRect |= kvp.Value.Any();
+                        elementsInDragRect |= kvp.Value.Count > 0;
                         kvp.Key.SetSelectedFaces(current);
                     }
 
@@ -388,7 +388,7 @@ namespace UnityEditor.ProBuilder
                             current = selectedEdges;
                         }
 
-                        elementsInDragRect |= kvp.Value.Any();
+                        elementsInDragRect |= kvp.Value.Count > 0;
                         mesh.SetSelectedEdges(current.Select(x => x.local));
                     }
 

--- a/Editor/EditorCore/EditorShapeUtility.cs
+++ b/Editor/EditorCore/EditorShapeUtility.cs
@@ -121,10 +121,7 @@ namespace UnityEditor.ProBuilder
                     if(pref == null)
                         pref = (Shape) Activator.CreateInstance(type);
 
-                    if(s_Prefs.ContainsKey(name))
-                        s_Prefs[name] = pref;
-                    else
-                        s_Prefs.Add(name, pref);
+                    s_Prefs[name] = pref;
                 }
             }
 

--- a/Editor/EditorCore/EditorToolbar.cs
+++ b/Editor/EditorCore/EditorToolbar.cs
@@ -37,7 +37,7 @@ namespace UnityEditor.ProBuilder
         public EditorToolbar(EditorWindow parent)
         {
             m_Actions = EditorToolbarLoader.GetActions(true);
-            m_ActionsLength = m_Actions.Count();
+            m_ActionsLength = m_Actions.Count;
 
             EditorApplication.update -= Update;
             EditorApplication.update += Update;

--- a/Editor/EditorCore/EntityUtility.cs
+++ b/Editor/EditorCore/EntityUtility.cs
@@ -32,9 +32,7 @@ namespace UnityEditor.ProBuilder
         [Obsolete("pb_Entity is deprecated. Manage static flags manually or use Set Trigger/Set Collider actions.")]
         public static void SetEntityType(EntityType newEntityType, GameObject target)
         {
-            Entity ent = target.GetComponent<Entity>();
-
-            if (ent == null)
+            if (!target.TryGetComponent<Entity>(out var ent))
                 ent = target.AddComponent<Entity>();
 
             ProBuilderMesh pb = target.GetComponent<ProBuilderMesh>();

--- a/Editor/EditorCore/EntityVisibility.cs
+++ b/Editor/EditorCore/EntityVisibility.cs
@@ -41,8 +41,7 @@ namespace UnityEditor.ProBuilder
             foreach (var entity in Object.FindObjectsOfType<Entity>())
                 if (entity.entityType == entityType)
                 {
-                    var mr = entity.GetComponent<MeshRenderer>();
-                    if (mr != null) mr.enabled = isVisible;
+                    if (entity.TryGetComponent<MeshRenderer>(out var mr)) mr.enabled = isVisible;
                 }
         }
 

--- a/Editor/EditorCore/Lightmapping.cs
+++ b/Editor/EditorCore/Lightmapping.cs
@@ -156,12 +156,9 @@ namespace UnityEditor.ProBuilder
                 {
                     var gameObject = modification.currentValue.target as GameObject;
 
-                    if (gameObject != null)
+                    if (gameObject != null && gameObject.TryGetComponent<ProBuilderMesh>(out var mesh))
                     {
-                        var mesh = gameObject.GetComponent<ProBuilderMesh>();
-
-                        if (mesh != null)
-                            mesh.Optimize();
+                        mesh.Optimize();
                     }
                 }
             }

--- a/Editor/EditorCore/MeshSelection.cs
+++ b/Editor/EditorCore/MeshSelection.cs
@@ -601,7 +601,7 @@ namespace UnityEditor.ProBuilder
             {
                 case PivotPoint.ActiveElement:
                 case PivotPoint.IndividualOrigins:
-                    if (!active.elementGroups.Any())
+                    if (active.elementGroups.Count == 0)
                         goto case default;
                     return active.elementGroups.Last().position;
 
@@ -624,7 +624,7 @@ namespace UnityEditor.ProBuilder
                     return active.mesh.transform.rotation;
 
                 case HandleOrientation.ActiveElement:
-                    if (!active.elementGroups.Any())
+                    if (active.elementGroups.Count == 0)
                         goto case HandleOrientation.ActiveObject;
                     return active.elementGroups.Last().rotation;
 

--- a/Editor/EditorCore/ObjExporter.cs
+++ b/Editor/EditorCore/ObjExporter.cs
@@ -96,7 +96,7 @@ namespace UnityEditor.ProBuilder
                 return false;
             }
 
-            if (models.Where(m => m.vertexCount > 0).Count() < 1)
+            if (models.Count(m => m.vertexCount > 0) < 1)
             {
                 Debug.LogWarning("Trying to export an empty model : "+name+". This model won't be exported.");
                 objContents = null;

--- a/Editor/EditorCore/ProBuilderAnalytics.cs
+++ b/Editor/EditorCore/ProBuilderAnalytics.cs
@@ -70,12 +70,8 @@ namespace UnityEditor.ProBuilder
             }
 
             var allNames = Enum.GetNames(typeof(EventName));
-            if (allNames.Any(eventName => !RegisterEvent(eventName)))
-            {
-                return false;
-            }
 
-            return true;
+            return !allNames.Any(eventName => !RegisterEvent(eventName));
         }
 
 

--- a/Editor/EditorCore/StripProBuilderScripts.cs
+++ b/Editor/EditorCore/StripProBuilderScripts.cs
@@ -72,9 +72,7 @@ namespace UnityEditor.ProBuilder.Actions
             {
                 GameObject go = pb.gameObject;
 
-                Renderer ren = go.GetComponent<Renderer>();
-
-                if (ren != null)
+                if (go.TryGetComponent<Renderer>(out var ren))
                     EditorUtility.SetSelectionRenderState(ren, EditorSelectedRenderState.Highlight | EditorSelectedRenderState.Wireframe);
 
                 if (EditorUtility.IsPrefabAsset(go))

--- a/Editor/EditorCore/UVEditor.cs
+++ b/Editor/EditorCore/UVEditor.cs
@@ -489,7 +489,7 @@ namespace UnityEditor.ProBuilder
             RefreshUVCoordinates();
 
             // get incompletely selected texture groups
-            int len = selection == null ? 0 : selection.Count();
+            int len = selection == null ? 0 : selection.Length;
 
             incompleteTextureGroupsInSelection = new List<Face[]>[len];
             incompleteTextureGroupsInSelection_CoordCache.Clear();
@@ -2070,7 +2070,7 @@ namespace UnityEditor.ProBuilder
         void ResetCanvas()
         {
             uvGraphScale = 1f;
-            SetCanvasCenter(new Vector2(.5f, -.5f) * uvGridSize * uvGraphScale);
+            SetCanvasCenter(uvGraphScale * uvGridSize * new Vector2(.5f, -.5f));
             uvGraphOffset = Vector2.zero;
         }
 
@@ -2108,7 +2108,7 @@ namespace UnityEditor.ProBuilder
         Vector2 UVToGUIPoint(Vector2 v)
         {
             Vector2 p = new Vector2(v.x, -v.y);
-            return UVGraphCenter + (p * uvGridSize * uvGraphScale) + uvGraphOffset;
+            return UVGraphCenter + (uvGraphScale * uvGridSize * p) + uvGraphOffset;
         }
 
         Vector2 GUIToUVPoint(Vector2 v)
@@ -2144,7 +2144,7 @@ namespace UnityEditor.ProBuilder
             {
                 Bounds2D uvBounds = UVSelectionBounds();
                 _selected_gui_bounds.center = UVToGUIPoint(uvBounds.center);
-                _selected_gui_bounds.size = uvBounds.size * uvGridSize * uvGraphScale;
+                _selected_gui_bounds.size = uvGraphScale * uvGridSize * uvBounds.size;
                 return _selected_gui_bounds;
             }
         }
@@ -3271,7 +3271,7 @@ namespace UnityEditor.ProBuilder
         Color screenshot_backgroundColor = Color.black;
         string screenShotPath = "";
 
-        readonly Color UV_FILL_COLOR = new Color(.192f, .192f, .192f, 1f);
+        readonly Color32 UV_FILL_COLOR = new Color32(49, 49, 49, 255);
 
         // This is the default background of the UV editor - used to compare bacground pixels when rendering UV template
         void InitiateScreenshot(int ImageSize, bool HideGrid, Color LineColor, bool TransparentBackground, Color BackgroundColor, bool RenderTexture)
@@ -3404,15 +3404,15 @@ namespace UnityEditor.ProBuilder
 
                     if (screenshot_transparentBackground)
                     {
-                        Color[] px = screenshot.GetPixels(0);
+                        Color32[] px = screenshot.GetPixels32(0);
 
                         for (int i = 0; i < px.Length; i++)
-                            if (Mathf.Abs(px[i].r - UV_FILL_COLOR.r) < .01f &&
-                                Mathf.Abs(px[i].g - UV_FILL_COLOR.g) < .01f &&
-                                Mathf.Abs(px[i].b - UV_FILL_COLOR.b) < .01f)
+                            if (Mathf.Abs(px[i].r - UV_FILL_COLOR.r) < 2 &&
+                                Mathf.Abs(px[i].g - UV_FILL_COLOR.g) < 2 &&
+                                Mathf.Abs(px[i].b - UV_FILL_COLOR.b) < 2)
                                 px[i] = Color.clear;
 
-                        screenshot.SetPixels(px);
+                        screenshot.SetPixels32(px);
                         screenshot.Apply();
                     }
 

--- a/Editor/EditorCore/UndoUtility.cs
+++ b/Editor/EditorCore/UndoUtility.cs
@@ -120,9 +120,9 @@ namespace UnityEditor.ProBuilder
                 return;
 
             Object[] obj = objs.Where(x => !(x is ProBuilderMesh)).ToArray();
-            ProBuilderMesh[] pb = objs.Where(x => x is ProBuilderMesh).Cast<ProBuilderMesh>().ToArray();
+            ProBuilderMesh[] pb = objs.OfType<ProBuilderMesh>().ToArray();
 
-            if (obj.Any())
+            if (obj.Length > 0)
                 Undo.RecordObjects(obj, msg);
 
             RecordSelection(pb, msg);

--- a/Editor/MenuActions/Export/Export.cs
+++ b/Editor/MenuActions/Export/Export.cs
@@ -177,7 +177,7 @@ namespace UnityEditor.ProBuilder.Actions
 
             List<ProBuilderMesh> meshes = m_ExportRecursive ? MeshSelection.deep.ToList() : MeshSelection.topInternal;
 
-            if (meshes == null || !meshes.Any())
+            if (meshes == null || meshes.Count == 0)
                 return new ActionResult(ActionResult.Status.Canceled, "No ProBuilder Mesh");
 
             if (m_ExportFormat == ExportFormat.Obj)

--- a/Editor/MenuActions/Export/ExportAsset.cs
+++ b/Editor/MenuActions/Export/ExportAsset.cs
@@ -61,12 +61,12 @@ namespace UnityEditor.ProBuilder.Actions
         /// <returns></returns>
         public static string ExportWithFileDialog(IList<ProBuilderMesh> meshes, ExportAssetOptions options)
         {
-            if (meshes == null || !meshes.Any())
+            if (meshes == null || meshes.Count == 0)
                 return "";
 
             string res = null;
 
-            if (meshes.Count() < 2)
+            if (meshes.Count < 2)
             {
                 ProBuilderMesh first = meshes.FirstOrDefault();
 

--- a/Editor/MenuActions/Object/FreezeTransform.cs
+++ b/Editor/MenuActions/Object/FreezeTransform.cs
@@ -60,8 +60,7 @@ namespace UnityEditor.ProBuilder.Actions
                 ProBuilderMesh pb = selection[i];
                 bool flipFaces = ShouldFlipFaces(pb.transform.localScale);
 
-                pb.transform.position = Vector3.zero;
-                pb.transform.rotation = Quaternion.identity;
+                pb.transform.SetPositionAndRotation(Vector3.zero, Quaternion.identity);
                 pb.transform.localScale = Vector3.one;
 
                 foreach(Face face in pb.facesInternal)

--- a/Editor/MenuActions/Object/SetCollider.cs
+++ b/Editor/MenuActions/Object/SetCollider.cs
@@ -42,9 +42,7 @@ namespace UnityEditor.ProBuilder.Actions
                 for (int i = 0, c = existing.Length; i < c; i++)
                     Undo.DestroyObjectImmediate(existing[i]);
 
-                var entity = pb.GetComponent<Entity>();
-
-                if (entity != null)
+                if (pb.TryGetComponent<Entity>(out var entity))
                     Undo.DestroyObjectImmediate(entity);
 
                 if (!pb.GetComponent<Collider>())

--- a/Editor/MenuActions/Object/SetTrigger.cs
+++ b/Editor/MenuActions/Object/SetTrigger.cs
@@ -44,9 +44,7 @@ namespace UnityEditor.ProBuilder.Actions
                 for (int i = 0, c = existing.Length; i < c; i++)
                     Undo.DestroyObjectImmediate(existing[i]);
 
-                var entity = pb.GetComponent<Entity>();
-
-                if (entity != null)
+                if (pb.TryGetComponent<Entity>(out var entity))
                     Undo.DestroyObjectImmediate(entity);
 
                 if (!pb.GetComponent<Collider>())

--- a/Editor/MenuActions/Selection/SelectVertexColor.cs
+++ b/Editor/MenuActions/Selection/SelectVertexColor.cs
@@ -112,10 +112,7 @@ namespace UnityEditor.ProBuilder.Actions
                         List<Face> matches = new List<Face>();
                         Face[] faces = pb.facesInternal;
 
-                        foreach(var face in faces)
-                        {
-                            matches.Add(face);
-                        }
+                        matches.AddRange(faces);
 
                         if (matches.Count > 0)
                         {

--- a/Runtime/Core/Math.cs
+++ b/Runtime/Core/Math.cs
@@ -240,7 +240,7 @@ namespace UnityEngine.ProBuilder
 
             float dist = Mathf.Sin(Vector2.Angle(line, point - lineStart) * Mathf.Deg2Rad) * Vector2.Distance(point, lineStart);
 
-            return point + perp * (dist * 2f) * (Vector2.Dot(point - lineStart, perp) > 0 ? -1f : 1f);
+            return point + (dist * 2f) * (Vector2.Dot(point - lineStart, perp) > 0 ? -1f : 1f) * perp;
         }
 
         internal static float SqrDistanceRayPoint(Ray ray, Vector3 point)

--- a/Runtime/Core/MeshUtility.cs
+++ b/Runtime/Core/MeshUtility.cs
@@ -435,14 +435,14 @@ namespace UnityEngine.ProBuilder
             mesh.GetUVs(2, uv3s);
             mesh.GetUVs(3, uv4s);
 
-            bool _hasPositions = positions != null && positions.Count() == vertexCount;
-            bool _hasColors = colors != null && colors.Count() == vertexCount;
-            bool _hasNormals = normals != null && normals.Count() == vertexCount;
-            bool _hasTangents = tangents != null && tangents.Count() == vertexCount;
-            bool _hasUv0 = uv0s != null && uv0s.Count() == vertexCount;
-            bool _hasUv2 = uv2s != null && uv2s.Count() == vertexCount;
-            bool _hasUv3 = uv3s.Count() == vertexCount;
-            bool _hasUv4 = uv4s.Count() == vertexCount;
+            bool _hasPositions = positions != null && positions.Length == vertexCount;
+            bool _hasColors = colors != null && colors.Length == vertexCount;
+            bool _hasNormals = normals != null && normals.Length == vertexCount;
+            bool _hasTangents = tangents != null && tangents.Length == vertexCount;
+            bool _hasUv0 = uv0s != null && uv0s.Length == vertexCount;
+            bool _hasUv2 = uv2s != null && uv2s.Length == vertexCount;
+            bool _hasUv3 = uv3s.Count == vertexCount;
+            bool _hasUv4 = uv4s.Count == vertexCount;
 
             for (int i = 0; i < vertexCount; i++)
             {

--- a/Runtime/Core/PreferenceDictionary.cs
+++ b/Runtime/Core/PreferenceDictionary.cs
@@ -311,10 +311,7 @@ namespace UnityEngine.ProBuilder
         /// </summary>
         public void SetBool(string key, bool value)
         {
-            if (m_Bool.ContainsKey(key))
-                m_Bool[key] = value;
-            else
-                m_Bool.Add(key, value);
+            m_Bool[key] = value;
         }
 
         /// <summary>
@@ -322,10 +319,7 @@ namespace UnityEngine.ProBuilder
         /// </summary>
         public void SetInt(string key, int value)
         {
-            if (m_Int.ContainsKey(key))
-                m_Int[key] = value;
-            else
-                m_Int.Add(key, value);
+            m_Int[key] = value;
         }
 
         /// <summary>
@@ -333,10 +327,7 @@ namespace UnityEngine.ProBuilder
         /// </summary>
         public void SetFloat(string key, float value)
         {
-            if (m_Float.ContainsKey(key))
-                m_Float[key] = value;
-            else
-                m_Float.Add(key, value);
+            m_Float[key] = value;
         }
 
         /// <summary>
@@ -344,10 +335,7 @@ namespace UnityEngine.ProBuilder
         /// </summary>
         public void SetString(string key, string value)
         {
-            if (m_String.ContainsKey(key))
-                m_String[key] = value;
-            else
-                m_String.Add(key, value);
+            m_String[key] = value;
         }
 
         /// <summary>
@@ -355,10 +343,7 @@ namespace UnityEngine.ProBuilder
         /// </summary>
         public void SetColor(string key, Color value)
         {
-            if (m_Color.ContainsKey(key))
-                m_Color[key] = value;
-            else
-                m_Color.Add(key, value);
+            m_Color[key] = value;
         }
 
         /// <summary>
@@ -366,10 +351,7 @@ namespace UnityEngine.ProBuilder
         /// </summary>
         public void SetMaterial(string key, Material value)
         {
-            if (m_Material.ContainsKey(key))
-                m_Material[key] = value;
-            else
-                m_Material.Add(key, value);
+            m_Material[key] = value;
         }
 
         /// <summary>

--- a/Runtime/Core/ProBuilderMesh.cs
+++ b/Runtime/Core/ProBuilderMesh.cs
@@ -453,14 +453,14 @@ namespace UnityEngine.ProBuilder
             GetUVs(2, uv3s);
             GetUVs(3, uv4s);
 
-            bool _hasPositions = positions != null && positions.Count() == meshVertexCount;
-            bool _hasColors = colors != null && colors.Count() == meshVertexCount;
-            bool _hasNormals = normals != null && normals.Count() == meshVertexCount;
-            bool _hasTangents = tangents != null && tangents.Count() == meshVertexCount;
-            bool _hasUv0 = uv0s != null && uv0s.Count() == meshVertexCount;
-            bool _hasUv2 = uv2s != null && uv2s.Count() == meshVertexCount;
-            bool _hasUv3 = uv3s.Count() == meshVertexCount;
-            bool _hasUv4 = uv4s.Count() == meshVertexCount;
+            bool _hasPositions = positions != null && positions.Length == meshVertexCount;
+            bool _hasColors = colors != null && colors.Length == meshVertexCount;
+            bool _hasNormals = normals != null && normals.Length == meshVertexCount;
+            bool _hasTangents = tangents != null && tangents.Length == meshVertexCount;
+            bool _hasUv0 = uv0s != null && uv0s.Length == meshVertexCount;
+            bool _hasUv2 = uv2s != null && uv2s.Length == meshVertexCount;
+            bool _hasUv3 = uv3s.Count == meshVertexCount;
+            bool _hasUv4 = uv4s.Count == meshVertexCount;
 
             for (int i = 0; i < vc; i++)
             {
@@ -519,14 +519,14 @@ namespace UnityEngine.ProBuilder
             GetUVs(2, uv3s);
             GetUVs(3, uv4s);
 
-            bool _hasPositions = positions != null && positions.Count() == vc;
-            bool _hasColors = colors != null && colors.Count() == vc;
-            bool _hasNormals = normals != null && normals.Count() == vc;
-            bool _hasTangents = tangents != null && tangents.Count() == vc;
-            bool _hasUv0 = uv0s != null && uv0s.Count() == vc;
-            bool _hasUv2 = uv2s != null && uv2s.Count() == vc;
-            bool _hasUv3 = uv3s.Count() == vc;
-            bool _hasUv4 = uv4s.Count() == vc;
+            bool _hasPositions = positions != null && positions.Length == vc;
+            bool _hasColors = colors != null && colors.Length == vc;
+            bool _hasNormals = normals != null && normals.Length == vc;
+            bool _hasTangents = tangents != null && tangents.Length == vc;
+            bool _hasUv0 = uv0s != null && uv0s.Length == vc;
+            bool _hasUv2 = uv2s != null && uv2s.Length == vc;
+            bool _hasUv3 = uv3s.Count == vc;
+            bool _hasUv4 = uv4s.Count == vc;
 
             for (int i = 0; i < vc; i++)
             {
@@ -671,9 +671,9 @@ namespace UnityEngine.ProBuilder
 
             set
             {
-                if (value == null || value.Count() == 0)
+                if (value == null || value.Count == 0)
                     m_Colors = null;
-                else if (value.Count() != vertexCount)
+                else if (value.Count != vertexCount)
                     throw new ArgumentOutOfRangeException("value", "Array length must match vertex count.");
                 else
                     m_Colors = value.ToArray();
@@ -715,7 +715,7 @@ namespace UnityEngine.ProBuilder
             {
                 if (value == null)
                     m_Tangents = null;
-                else if (value.Count() != vertexCount)
+                else if (value.Count != vertexCount)
                     throw new ArgumentOutOfRangeException("value", "Tangent array length must match vertex count");
                 else
                     m_Tangents = value.ToArray();
@@ -773,7 +773,7 @@ namespace UnityEngine.ProBuilder
             {
                 if (value == null)
                     m_Textures0 = null;
-                else if (value.Count() != vertexCount)
+                else if (value.Count != vertexCount)
                     throw new ArgumentOutOfRangeException("value");
                 else
                     m_Textures0 = value.ToArray();

--- a/Runtime/Core/ProBuilderMeshSelection.cs
+++ b/Runtime/Core/ProBuilderMeshSelection.cs
@@ -123,8 +123,7 @@ namespace UnityEngine.ProBuilder
                             m_SelectedSharedVerticesCount++;
                             m_SelectedCoincidentVertexCount += coincident.Count;
 
-                            foreach (var n in coincident)
-                                m_SelectedCoincidentVertices.Add(n);
+                            m_SelectedCoincidentVertices.AddRange(coincident);
                         }
                     }
                 }

--- a/Runtime/Core/SelectPathFaces.cs
+++ b/Runtime/Core/SelectPathFaces.cs
@@ -150,11 +150,11 @@ namespace UnityEngine.ProBuilder
             Vector3 p2 = Vector3.zero;
             foreach (var point in mesh.facesInternal[face1].indexesInternal)
             {
-                p1 += mesh.positionsInternal[point] / mesh.facesInternal[face1].indexesInternal.Count();
+                p1 += mesh.positionsInternal[point] / mesh.facesInternal[face1].indexesInternal.Length;
             }
             foreach (var point in mesh.facesInternal[face2].indexesInternal)
             {
-                p2 += mesh.positionsInternal[point] / mesh.facesInternal[face2].indexesInternal.Count();
+                p2 += mesh.positionsInternal[point] / mesh.facesInternal[face2].indexesInternal.Length;
             }
 
             float distCost = (p2 - p1).magnitude * distMult;

--- a/Runtime/Core/SelectionPickerSettings.cs
+++ b/Runtime/Core/SelectionPickerSettings.cs
@@ -172,12 +172,9 @@ namespace UnityEngine.ProBuilder
             dst.faces.Clear();
             dst.edges.Clear();
             dst.vertexes.Clear();
-            foreach (var x in faces)
-                dst.faces.Add(x);
-            foreach (var x in edges)
-                dst.edges.Add(x);
-            foreach (var x in vertexes)
-                dst.vertexes.Add(x);
+            dst.faces.AddRange(faces);
+            dst.edges.AddRange(edges);
+            dst.vertexes.AddRange(vertexes);
         }
 
         /// <summary>

--- a/Runtime/Core/ShapeGenerator.cs
+++ b/Runtime/Core/ShapeGenerator.cs
@@ -1562,7 +1562,7 @@ namespace UnityEngine.ProBuilder
 
             int col = clampedColumns - 1;
 
-            Vector3[] cir = GetCirclePoints(clampedRows, clampedTubeRadius, clampedVerticalCircumference, Quaternion.Euler(Vector3.up * 0f * clampedHorizontalCircumference), clampedRadius);
+            Vector3[] cir = GetCirclePoints(clampedRows, clampedTubeRadius, clampedVerticalCircumference, Quaternion.Euler(0f * clampedHorizontalCircumference * Vector3.up), clampedRadius);
 
             for (int i = 1; i < clampedColumns; i++)
             {

--- a/Runtime/Core/ShapeGenerator.cs
+++ b/Runtime/Core/ShapeGenerator.cs
@@ -1562,7 +1562,7 @@ namespace UnityEngine.ProBuilder
 
             int col = clampedColumns - 1;
 
-            Vector3[] cir = GetCirclePoints(clampedRows, clampedTubeRadius, clampedVerticalCircumference, Quaternion.Euler(0f * clampedHorizontalCircumference * Vector3.up), clampedRadius);
+            Vector3[] cir = GetCirclePoints(clampedRows, clampedTubeRadius, clampedVerticalCircumference, Quaternion.Euler(Vector3.zero), clampedRadius);
 
             for (int i = 1; i < clampedColumns; i++)
             {

--- a/Runtime/Core/TriggerBehaviour.cs
+++ b/Runtime/Core/TriggerBehaviour.cs
@@ -28,17 +28,13 @@ namespace UnityEngine.ProBuilder
 
         public override void OnEnterPlayMode()
         {
-            var r = GetComponent<Renderer>();
-
-            if (r != null)
+            if (TryGetComponent<Renderer>(out var r))
                 r.enabled = false;
         }
 
         public override void OnSceneLoaded(Scene scene, LoadSceneMode mode)
         {
-            var r = GetComponent<Renderer>();
-
-            if (r != null)
+            if (TryGetComponent<Renderer>(out var r))
                 r.enabled = false;
         }
     }

--- a/Runtime/Core/WingedEdge.cs
+++ b/Runtime/Core/WingedEdge.cs
@@ -318,7 +318,7 @@ namespace UnityEngine.ProBuilder
                 return null;
 
             SortEdgesByAdjacency(matches);
-            return matches.Select(x => x.a).ToList();
+            return matches.ConvertAll(x => x.a);
         }
 
         /// <summary>

--- a/Runtime/MeshOperations/AppendElements.cs
+++ b/Runtime/MeshOperations/AppendElements.cs
@@ -1019,7 +1019,7 @@ namespace UnityEngine.ProBuilder.MeshOperations
 
             Dictionary<Face, FaceRebuildData> modifiedFaces = new Dictionary<Face, FaceRebuildData>();
 
-            int originalSharedIndexesCount = lookup.Count();
+            int originalSharedIndexesCount = lookup.Count;
             int sharedIndexesCount = originalSharedIndexesCount;
 
             foreach (Edge edge in distinctEdges)
@@ -1368,7 +1368,7 @@ namespace UnityEngine.ProBuilder.MeshOperations
             List<int> indexesToDelete = new List<int>();
             Dictionary<Face, FaceRebuildData> modifiedFaces = new Dictionary<Face, FaceRebuildData>();
 
-            int originalSharedIndexesCount = lookup.Count();
+            int originalSharedIndexesCount = lookup.Count;
 
             //Ensure the new point is on the edge
             //Using Scalar projection
@@ -1519,7 +1519,7 @@ namespace UnityEngine.ProBuilder.MeshOperations
             Dictionary<int, int> lookupUV = null;
 
             // List<int> indexesToDelete = new List<int>();
-            int originalSharedIndexesCount = lookup.Count();
+            int originalSharedIndexesCount = lookup.Count;
 
             if (mesh.sharedTextures != null)
             {

--- a/Runtime/MeshOperations/CombineMeshes.cs
+++ b/Runtime/MeshOperations/CombineMeshes.cs
@@ -278,7 +278,7 @@ namespace UnityEngine.ProBuilder.MeshOperations
                 vertices,
                 faces,
                 SharedVertex.ToSharedVertices(sv),
-                st.Any() ? SharedVertex.ToSharedVertices(st) : null,
+                st.Count > 0 ? SharedVertex.ToSharedVertices(st) : null,
                 materials);
         }
 
@@ -326,7 +326,7 @@ namespace UnityEngine.ProBuilder.MeshOperations
                 mf.Add(face);
             }
 
-            if (mv.Any())
+            if (mv.Count > 0)
                 meshes.Add(CreateMeshFromSplit(mv, mf, sharedVertexLookup, sharedTextureLookup, remap, new Material[submeshCount]));
 
             return meshes;

--- a/Runtime/MeshOperations/MeshValidation.cs
+++ b/Runtime/MeshOperations/MeshValidation.cs
@@ -119,7 +119,7 @@ namespace UnityEngine.ProBuilder.MeshOperations
                 {
                     var groups = CollectFaceGroups(mesh, face);
 
-                    if (groups.Count() < 2)
+                    if (groups.Count < 2)
                         continue;
 
                     face.SetIndexes(groups[0].SelectMany(x=>x.indices));
@@ -295,7 +295,7 @@ namespace UnityEngine.ProBuilder.MeshOperations
 
             mesh.DeleteVertices(del);
 
-            return del.Any();
+            return del.Count > 0;
         }
 
         /// <summary>

--- a/Runtime/MeshOperations/UV/UVEditing.cs
+++ b/Runtime/MeshOperations/UV/UVEditing.cs
@@ -101,10 +101,10 @@ namespace UnityEngine.ProBuilder.MeshOperations
                     int a, b;
 
                     if (!lookup.TryGetValue(indexes[i], out a))
-                        lookup.Add(indexes[i], a = lookup.Count());
+                        lookup.Add(indexes[i], a = lookup.Count);
 
                     if (!lookup.TryGetValue(indexes[n], out b))
-                        lookup.Add(indexes[n], b = lookup.Count());
+                        lookup.Add(indexes[n], b = lookup.Count);
 
                     if (a == b)
                         continue;

--- a/Runtime/MeshOperations/VertexEditing.cs
+++ b/Runtime/MeshOperations/VertexEditing.cs
@@ -38,7 +38,7 @@ namespace UnityEngine.ProBuilder.MeshOperations
             Vertex cen = collapseToFirst ? vertices[indexes[0]] : Vertex.Average(vertices, indexes);
             mesh.SetVerticesCoincident(indexes);
             UVEditing.SplitUVs(mesh, indexes);
-            int sharedVertexHandle = mesh.GetSharedVertexHandle(indexes.First());
+            int sharedVertexHandle = mesh.GetSharedVertexHandle(indexes[0]);
             mesh.SetSharedVertexValues(sharedVertexHandle, cen);
 
             SharedVertex merged = mesh.sharedVerticesInternal[sharedVertexHandle];
@@ -95,7 +95,7 @@ namespace UnityEngine.ProBuilder.MeshOperations
 
             // ToDictionary always sets the universal indexes in ascending order from 0+.
             Dictionary<int, int> lookup = mesh.sharedVertexLookup;
-            int max = lookup.Count();
+            int max = lookup.Count;
             foreach (int i in vertices)
                 lookup[i] = ++max;
             mesh.SetSharedVertices(lookup);
@@ -129,7 +129,7 @@ namespace UnityEngine.ProBuilder.MeshOperations
             // If a radial search returns neighbors matching the max count, the search is re-done and maxNearestNeighbors
             // is set to the resulting length. This will be slow, but in most cases shouldn't happen ever, or if it does,
             // should only happen once or twice.
-            int maxNearestNeighbors = System.Math.Min(32, common.Count());
+            int maxNearestNeighbors = System.Math.Min(32, common.Count);
 
             // 3 dimensions, duplicate entries allowed
             KdTree<float, int> tree = new KdTree<float, int>(3, new FloatMath(), AddDuplicateBehavior.Collect);

--- a/Tests/Editor/Picking/RectSelection.cs
+++ b/Tests/Editor/Picking/RectSelection.cs
@@ -121,8 +121,7 @@ class RectSelection
     {
         // Create a parent container with -90 degree rotation around Z
         var parent = new GameObject("Parent");
-        parent.transform.position = new Vector3(0f, 0f, 0f);
-        parent.transform.rotation = Quaternion.Euler(0f, 0f, -90f);
+        parent.transform.SetPositionAndRotation(new Vector3(0f, 0f, 0f), Quaternion.Euler(0f, 0f, -90f));
 
         // Create a Cube such that when parented to the container has (6f, 0f, 0f) world position
         var cube = ShapeFactory.Instantiate<UnityEngine.ProBuilder.Shapes.Cube>();
@@ -159,7 +158,7 @@ class RectSelection
         var selection = vertices.FirstOrDefault();
         Assert.IsNotNull(selection);
         HashSet<int> selectedElements = selection.Value;
-        Assert.Less(selectedElements.Count, selection.Key.sharedVertices.Count());
+        Assert.Less(selectedElements.Count, selection.Key.sharedVertices.Count);
         Assert.Greater(selectedElements.Count, 0);
         Cleanup();
     }
@@ -172,7 +171,7 @@ class RectSelection
         var selection = vertices.FirstOrDefault();
         Assert.IsNotNull(selection);
         HashSet<int> selectedElements = selection.Value;
-        Assert.AreEqual(selectedElements.Count, selection.Key.sharedVertices.Count());
+        Assert.AreEqual(selectedElements.Count, selection.Key.sharedVertices.Count);
         Cleanup();
     }
 

--- a/Tests/Editor/Picking/RectSelectionPicker.cs
+++ b/Tests/Editor/Picking/RectSelectionPicker.cs
@@ -24,8 +24,7 @@ class RectSelectionPicker
     public void Setup()
     {
         camera = new GameObject("Camera", typeof(Camera)).GetComponent<Camera>();
-        camera.transform.position = Vector3.zero;
-        camera.transform.rotation = Quaternion.identity;
+        camera.transform.SetPositionAndRotation(Vector3.zero, Quaternion.identity);
 
         GameObject cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
         cube.transform.position = new Vector3(0, 0, 5f);
@@ -53,7 +52,7 @@ class RectSelectionPicker
     {
         for (int i = 0; i < sceneObjects.Length; ++i)
         {
-            UObject.DestroyImmediate(sceneObjects[i].gameObject);
+            UObject.DestroyImmediate(sceneObjects[i]);
         }
 
         for (int i = 0; i < selectables.Length; i++)

--- a/Tests/Framework/TestUtility.cs
+++ b/Tests/Framework/TestUtility.cs
@@ -169,14 +169,14 @@ namespace UnityEngine.ProBuilder.Tests.Framework
             mesh.GetUVs(2, uv3s);
             mesh.GetUVs(3, uv4s);
 
-            bool _hasPositions = positions != null && positions.Count() == vertexCount;
-            bool _hasColors = colors != null && colors.Count() == vertexCount;
-            bool _hasNormals = normals != null && normals.Count() == vertexCount;
-            bool _hasTangents = tangents != null && tangents.Count() == vertexCount;
-            bool _hasUv0 = uv0s != null && uv0s.Count() == vertexCount;
-            bool _hasUv2 = uv2s != null && uv2s.Count() == vertexCount;
-            bool _hasUv3 = uv3s.Count() == vertexCount;
-            bool _hasUv4 = uv4s.Count() == vertexCount;
+            bool _hasPositions = positions != null && positions.Length == vertexCount;
+            bool _hasColors = colors != null && colors.Length == vertexCount;
+            bool _hasNormals = normals != null && normals.Length == vertexCount;
+            bool _hasTangents = tangents != null && tangents.Length == vertexCount;
+            bool _hasUv0 = uv0s != null && uv0s.Length == vertexCount;
+            bool _hasUv2 = uv2s != null && uv2s.Length == vertexCount;
+            bool _hasUv3 = uv3s.Count == vertexCount;
+            bool _hasUv4 = uv4s.Count == vertexCount;
 
             for (int i = 0; i < vertexCount; i++)
             {


### PR DESCRIPTION
### Purpose of this PR

Improved CPU performance using:

- Use native Lenth/Count instead of LINQ
- Re-order vector calculations to be faster
- merge .rotation and .position into .SetPositionAndRotation
- Use better dictionary usage
- Use TryGetComponent for less garbage allocation
- Merge LINQ statements
- Merge if/else return into single return
- Use OfType instead of Where().Cast
- Use Color32 (in UVEditor.cs, please double check)
- Use AddRange instead of looped Add


### Comments to Reviewers

The Color32 improvement in UVEditor worked for me, but since this is the only major change this should be double checked