### PR TITLE
Revert "remove outdated test targets"

### DIFF
--- a/.yamato/promotion.yml
+++ b/.yamato/promotion.yml
@@ -1,6 +1,8 @@
 test_editors:
-  - version: 2021.3
-  - version: 2022.2
+  - version: 2019.4
+  - version: 2020.3
+  - version: 2021.2
+  - version: 2022.1
   - version: trunk
 test_platforms:
   - name: win

--- a/.yamato/promotion.yml
+++ b/.yamato/promotion.yml
@@ -1,8 +1,8 @@
 test_editors:
   - version: 2019.4
   - version: 2020.3
-  - version: 2021.2
-  - version: 2022.1
+  - version: 2021.3
+  - version: 2022.2
   - version: trunk
 test_platforms:
   - name: win

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -1,6 +1,8 @@
 test_editors:
-  - version: 2021.3
-  - version: 2022.2
+  - version: 2019.4
+  - version: 2020.3
+  - version: 2021.2
+  - version: 2022.1
   - version: trunk
 test_platforms:
   - name: win

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -1,8 +1,8 @@
 test_editors:
   - version: 2019.4
   - version: 2020.3
-  - version: 2021.2
-  - version: 2022.1
+  - version: 2021.3
+  - version: 2022.2
   - version: trunk
 test_platforms:
   - name: win


### PR DESCRIPTION
This reverts commit d07ed6c7a32a7c1ff661a0b9491dc4d2700ab558.

### Purpose of this PR

We can't promote the unity version in package.json since this is a minor release. Reverting commit d07ed6c because we need to support tests for 2019.4 (otherwise Yamato blocks).