### PR TITLE
[PBLD-75] Fixing mesh duplication when ProBuilder Mesh is on children object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- [case: PBLD-75] Fixed a bug where duplicating a GameObject with  `ProBuilderMesh` children would not make unique `Mesh` for the duplicates.
 - Fixed an exception in `CombineMeshes.AccumulateMeshesInfo` when a `ProBuilderMesh` contains an empty `Material` array.
 - [case: PBLD-78] Fixed a regression where it was no longer possible to set the extrusion point with the Poly Shape tool.
 - [case: UUM-43960] Fixed warning on project import caused by merge conflicts in a meta file.

--- a/Editor/EditorCore/HierarchyListener.cs
+++ b/Editor/EditorCore/HierarchyListener.cs
@@ -106,12 +106,12 @@ namespace UnityEditor.ProBuilder
         {
             if(go.TryGetComponent<ProBuilderMesh>(out var mesh))
                 OnObjectCreated(mesh);
-            // var childCount = go.transform.childCount;
-            // if (childCount > 0)
-            // {
-            //     for(int childIndex = 0; childIndex < childCount; ++childIndex)
-            //         CheckForProBuilderMeshesCreatedOrModified(go.transform.GetChild(childIndex).gameObject);
-            // }
+            var childCount = go.transform.childCount;
+            if (childCount > 0)
+            {
+                for(int childIndex = 0; childIndex < childCount; ++childIndex)
+                    CheckForProBuilderMeshesCreatedOrModified(go.transform.GetChild(childIndex).gameObject);
+            }
         }
 
         // used by tests

--- a/Editor/EditorCore/HierarchyListener.cs
+++ b/Editor/EditorCore/HierarchyListener.cs
@@ -89,7 +89,7 @@ namespace UnityEditor.ProBuilder
                         EditorUtility.SynchronizeWithMeshFilter(pb);
                 }
             }
-            
+
             ProBuilderEditor.Refresh();
         }
         #endif
@@ -98,9 +98,20 @@ namespace UnityEditor.ProBuilder
         {
             // if the created object is a probuilder mesh, check if it is a copy of an existing instance.
             // if so, we need to create a new mesh asset.
-            if (UnityEditor.EditorUtility.InstanceIDToObject(instanceId) is GameObject go
-                && go.TryGetComponent<ProBuilderMesh>(out var mesh))
+            if (UnityEditor.EditorUtility.InstanceIDToObject(instanceId) is GameObject go)
+                CheckForProBuilderMeshesCreatedOrModified(go);
+        }
+
+        static void CheckForProBuilderMeshesCreatedOrModified(GameObject go)
+        {
+            if(go.TryGetComponent<ProBuilderMesh>(out var mesh))
                 OnObjectCreated(mesh);
+            // var childCount = go.transform.childCount;
+            // if (childCount > 0)
+            // {
+            //     for(int childIndex = 0; childIndex < childCount; ++childIndex)
+            //         CheckForProBuilderMeshesCreatedOrModified(go.transform.GetChild(childIndex).gameObject);
+            // }
         }
 
         // used by tests

--- a/Tests/Editor/Editor/MeshSyncTests.cs
+++ b/Tests/Editor/Editor/MeshSyncTests.cs
@@ -63,8 +63,9 @@ class MeshSyncTests : TemporaryAssetTest
         Assert.That(copy.GetComponent<MeshFilter>().sharedMesh.GetInstanceID(), Is.Not.EqualTo(originalMeshId));
     }
 
+    //[PBLD-75] Sending the event to the scene view is needed as just calling HierarchyListener.OnObjectCreated
+    // is not reproducing the actual bug.
     [UnityTest]
-    //[TestCaseSource(nameof(CopyPasteDuplicate))]
     public IEnumerator ExecuteCopyPasteDuplicateOnParent_CreatesUniqueMesh()
     {
         string[] commands = new[] { "Duplicate" };


### PR DESCRIPTION
### Purpose of this PR

Duplicating a parent of a PBMesh was not updating the reference to the Mesh and still pointing to the original mesh.
This PR fixes this and allow to duplicate GameObject with ProBuilderMesh children.

+ Adding tests

### Links

**Jira:** https://jira.unity3d.com/browse/PBLD-75

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]