### PR TITLE
fix missing inner radius field in stairs pref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - [case: PBLD-61] Fixed a bug where drawing a shape of size zero was causing errors and incorrect values in ProBuilderShape.
+- [case: PBLD-65] Fixed stair shape "Inner Radius" parameter not being correctly applied when placing new stair shapes in scene.
 
 ## [5.0.7] - 2023-04-04
 

--- a/Runtime/Shapes/Stairs.cs
+++ b/Runtime/Shapes/Stairs.cs
@@ -105,6 +105,7 @@ namespace UnityEngine.ProBuilder.Shapes
                 m_HomogeneousSteps = stairs.m_HomogeneousSteps;
                 m_Circumference = stairs.m_Circumference;
                 m_Sides = stairs.m_Sides;
+                m_InnerRadius = stairs.m_InnerRadius;
             }
         }
 


### PR DESCRIPTION
### Purpose of this PR

Fixes the `Stair` shape not copying the `Inner Radius` value from prefs.

### Links

**Jira:** https://jira.unity3d.com/browse/PBLD-65

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]