### PR TITLE
Fix for no UV distribution metric recalculation after mesh optimization step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- [case: PBLD-34] Fixed a bug where `Experimental Features Enabled` was not activating when using `Dedicated Server` platform. 
+- [case: PBLD-34] Fixed a bug where `Experimental Features Enabled` was not activating when using `Dedicated Server` platform.
+- [case: PBLD-41] Fixed an issue where UV distribution metric would not be recalculated after the mesh optimization step.
 - [case: PBLD-32] Fixed `New Shape` start location being incorrect after using right mouse button.
 - [case: PBLD-19] Fixed shape creation when the camera perspective is set to Top.
 - [case: PBLD-38] Fixed an issue where exported assets would incorrectly use the UInt32 mesh index format.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - [case: PBLD-34] Fixed a bug where `Experimental Features Enabled` was not activating when using `Dedicated Server` platform.
-- [case: PBLD-41] Fixed an issue where UV distribution metric would not be recalculated after the mesh optimization step.
+- [case: PBLD-41] Fixed an issue where UV distribution metric would not recalculate after the mesh optimization step.
 - [case: PBLD-32] Fixed `New Shape` start location being incorrect after using right mouse button.
 - [case: PBLD-19] Fixed shape creation when the camera perspective is set to Top.
 - [case: PBLD-38] Fixed an issue where exported assets would incorrectly use the UInt32 mesh index format.

--- a/Editor/EditorCore/EditorMeshUtility.cs
+++ b/Editor/EditorCore/EditorMeshUtility.cs
@@ -49,7 +49,9 @@ namespace UnityEditor.ProBuilder
                 if (umesh.GetTopology(i) != MeshTopology.Triangles)
                     skipMeshProcessing = true;
 
+#pragma warning disable 0219
             bool uv2Built = false;
+#pragma warning restore 0219
             if (!skipMeshProcessing)
             {
                 bool autoLightmap = Lightmapping.autoUnwrapLightmapUV;
@@ -111,9 +113,11 @@ namespace UnityEditor.ProBuilder
             if (Experimental.meshesAreAssets)
                 TryCacheMesh(mesh);
 
+#if UNITY_2020_2_OR_NEWER
             umesh.RecalculateUVDistributionMetric(0);
             if (uv2Built)
                 umesh.RecalculateUVDistributionMetric(1);
+#endif
 
             UnityEditor.EditorUtility.SetDirty(mesh);
         }

--- a/Editor/EditorCore/EditorMeshUtility.cs
+++ b/Editor/EditorCore/EditorMeshUtility.cs
@@ -49,6 +49,7 @@ namespace UnityEditor.ProBuilder
                 if (umesh.GetTopology(i) != MeshTopology.Triangles)
                     skipMeshProcessing = true;
 
+            bool uv2Built = false;
             if (!skipMeshProcessing)
             {
                 bool autoLightmap = Lightmapping.autoUnwrapLightmapUV;
@@ -82,6 +83,8 @@ namespace UnityEditor.ProBuilder
                     {
                         for (int i = 0; i < uv2.Length; i++)
                             vertices[i].uv2 = uv2[i];
+
+                        uv2Built = true;
                     }
                     else
                     {
@@ -107,6 +110,10 @@ namespace UnityEditor.ProBuilder
 
             if (Experimental.meshesAreAssets)
                 TryCacheMesh(mesh);
+
+            umesh.RecalculateUVDistributionMetric(0);
+            if (uv2Built)
+                umesh.RecalculateUVDistributionMetric(1);
 
             UnityEditor.EditorUtility.SetDirty(mesh);
         }


### PR DESCRIPTION
### Purpose of this PR

PR fixes an issue where the UV distribution metric was not recalculated after rebuilding a mesh. This would have the side effect of incorrect mip maps being loaded.

Tested for possible performance implications: used a 5k vertex cube and sampled the `EditorMeshUtility. Optimize` function. With `RecalculateUVDistributionMetric` or without  the measurements fluctuated between 55ms and 70ms, therefore if there is any impact, it's pretty negligible and probably around additional 5-10ms per 5K vertices.

### Links

**Jira:** https://jira.unity3d.com/browse/PBLD-41
**Slack:** https://unity.slack.com/archives/C7HJDB0A0/p1666627588183009

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]