### PR TITLE
Fix EntityBehaviour Build Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [case: PBLD-19] Fixed shape creation when the camera perspective is set to Top.
 - [case: PBLD-38] Fixed an issue where exported assets would incorrectly use the UInt32 mesh index format.
 - [case: PBLD-43] Fixed an issue where activating the **Edit Shape** tool would prevent the Editor tool context from switching. 
+- [case: PBLD-57] Fixed error when building player with `EntityBehaviour` applied to prefabs.
 
 ### Changes
 

--- a/Editor/EditorCore/UnityScenePostProcessor.cs
+++ b/Editor/EditorCore/UnityScenePostProcessor.cs
@@ -25,6 +25,7 @@ namespace UnityEditor.ProBuilder
             var invisibleFaceMaterial = Resources.Load<Material>("Materials/InvisibleFace");
 
             var pbMeshes = (ProBuilderMesh[]) Resources.FindObjectsOfTypeAll(typeof(ProBuilderMesh));
+
             // Hide nodraw faces if present.
             foreach (var pb in pbMeshes)
             {
@@ -49,12 +50,15 @@ namespace UnityEditor.ProBuilder
                 return;
 
             var renderersToStrip = new List<Renderer>();
+
             foreach (var entity in Resources.FindObjectsOfTypeAll<EntityBehaviour>())
             {
                 if (entity.manageVisibility)
                     entity.OnEnterPlayMode();
 
-                if ((entity is TriggerBehaviour || entity is ColliderBehaviour) && entity.gameObject.TryGetComponent(out MeshRenderer renderer))
+                if ((entity is TriggerBehaviour || entity is ColliderBehaviour)
+                    && entity.gameObject.TryGetComponent(out MeshRenderer renderer)
+                    && !UnityEditor.EditorUtility.IsPersistent(entity))
                     renderersToStrip.Add(renderer);
             }
 


### PR DESCRIPTION
### Purpose of this PR

Fixes a build time error caused by the post-processor attempting to destroy the `MeshRenderer` on a prefab despite the `ProBuilderMesh` component still being present.

### Links

**Jira:** https://jira.unity3d.com/browse/PBLD-57