### PR TITLE
Bump version to 5.1.0 and revert test versions back to 2019.4

### DIFF
--- a/.yamato/promotion.yml
+++ b/.yamato/promotion.yml
@@ -1,6 +1,8 @@
 test_editors:
-  - version: 2021.3
-  - version: 2022.2
+  - version: 2019.4
+  - version: 2020.3
+  - version: 2021.2
+  - version: 2022.1
   - version: trunk
 test_platforms:
   - name: win

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -1,6 +1,8 @@
 test_editors:
-  - version: 2021.3
-  - version: 2022.2
+  - version: 2019.4
+  - version: 2020.3
+  - version: 2021.2
+  - version: 2022.1
   - version: trunk
 test_platforms:
   - name: win

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [5.0.8] - 2023-06-01
+## [5.1.0] - 2023-06-01
 
 ### Fixed
 

--- a/Editor/EditorCore/StripProBuilderScripts.cs
+++ b/Editor/EditorCore/StripProBuilderScripts.cs
@@ -13,6 +13,8 @@ namespace UnityEditor.ProBuilder.Actions
     sealed class StripProBuilderScripts : Editor
     {
         const string k_UndoMessage = "Strip ProBuilder Scripts";
+
+        #if UNITY_2020_1_OR_NEWER
         // return ProBuilderMesh components in loaded scenes only for the current stage
         static List<ProBuilderMesh> GetMeshesInActiveScenes()
         {
@@ -27,6 +29,7 @@ namespace UnityEditor.ProBuilder.Actions
                     filtered.Add(mesh);
             return filtered;
         }
+        #endif
 
         [MenuItem("Tools/" + PreferenceKeys.pluginTitle + "/Actions/Strip All ProBuilder Scripts in Scene %&s")]
         public static void StripAllScenes()
@@ -34,7 +37,11 @@ namespace UnityEditor.ProBuilder.Actions
             if (!UnityEditor.EditorUtility.DisplayDialog("Strip ProBuilder Scripts", "This will remove all ProBuilder scripts in the scene. You will no longer be able to edit these objects.\n\nContinue?", "Okay", "Cancel"))
                 return;
 
+            #if UNITY_2020_1_OR_NEWER
             var all = GetMeshesInActiveScenes();
+            #else
+            var all = new List<ProBuilderMesh>((ProBuilderMesh[])Resources.FindObjectsOfTypeAll(typeof(ProBuilderMesh)));
+            #endif
 
             for (int i = 0, c = all?.Count ?? 0; i < c; i++)
             {

--- a/Editor/EditorCore/UVEditor.cs
+++ b/Editor/EditorCore/UVEditor.cs
@@ -3271,7 +3271,11 @@ namespace UnityEditor.ProBuilder
         Color screenshot_backgroundColor = Color.black;
         string screenShotPath = "";
 
+        #if UNITY_2021_3_OR_NEWER
         readonly Color32 UV_FILL_COLOR = new Color32(49, 49, 49, 255);
+        #else
+        readonly Color UV_FILL_COLOR = (Color) new Color32(49, 49, 49, 255);
+        #endif
 
         // This is the default background of the UV editor - used to compare bacground pixels when rendering UV template
         void InitiateScreenshot(int ImageSize, bool HideGrid, Color LineColor, bool TransparentBackground, Color BackgroundColor, bool RenderTexture)

--- a/Tests/Editor/Editor/MeshSyncTests.cs
+++ b/Tests/Editor/Editor/MeshSyncTests.cs
@@ -24,6 +24,7 @@ class MeshSyncTests : TemporaryAssetTest
         OpenScene(copyPasteTestScene);
     }
 
+    #if UNITY_2020_2_OR_NEWER
     static IEnumerable CopyPasteDuplicate
     {
         get
@@ -60,6 +61,7 @@ class MeshSyncTests : TemporaryAssetTest
         Assume.That(copy, Is.Not.EqualTo(cube));
         Assert.That(copy.GetComponent<MeshFilter>().sharedMesh.GetInstanceID(), Is.Not.EqualTo(originalMeshId));
     }
+    #endif
 
     [Test]
     public void OpenSceneDoesNotDirtyScene()

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.probuilder",
   "displayName": "ProBuilder",
-  "version": "5.0.8",
+  "version": "5.1.0",
   "unity": "2019.4",
   "description": "Build, edit, and texture custom geometry in Unity. Use ProBuilder for in-scene level design, prototyping, collision meshes, all with on-the-fly play-testing.\n\nAdvanced features include UV editing, vertex colors, parametric shapes, and texture blending. With ProBuilder's model export feature it's easy to tweak your levels in any external 3D modelling suite.\n\nIf you are using URP/HDRP, be careful to also import the corresponding sample project in the section below to get the proper materials.",
   "keywords": [

--- a/validationExceptions.json
+++ b/validationExceptions.json
@@ -1,9 +1,0 @@
-{
-    "Exceptions":
-    [
-        {
-             "ValidationTest": "API Validation",
-             "PackageVersion": "5.0.5"
-       }
-    ]
-}

--- a/validationExceptions.json.meta
+++ b/validationExceptions.json.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: a1430a41101d44a61a313b6897f438c0
-TextScriptImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
This reverts commit https://github.com/Unity-Technologies/com.unity.probuilder/commit/d07ed6c7a32a7c1ff661a0b9491dc4d2700ab558.

### Purpose of this PR

We can't promote the unity version in package.json since this is a minor release. Reverting commit https://github.com/Unity-Technologies/com.unity.probuilder/commit/d07ed6c7a32a7c1ff661a0b9491dc4d2700ab558 because we need to support tests for 2019.4 (otherwise Yamato blocks).

EDIT 2023-06-08

There are public API changes in this release (MeshSyncState has a new enum entry) and Yamato blocks this from being a minor version update. So bumping to 5.1.0 instead of 5.0.8 now.
