### PR TITLE
add package field to buginfo file

### DIFF
--- a/.buginfo
+++ b/.buginfo
@@ -1,4 +1,5 @@
 system: jira
-server: jira.unity3d.com
-project: PBLD
+system: jira.unity3d.com
 issuetype: Bug
+package: Probuilder
+project: PBLD


### PR DESCRIPTION
### Purpose of this PR

Internal change, no entry to changelog is intentional.

Adds the `package` field to `.buginfo` file.

### Links

**Jira:**

https://jira.unity3d.com/browse/CODE-562