### PR TITLE
API Update for Analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Internal
+
+- Updated analytics API for 2023.2 and after.
+
 ## [5.1.1] - 2023-08-01
 
 ### Fixed

--- a/Editor/EditorCore/ProBuilderAnalytics.cs
+++ b/Editor/EditorCore/ProBuilderAnalytics.cs
@@ -122,8 +122,9 @@ namespace UnityEditor.ProBuilder
             }
             #endif
 
-            #if PB_ANALYTICS_DONTSEND
-            return;
+            #if PB_ANALYTICS_DONTSEND || DEBUG
+                DumpLogInfo($"[PB] Analytics disabled: event='{k_ProbuilderEventName}', time='{DateTime.Now:HH:mm:ss}', payload={EditorJsonUtility.ToJson(data, true)}");
+                return;
             #endif
 
             try
@@ -224,7 +225,7 @@ namespace UnityEditor.ProBuilder
             }
             #endif
 
-            #if !PB_ANALYTICS_DONTSEND
+            #if !PB_ANALYTICS_DONTSEND || DEBUG
             s_EventRegistered = RegisterEvents();
             #endif
 

--- a/Editor/EditorCore/ProBuilderAnalytics.cs
+++ b/Editor/EditorCore/ProBuilderAnalytics.cs
@@ -17,7 +17,6 @@ using UnityEngine.Analytics;
 using UnityEngine.ProBuilder;
 #if !UNITY_2023_2_OR_NEWER
 using System.Linq;
-using System.IO;
 using UnityEngine;
 #endif
 
@@ -59,7 +58,11 @@ namespace UnityEditor.ProBuilder
 
         // Data structure for Triggered Actions
         [Serializable]
+#if UNITY_2023_2_OR_NEWER
         struct ProBuilderActionData : IAnalytic.IData
+#else
+        struct ProBuilderActionData
+#endif
         {
             public string actionName;
             public string actionType;


### PR DESCRIPTION
### Purpose of this PR

API has been changed in unity 2023.2.0a22 and after for analytics causing warning messages in the console when using ProBuilder. 
This PR updates the analytics to use the new API for 2023.2 and after.

Based on this doc : https://docs.editor-data.unity3d.com/Contribute/EditorAnalytics/cs_guide/

### Links

**Jira:** https://jira.unity3d.com/browse/STO-2988

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]