### PR TITLE
fix potential access of first array element when array is empty

### DIFF
--- a/Runtime/MeshOperations/CombineMeshes.cs
+++ b/Runtime/MeshOperations/CombineMeshes.cs
@@ -203,7 +203,7 @@ namespace UnityEngine.ProBuilder.MeshOperations
                         newFace.manualUV = true;
                         autoUvFaces.Add(newFace);
                     }
-                    var material = materials[Math.Clamp(face.submeshIndex, 0, materialCount - 1)];
+                    var material = materialCount > 0 ? materials[Math.Clamp(face.submeshIndex, 0, materialCount - 1)] : null;
                     var submeshIndex = materialMap.IndexOf(material);
 
                     if (submeshIndex > -1)


### PR DESCRIPTION
**DO NOT FORGET TO INCLUDE A CHANGELOG ENTRY**

### Purpose of this PR

Probuilder 5.1.0 introduces a array index exception bug in the following part of CombineMeshes.cs
AccumulateMeshesInfo() may trigger a array index bug when one of the source meshes has no material attached. Its quite clear as line 206 does not check the materials[] array for a length of zero, so if materialCount == 0, the following expression still accesses element 0, which of course does not exist in an empty array
Line 206:
var material = materials[Math.Clamp(face.submeshIndex, 0, materialCount - 1)];

### Links
https://forum.unity.com/threads/probuilder-5-1-0-exception-in-combinemeshes-cs-where-to-report.1454617/

### Comments to Reviewers

Downgrading to 5.0.7 fixes the issue., and i guess it has to do with the following changes

[5.1.0] - 2023-06-01
Fixed

    [case: PBLD-70] Fixed a bug where unused materials were not removed from the mesh renderer when deleting faces.
    [case: PBLD-52] Fixed a bug where unused materials were not removed from the mesh renderer when detaching faces.

 
