### PR TITLE
Revert tests versions back to 2019.4

### DIFF
--- a/.yamato/promotion.yml
+++ b/.yamato/promotion.yml
@@ -1,6 +1,8 @@
 test_editors:
-  - version: 2021.3
-  - version: 2022.2
+  - version: 2019.4
+  - version: 2020.3
+  - version: 2021.2
+  - version: 2022.1
   - version: trunk
 test_platforms:
   - name: win

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -1,6 +1,8 @@
 test_editors:
-  - version: 2021.3
-  - version: 2022.2
+  - version: 2019.4
+  - version: 2020.3
+  - version: 2021.2
+  - version: 2022.1
   - version: trunk
 test_platforms:
   - name: win

--- a/Editor/EditorCore/StripProBuilderScripts.cs
+++ b/Editor/EditorCore/StripProBuilderScripts.cs
@@ -13,6 +13,8 @@ namespace UnityEditor.ProBuilder.Actions
     sealed class StripProBuilderScripts : Editor
     {
         const string k_UndoMessage = "Strip ProBuilder Scripts";
+
+        #if UNITY_2020_1_OR_NEWER
         // return ProBuilderMesh components in loaded scenes only for the current stage
         static List<ProBuilderMesh> GetMeshesInActiveScenes()
         {
@@ -27,6 +29,7 @@ namespace UnityEditor.ProBuilder.Actions
                     filtered.Add(mesh);
             return filtered;
         }
+        #endif
 
         [MenuItem("Tools/" + PreferenceKeys.pluginTitle + "/Actions/Strip All ProBuilder Scripts in Scene %&s")]
         public static void StripAllScenes()
@@ -34,7 +37,11 @@ namespace UnityEditor.ProBuilder.Actions
             if (!UnityEditor.EditorUtility.DisplayDialog("Strip ProBuilder Scripts", "This will remove all ProBuilder scripts in the scene. You will no longer be able to edit these objects.\n\nContinue?", "Okay", "Cancel"))
                 return;
 
+            #if UNITY_2020_1_OR_NEWER
             var all = GetMeshesInActiveScenes();
+            #else
+            var all = new List<ProBuilderMesh>((ProBuilderMesh[])Resources.FindObjectsOfTypeAll(typeof(ProBuilderMesh)));
+            #endif
 
             for (int i = 0, c = all?.Count ?? 0; i < c; i++)
             {


### PR DESCRIPTION
This reverts commit https://github.com/Unity-Technologies/com.unity.probuilder/commit/d07ed6c7a32a7c1ff661a0b9491dc4d2700ab558.

### Purpose of this PR

We can't promote the unity version in package.json since this is a minor release. Reverting commit https://github.com/Unity-Technologies/com.unity.probuilder/commit/d07ed6c7a32a7c1ff661a0b9491dc4d2700ab558 because we need to support tests for 2019.4 (otherwise Yamato blocks).