### PR TITLE
Fixed Edit Shape tool preventing correct activation of next context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [case: PBLD-32] Fixed `New Shape` start location being incorrect after using right mouse button.
 - [case: PBLD-19] Fixed shape creation when the camera perspective is set to Top.
 - [case: PBLD-38] Fixed an issue where exported assets would incorrectly use the UInt32 mesh index format.
-- [case: PBLD-43] Fixed an issue where activating the Edit Shape tool would prevent the next switch of editor tool context from properly executing. 
+- [case: PBLD-43] Fixed an issue where activating the **Edit Shape** tool would prevent the Editor tool context from switching. 
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [case: PBLD-32] Fixed `New Shape` start location being incorrect after using right mouse button.
 - [case: PBLD-19] Fixed shape creation when the camera perspective is set to Top.
 - [case: PBLD-38] Fixed an issue where exported assets would incorrectly use the UInt32 mesh index format.
+- [case: PBLD-43] Fixed an issue where activating the Edit Shape tool would prevent the next switch of editor tool context from properly executing. 
 
 ### Changes
 

--- a/Editor/EditorCore/EditShapeTool.cs
+++ b/Editor/EditorCore/EditShapeTool.cs
@@ -158,7 +158,7 @@ namespace UnityEditor.ProBuilder
 
         public void ResetToLastSelectMode()
         {
-            if(ProBuilderToolManager.activeTool != Tool.Custom)
+            if(ProBuilderToolManager.activeTool != Tool.Custom && ProBuilderToolManager.IsAnyProBuilderContextActive())
                 ProBuilderEditor.ResetToLastSelectMode();
         }
 #endif

--- a/Editor/EditorCore/ProBuilderToolManager.cs
+++ b/Editor/EditorCore/ProBuilderToolManager.cs
@@ -182,6 +182,13 @@ namespace UnityEditor.ProBuilder
 #endif
         }
 
+#if TOOL_CONTEXTS_ENABLED
+        internal static bool IsAnyProBuilderContextActive()
+        {
+            return (ToolManager.activeContextType == typeof(PositionToolContext) || ToolManager.activeContextType == typeof(TextureToolContext));
+        }
+#endif
+
 #if !TOOL_CONTEXTS_ENABLED
         bool GetBuiltinToolType(Type type, out Type builtin)
         {


### PR DESCRIPTION
### Purpose of this PR

PR fixes an issue where activating the Edit Shape tool would prevent the next editor tool context from properly activating. 

### Links

**Jira:** https://jira.unity3d.com/browse/PBLD-43

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]