### PR TITLE
fix missing mesh reference in prefabs after stripping probuilder mesh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [case: STO-2878] In Unit Editor 2023.1 and newer, fixed an issue where reverting a prefab instance containing a `ProBuilderMesh` component would leak a `Mesh` asset in the scene.
 - [case: PBLD-61] Fixed a bug where drawing a shape of size zero was causing errors and incorrect values in ProBuilderShape.
 - [case: PBLD-65] Fixed stair shape "Inner Radius" parameter not being correctly applied when placing new stair shapes in scene.
+- [case: PBLD-63] "Strip ProBuilder Scripts" now creates a mesh asset, fixing an issue where prefabs would no longer contain a valid mesh reference after stripping ProBuilder scripts.
 
 ### Changes
 

--- a/Editor/EditorCore/EditorUtility.cs
+++ b/Editor/EditorCore/EditorUtility.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 using System.Linq;
 using System;
 using System.Diagnostics;
+using System.IO;
 using UnityEngine.ProBuilder;
 using UnityEngine.Rendering;
 using UObject = UnityEngine.Object;
@@ -581,6 +582,17 @@ namespace UnityEditor.ProBuilder
 #else
             return UObject.FindObjectsOfType<T>();
 #endif
+        }
+
+        internal static string GetActiveSceneAssetsPath()
+        {
+            const string k_SavedMeshPath = "Assets/ProBuilder Data/Saved Meshes";
+            var scene = SceneManager.GetActiveScene();
+            var path = string.IsNullOrEmpty(scene.path)
+                ? k_SavedMeshPath
+                : $"{Path.GetDirectoryName(scene.path)}/{scene.name}/ProBuilder Meshes";
+            Directory.CreateDirectory(path);
+            return path;
         }
     }
 }

--- a/Editor/EditorCore/ProBuilderMeshPreview.cs
+++ b/Editor/EditorCore/ProBuilderMeshPreview.cs
@@ -44,7 +44,7 @@ namespace UnityEditor.ProBuilder
 
         public override bool HasPreviewGUI()
         {
-            if (!(target is ProBuilderMesh mesh))
+            if (target == null || !(target is ProBuilderMesh mesh) || mesh.gameObject == null)
                 return false;
             return PrefabUtility.IsPartOfPrefabAsset(mesh.gameObject);
         }

--- a/Tests/Editor/Actions/StripProBuilderScriptsTest.cs
+++ b/Tests/Editor/Actions/StripProBuilderScriptsTest.cs
@@ -1,9 +1,11 @@
 ﻿using UObject = UnityEngine.Object;
 using NUnit.Framework;
+using UnityEditor;
 using UnityEditor.ProBuilder;
 using UnityEngine;
 using UnityEngine.ProBuilder;
 using UnityEditor.ProBuilder.Actions;
+using UnityEditor.VersionControl;
 using UnityEngine.ProBuilder.MeshOperations;
 using UnityEngine.ProBuilder.Shapes;
 
@@ -26,6 +28,21 @@ public class StripProBuilderScriptsTest
         Assert.That(go.GetComponent<PolyShape>() == null);
 
         UObject.DestroyImmediate(go);
+    }
+
+    [Test]
+    public void StripProBuilderScripts_CreatesMeshAsset()
+    {
+        var cube = ShapeFactory.Instantiate<Cube>();
+        Assume.That(cube != null);
+        var gameObject = cube.gameObject;
+        StripProBuilderScripts.DoStrip(cube);
+        var copy = gameObject.GetComponent<MeshFilter>();
+        Assert.That(copy, Is.Not.Null);
+        var asset = AssetDatabase.GetAssetPath(copy);
+        Assert.That(asset, Is.Not.Null.Or.Empty);
+        UObject.DestroyImmediate(gameObject);
+        AssetDatabase.DeleteAsset(asset);
     }
 
     [Test]


### PR DESCRIPTION
### Purpose of this PR

Create assets in the project when "Strip ProBuilder Scripts" is used, preventing an issue where prefabs would reference scene assets.

### Links

**Fogbugz:**
**Jira:** https://jira.unity3d.com/browse/PBLD-63

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]