### PR TITLE
Removed merge conflict markers

### DIFF
--- a/Editor/EditorCore/MenuToolToggle.cs.meta
+++ b/Editor/EditorCore/MenuToolToggle.cs.meta
@@ -1,9 +1,5 @@
 fileFormatVersion: 2
-<<<<<<< HEAD
-guid: c7eb6fea243bbe045b0d90f776fe4013
-=======
 guid: 75ee05acc67ed8445b569a5aab0f3cc8
->>>>>>> master
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2


### PR DESCRIPTION
**DO NOT FORGET TO INCLUDE A CHANGELOG ENTRY**

### Purpose of this PR

Removed merge conflict markers (">>>>>>", etc...) as they were causing the following error on CI checks for DOTS monorepo job:

`The GUID inside 'Packages/com.unity.probuilder/Editor/EditorCore/MenuToolToggle.cs.meta' cannot be extracted by the YAML Parser. Attempting to extract it via string matching instead. Please verify the file does not contain unexpected data.`

### Links

**Jira:** Part of https://jira.unity3d.com/browse/DOTS-9177
