### PR TITLE
August ProBuilder documentation fixes

### DIFF
--- a/Documentation~/vertex-colors.md
+++ b/Documentation~/vertex-colors.md
@@ -10,7 +10,7 @@ To open this window, click the **Vertex Colors** button ( ![Vertex Color Editor 
 
 **(A)** Click the **Reset** button to return all the colors on the **Color Palette** to their default values.
 
-**(B)** You can import your [own swatch library](https://docs.unity3d.com/Manual/PresetLibraries.html) and use its colors instead of the default Unity colors. To do this, set a reference to the swatch library file.
+**(B)** You can import your own swatch library and use its colors instead of the default Unity colors. To do this, set a reference to the swatch library file.
 
 **(C)** Click the **Apply** button to [set the associated color](workflow-vertexcolors.md#apply) on the selected object(s) or element(s).
 


### PR DESCRIPTION
### Purpose of this PR

* Fixed broken link in `vertex-colors.md`.
* In `api.md`, changed the `Modify a Mesh` sample. It was no longer compiling. 

### Links

**Jira:**

- https://jira.unity3d.com/browse/DOCATT-381
- https://jira.unity3d.com/browse/DOCATT-392
- https://jira.unity3d.com/browse/DOCATT-404
- https://jira.unity3d.com/browse/DOCATT-410
- https://jira.unity3d.com/browse/DOCATT-1048
- https://jira.unity3d.com/browse/DOCATT-3025

