### PR TITLE
Fix poly shape regression - not being able to set an extrusion point.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Fixed an exception in `CombineMeshes.AccumulateMeshesInfo` when a `ProBuilderMesh` contains an empty `Material` array.
+- [case: PBLD-78] Fixed a regression where it was no longer possible to set the extrusion point with the Poly Shape tool.
 
 ## [5.1.0] - 2023-06-01
 

--- a/Runtime/Core/ProBuilderMeshFunction.cs
+++ b/Runtime/Core/ProBuilderMeshFunction.cs
@@ -368,6 +368,18 @@ namespace UnityEngine.ProBuilder
 
             mesh.subMeshCount = submeshes.Length;
 
+            if (mesh.subMeshCount == 0)
+            {
+                EnsureMeshFilterIsAssigned();
+
+                if (usedInParticleSystem)
+                    MeshUtility.RestoreParticleSystem(this);
+
+                IncrementVersionIndex();
+
+                return;
+            }
+
             var currentSubmeshIndex = 0;
             var shouldReassignMaterials = false;
             for (int i = 0; i < mesh.subMeshCount; i++)

--- a/Runtime/Core/ProBuilderMeshFunction.cs
+++ b/Runtime/Core/ProBuilderMeshFunction.cs
@@ -368,15 +368,12 @@ namespace UnityEngine.ProBuilder
 
             mesh.subMeshCount = submeshes.Length;
 
+            // If the mesh does not have any submeshes, we don't want to do
+            // any manipulation on the mesh's materials. We skip to the end
+            // of the method and return.
             if (mesh.subMeshCount == 0)
             {
-                EnsureMeshFilterIsAssigned();
-
-                if (usedInParticleSystem)
-                    MeshUtility.RestoreParticleSystem(this);
-
-                IncrementVersionIndex();
-
+                FinalizeToMesh(usedInParticleSystem);
                 return;
             }
 
@@ -428,9 +425,14 @@ namespace UnityEngine.ProBuilder
             if (shouldReassignMaterials)
                 renderer.sharedMaterials = MaterialUtility.s_MaterialArray.ToArray();
 
+            FinalizeToMesh(usedInParticleSystem);
+        }
+
+        private void FinalizeToMesh(bool usedInParticleSystem)
+        {
             EnsureMeshFilterIsAssigned();
 
-            if(usedInParticleSystem)
+            if (usedInParticleSystem)
                 MeshUtility.RestoreParticleSystem(this);
 
             IncrementVersionIndex();


### PR DESCRIPTION
### Purpose of this PR

This PR fixes a regression in the poly shape tool, with the user not being able to set an extrusion point, that I caused when fixing these bugs (https://jira.unity3d.com/browse/PBLD-52 and https://jira.unity3d.com/browse/PBLD-70).

### Links

**Jira:** https://jira.unity3d.com/browse/PBLD-78