### PR TITLE
[PBLD-48] Change Shape's min size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- [case: PBLD-48] Fixed a bug where the minimum size for a shape was not taking into account the snap and grid sizes.
+- [case: PBLD-48] Fixed a bug where the minimum size of a shape did not take into account snap and grid sizes.
 - [case: PBLD-34] Fixed a bug where `Experimental Features Enabled` was not activating when using `Dedicated Server` platform.
 - [case: PBLD-41] Fixed an issue where UV distribution metric would not recalculate after the mesh optimization step.
 - [case: PBLD-32] Fixed `New Shape` start location being incorrect after using right mouse button.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- [case: PBLD-48] Fixed a bug where the minimum size for a shape was not taking into account the snap and grid sizes.
 - [case: PBLD-34] Fixed a bug where `Experimental Features Enabled` was not activating when using `Dedicated Server` platform.
 - [case: PBLD-41] Fixed an issue where UV distribution metric would not recalculate after the mesh optimization step.
 - [case: PBLD-32] Fixed `New Shape` start location being incorrect after using right mouse button.

--- a/Editor/EditorCore/DrawShapeTool.cs
+++ b/Editor/EditorCore/DrawShapeTool.cs
@@ -78,6 +78,26 @@ namespace UnityEditor.ProBuilder
         internal static Pref<Quaternion> s_LastRotation = new Pref<Quaternion>("ShapeBuilder.LastRotation", Quaternion.identity);
 
         int m_ControlID;
+
+        internal float minSnapSize
+        {
+            get
+            {
+                if (m_IsOnGrid)
+                {
+                    return Mathf.Min(EditorSnapping.activeMoveSnapValue.x,
+                        Mathf.Min(EditorSnapping.activeMoveSnapValue.y,
+                            EditorSnapping.activeMoveSnapValue.z));
+                }
+
+                return Mathf.Min(EditorSnapping.incrementalSnapMoveValue.x,
+                    Mathf.Min(EditorSnapping.incrementalSnapMoveValue.y,
+                        EditorSnapping.incrementalSnapMoveValue.z));
+            }
+        }
+
+        const float k_MinBoundLength = 0.001f; // 1mm
+
         // ideally this would be owned by the state machine
         public int controlID => m_ControlID;
 
@@ -358,9 +378,9 @@ namespace UnityEditor.ProBuilder
         {
             RecalculateBounds();
 
-            if(m_Bounds.size.sqrMagnitude < .01f
-               || Mathf.Abs(m_Bounds.extents.x) < 0.001f
-               || Mathf.Abs(m_Bounds.extents.z) < 0.001f)
+            if(m_Bounds.size.sqrMagnitude <= Mathf.Min(.01f , minSnapSize*minSnapSize)
+               || Mathf.Abs(m_Bounds.extents.x) < k_MinBoundLength
+               || Mathf.Abs(m_Bounds.extents.z) < k_MinBoundLength)
             {
                 if(m_ProBuilderShape != null
                    && m_ProBuilderShape.mesh.vertexCount > 0)

--- a/Editor/StateMachines/ShapeState_DrawBaseShape.cs
+++ b/Editor/StateMachines/ShapeState_DrawBaseShape.cs
@@ -58,7 +58,7 @@ namespace UnityEditor.ProBuilder
                                 return ResetState();
                             }
 
-                            if(Vector3.Distance(tool.m_BB_OppositeCorner, tool.m_BB_Origin) < .1f)
+                            if(Vector3.Distance(tool.m_BB_OppositeCorner, tool.m_BB_Origin) <= Mathf.Min(0.01f, tool.minSnapSize))
                                 return ResetState();
 
                             return NextState();


### PR DESCRIPTION
### Purpose of this PR

Fixed a bug where the minimum size for a shape was not taking into account the snap and grid sizes.
The min size was hard coded and not taking the snapping or grid sizes into account, which it does now if these sizes are smaller than the default one (0.1f);

Before:
![bug-pb-0 01](https://user-images.githubusercontent.com/66317117/211890155-9deb9b74-af6f-49ab-b3b9-f0e6d4e6ed41.gif)

After:
![fix-pb-0 01](https://user-images.githubusercontent.com/66317117/211890170-e25e3680-dde1-440a-959d-a7c85da920e5.gif)

### Links

**Jira:** https://jira.unity3d.com/browse/UUM-19007
