### PR TITLE
fix strip probuilder scripts not working in prefab stage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [case: PBLD-61] Fixed a bug where drawing a shape of size zero was causing errors and incorrect values in ProBuilderShape.
 - [case: PBLD-65] Fixed stair shape "Inner Radius" parameter not being correctly applied when placing new stair shapes in scene.
 - [case: PBLD-63] "Strip ProBuilder Scripts" now creates a mesh asset, fixing an issue where prefabs would no longer contain a valid mesh reference after stripping ProBuilder scripts.
+- [case: PBLD-64] Fixed "Strip ProBuilder Scripts" not correctly appyling changes when used in a prefab stage.
 
 ### Changes
 

--- a/Editor/EditorCore/BezierSplineEditor.cs
+++ b/Editor/EditorCore/BezierSplineEditor.cs
@@ -7,7 +7,7 @@ namespace UnityEditor.ProBuilder
     [CustomEditor(typeof(BezierShape))]
     sealed class BezierShapeEditor : Editor
     {
-        static GUIContent[] s_TangentModeIcons = new GUIContent[3];
+        static readonly GUIContent[] s_TangentModeIcons = new GUIContent[3];
 
         const float k_HandleSize = .05f;
 

--- a/Editor/EditorCore/StripProBuilderScripts.cs
+++ b/Editor/EditorCore/StripProBuilderScripts.cs
@@ -1,24 +1,58 @@
+using System.Collections.Generic;
+using UnityEditor.SceneManagement;
 using UnityEngine;
 using UnityEngine.ProBuilder;
 using UnityEngine.ProBuilder.Shapes;
+using UnityEngine.SceneManagement;
 
 namespace UnityEditor.ProBuilder.Actions
 {
     /// <summary>
     /// Menu items for stripping ProBuilder scripts from GameObjects.
     /// </summary>
-    /// @TODO MOVE TO ACTIONS
-    internal sealed class StripProBuilderScripts : Editor
+    sealed class StripProBuilderScripts : Editor
     {
-        [MenuItem("Tools/" + PreferenceKeys.pluginTitle + "/Actions/Strip All ProBuilder Scripts in Scene")]
+        const string k_UndoMessage = "Strip ProBuilder Scripts";
+        // return ProBuilderMesh components in loaded scenes only for the current stage
+        static List<ProBuilderMesh> GetMeshesInActiveScenes()
+        {
+            var stage = StageNavigationManager.instance.currentStage;
+            var c = stage.sceneCount;
+            var scenes = new HashSet<Scene>();
+            for (int i = 0; i < c; ++i)
+                scenes.Add(stage.GetSceneAt(i));
+            var filtered = new List<ProBuilderMesh>();
+            foreach(var mesh in Resources.FindObjectsOfTypeAll<ProBuilderMesh>())
+                if(scenes.Contains(mesh.gameObject.scene))
+                    filtered.Add(mesh);
+            return filtered;
+        }
+
+        [MenuItem("Tools/" + PreferenceKeys.pluginTitle + "/Actions/Strip All ProBuilder Scripts in Scene %&s")]
         public static void StripAllScenes()
         {
-            if (!UnityEditor.EditorUtility.DisplayDialog("Strip ProBuilder Scripts", "This will remove all ProBuilder scripts in the scene.  You will no longer be able to edit these objects.  There is no undo, please exercise caution!\n\nAre you sure you want to do this?", "Okay", "Cancel"))
+            if (!UnityEditor.EditorUtility.DisplayDialog("Strip ProBuilder Scripts", "This will remove all ProBuilder scripts in the scene. You will no longer be able to edit these objects.\n\nContinue?", "Okay", "Cancel"))
                 return;
 
-            ProBuilderMesh[] all = (ProBuilderMesh[])Resources.FindObjectsOfTypeAll(typeof(ProBuilderMesh));
+            var all = GetMeshesInActiveScenes();
 
-            Strip(all);
+            for (int i = 0, c = all?.Count ?? 0; i < c; i++)
+            {
+                if (c > 32 && UnityEditor.EditorUtility.DisplayCancelableProgressBar(
+                        "Stripping ProBuilder Scripts",
+                        "Working over " + all[i].GetInstanceID() + ".",
+                        ((float)i / all.Count)))
+                    break;
+
+                DoStrip(all[i], true);
+            }
+
+            UnityEditor.EditorUtility.ClearProgressBar();
+            UnityEditor.EditorUtility.DisplayDialog("Strip ProBuilder Scripts", "Successfully stripped out all ProBuilder components.", "Okay");
+
+            ProBuilderEditor.Refresh();
+            MeshSelection.OnObjectSelectionChanged();
+            AssetDatabase.Refresh();
         }
 
         [MenuItem("Tools/" + PreferenceKeys.pluginTitle + "/Actions/Strip ProBuilder Scripts in Selection %#s", true, 0)]
@@ -30,7 +64,7 @@ namespace UnityEditor.ProBuilder.Actions
         [MenuItem("Tools/" + PreferenceKeys.pluginTitle + "/Actions/Strip ProBuilder Scripts in Selection %#s")]
         public static void StripAllSelected()
         {
-            if (!UnityEditor.EditorUtility.DisplayDialog("Strip ProBuilder Scripts", "This will remove all ProBuilder scripts on the selected objects.  You will no longer be able to edit these objects.  There is no undo, please exercise caution!\n\nAre you sure you want to do this?", "Okay", "Cancel"))
+            if (!UnityEditor.EditorUtility.DisplayDialog("Strip ProBuilder Scripts", "This will remove all ProBuilder scripts on the selected objects. You will no longer be able to edit these objects.\n\nContinue?", "Okay", "Cancel"))
                 return;
 
             foreach (Transform t in Selection.transforms)
@@ -41,65 +75,57 @@ namespace UnityEditor.ProBuilder.Actions
             MeshSelection.OnObjectSelectionChanged();
         }
 
-        public static void Strip(ProBuilderMesh[] all)
+        public static void DoStrip(ProBuilderMesh pb, bool undo = false)
         {
-            for (int i = 0; i < all.Length; i++)
-            {
-                if (UnityEditor.EditorUtility.DisplayCancelableProgressBar(
-                        "Stripping ProBuilder Scripts",
-                        "Working over " + all[i].GetInstanceID() + ".",
-                        ((float)i / all.Length)))
-                    break;
+            GameObject go = pb.gameObject;
 
-                DoStrip(all[i]);
+            if (go.TryGetComponent<Renderer>(out var ren))
+                EditorUtility.SetSelectionRenderState(ren, EditorSelectedRenderState.Highlight | EditorSelectedRenderState.Wireframe);
+
+            EditorUtility.SynchronizeWithMeshFilter(pb);
+
+            if (pb.mesh == null)
+            {
+                DestroyProBuilderMeshAndDependencies(go, pb, false, undo);
+                return;
             }
 
-            UnityEditor.EditorUtility.ClearProgressBar();
-            UnityEditor.EditorUtility.DisplayDialog("Strip ProBuilder Scripts", "Successfully stripped out all ProBuilder components.", "Okay");
+            // if meshes are assets and the mesh cache is valid don't duplicate the mesh to an instance.
+            if (Experimental.meshesAreAssets && EditorMeshUtility.GetCachedMesh(pb, out _, out _))
+            {
+                DestroyProBuilderMeshAndDependencies(go, pb, true, undo);
+            }
+            else
+            {
+                Mesh instance = Instantiate(pb.mesh);
+                var path = $"{EditorUtility.GetActiveSceneAssetsPath()}/{pb.mesh.name}.asset";
+                AssetDatabase.CreateAsset(instance, AssetDatabase.GenerateUniqueAssetPath(path));
+                DestroyProBuilderMeshAndDependencies(go, pb, false, undo);
 
-            ProBuilderEditor.Refresh();
-            MeshSelection.OnObjectSelectionChanged();
-            AssetDatabase.Refresh();
+                var filter = go.GetComponent<MeshFilter>();
+
+                if(undo)
+                    Undo.RecordObject(filter, k_UndoMessage);
+
+                filter.sharedMesh = instance;
+                PrefabUtility.RecordPrefabInstancePropertyModifications(filter);
+
+                if (go.TryGetComponent(out MeshCollider collider))
+                {
+                    if(undo)
+                        Undo.RecordObject(collider, k_UndoMessage);
+                    collider.sharedMesh = instance;
+                    PrefabUtility.RecordPrefabInstancePropertyModifications(collider);
+                }
+            }
         }
 
-        public static void DoStrip(ProBuilderMesh pb)
+        static void Destroy(Object o, bool undo)
         {
-            try
-            {
-                GameObject go = pb.gameObject;
-
-                if (go.TryGetComponent<Renderer>(out var ren))
-                    EditorUtility.SetSelectionRenderState(ren, EditorSelectedRenderState.Highlight | EditorSelectedRenderState.Wireframe);
-
-                if (EditorUtility.IsPrefabAsset(go))
-                    return;
-
-                EditorUtility.SynchronizeWithMeshFilter(pb);
-
-                if (pb.mesh == null)
-                {
-                    DestroyProBuilderMeshAndDependencies(go, pb, false);
-                    return;
-                }
-
-                // if meshes are assets and the mesh cache is valid don't duplicate the mesh to an instance.
-                if (Experimental.meshesAreAssets && EditorMeshUtility.GetCachedMesh(pb, out _, out _))
-                {
-                    DestroyProBuilderMeshAndDependencies(go, pb, true);
-                }
-                else
-                {
-                    Mesh instance = Instantiate(pb.mesh);
-                    var path = $"{EditorUtility.GetActiveSceneAssetsPath()}/{pb.mesh.name}.asset";
-                    AssetDatabase.CreateAsset(instance, AssetDatabase.GenerateUniqueAssetPath(path));
-                    DestroyProBuilderMeshAndDependencies(go, pb);
-
-                    go.GetComponent<MeshFilter>().sharedMesh = instance;
-                    if (go.TryGetComponent(out MeshCollider meshCollider))
-                        meshCollider.sharedMesh = instance;
-                }
-            }
-            catch {}
+            if(undo)
+                Undo.DestroyObjectImmediate(o);
+            else
+                DestroyImmediate(o);
         }
 
         internal static void DestroyProBuilderMeshAndDependencies(
@@ -109,45 +135,25 @@ namespace UnityEditor.ProBuilder.Actions
             bool useUndoDestroy = false)
         {
             if(useUndoDestroy)
-                Undo.RecordObject(pb, "Removing ProBuilderMesh during scripts striping");
+                Undo.RecordObject(pb, k_UndoMessage);
 
             if (go.TryGetComponent(out PolyShape polyShape))
-            {
-                if(useUndoDestroy)
-                    Undo.DestroyObjectImmediate(polyShape);
-                else
-                    DestroyImmediate(polyShape);
-            }
+                Destroy(polyShape, useUndoDestroy);
 
             if (go.TryGetComponent(out BezierShape bezierShape))
-            {
-                if(useUndoDestroy)
-                    Undo.DestroyObjectImmediate(bezierShape);
-                else
-                    DestroyImmediate(bezierShape);
-            }
+                Destroy(bezierShape, useUndoDestroy);
 
             if (go.TryGetComponent(out ProBuilderShape shape))
-            {
-                if(useUndoDestroy)
-                    Undo.DestroyObjectImmediate(shape);
-                else
-                    DestroyImmediate(shape);
-            }
+                Destroy(shape, useUndoDestroy);
 
             pb.preserveMeshAssetOnDestroy = preserveMeshAssets;
-            if(useUndoDestroy)
-                Undo.DestroyObjectImmediate(pb);
-            else
-                DestroyImmediate(pb);
+
+            Destroy(pb, useUndoDestroy);
 
             if(go.TryGetComponent(out Entity entity))
-            {
-                if(useUndoDestroy)
-                    Undo.DestroyObjectImmediate(entity);
-                else
-                    DestroyImmediate(entity);
-            }
+                Destroy(entity, useUndoDestroy);
+
+            PrefabUtility.RecordPrefabInstancePropertyModifications(go);
         }
     }
 }


### PR DESCRIPTION
### Purpose of this PR

Fixed an issue where "Strip ProBuilder Scripts" in a prefab stage would not persist. Additionally, corrected the mesh asset collection logic in the "strip all" option to consider only active scenes with respect to the current stage.

### Links

**Fogbugz:**
**Jira:** https://jira.unity3d.com/browse/PBLD-64

### Comments to Reviewers

Skipping a test on this one because the risk of regression is low and the cost of spinning up a test for prefab staging specifically is high.