### PR TITLE
Fxing errors and bad size shape when trying to draw a 0-size shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- [case: PBLD-61] Fixed a bug where drawing a shape of size zero was causing errors and incorrect values in ProBuilderShape.
+
 ## [5.0.7] - 2023-04-04
 
 ### Fixed

--- a/Editor/EditorCore/DrawShapeTool.cs
+++ b/Editor/EditorCore/DrawShapeTool.cs
@@ -155,7 +155,6 @@ namespace UnityEditor.ProBuilder
 
             m_IconContent = new GUIContent()
             {
-                //image = IconUtility.GetIcon("Tools/ShapeTool/Arch"),
                 image = IconUtility.GetIcon("Toolbar/Panel_Shapes"),
                 text = "Shape Settings",
                 tooltip = "Shape Settings"
@@ -385,8 +384,10 @@ namespace UnityEditor.ProBuilder
                 if(m_ProBuilderShape != null
                    && m_ProBuilderShape.mesh.vertexCount > 0)
                 {
+                    m_ProBuilderShape.size = Vector3.zero;
                     m_ProBuilderShape.mesh.Clear();
                     m_ProBuilderShape.mesh.Rebuild();
+                    m_ProBuilderShape.Rebuild(new Bounds(m_BB_Origin, Vector3.zero), m_PlaneRotation, m_BB_Origin);
                     ProBuilderEditor.Refresh(true);
                 }
                 return;

--- a/Runtime/Shapes/ProBuilderShape.cs
+++ b/Runtime/Shapes/ProBuilderShape.cs
@@ -147,7 +147,7 @@ namespace UnityEngine.ProBuilder.Shapes
                 return;
 
             m_ShapeBox = m_Shape.RebuildMesh(mesh, size, rotation);
-            RebuildPivot(mesh, size, rotation);
+            RebuildPivot(size, rotation);
 
             Bounds bounds = m_ShapeBox;
             bounds.size = Math.Abs(m_ShapeBox.size);
@@ -213,9 +213,9 @@ namespace UnityEngine.ProBuilder.Shapes
             }
         }
 
-        void RebuildPivot(ProBuilderMesh mesh, Vector3 size, Quaternion rotation)
+        internal void RebuildPivot(Vector3 size, Quaternion rotation)
         {
-            if(mesh != null && mesh.mesh != null)
+            if(mesh != null)
             {
                 var bbCenter = mesh.transform.TransformPoint(m_ShapeBox.center);
                 var pivotWorldPos = mesh.transform.TransformPoint(m_PivotPosition);


### PR DESCRIPTION
### Purpose of this PR

This main part of the bug (console errors) has been fixed between 5.0.6 and .7 but there was still some remaining problems, like the shape being not in the right place or the values set in the ProBuilderShape size field.

### Links

**Jira:** https://jira.unity3d.com/browse/PBLD-62

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]