### PR TITLE
[PBLD-87] Fixing infinite recursion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- [PBLD-87] Fixed a bug where an infinite recursion loop could crash the editor when using the Boolean tool.  
+
 ### Internal
 
 - Updated analytics API for 2023.2 and after.

--- a/External/CSG/Classes/Plane.cs
+++ b/External/CSG/Classes/Plane.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace UnityEngine.ProBuilder.Csg
 {
@@ -126,12 +127,26 @@ namespace UnityEngine.ProBuilder.Csg
 
                     if (f.Count >= 3)
                     {
-                        front.Add(new Polygon(f, polygon.material));
+                        if (f.SequenceEqual(polygon.vertices))
+                            front.Add(polygon);
+                        else
+                        {
+                            var p = new Polygon(f, polygon.material);
+                            if (p.plane.Valid())
+                                front.Add(p);
+                        }
                     }
 
                     if (b.Count >= 3)
                     {
-                        back.Add(new Polygon(b, polygon.material));
+                         if (b.SequenceEqual(polygon.vertices))
+                             back.Add(polygon);
+                         else
+                        {
+                            var p = new Polygon(b, polygon.material);
+                            if (p.plane.Valid())
+                                back.Add(p);
+                        }
                     }
                 }
                 break;


### PR DESCRIPTION
### Purpose of this PR

Fixed a bug where an infinite recursion loop could crash the editor when using the Boolean tool.

The problem was caused by the creation of a new polygon every single time using:
`{front/back}.Add(new Polygon(f, polygon.material));`

In some cases, the created polygon was slightly different from the original one, causing a stoppin condition to fail in Node.Build  (line 116 or line 124), causing another call to Build() with the same polygin vertices, causing the same issue on the following loop.
`if (newNode && list.SequenceEqual(listBack/Front))`

Checking the vertex equality before creating the polygon fixes that, then the original polygon is used, instead of a new one.

Also adding a small optimization, checking that the new added polygon is valid before adding it to the list.


### Links

**Jira:** https://jira.unity3d.com/browse/PBLD-87

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]