### PR TITLE
Fixed the left mouse click for mesh editing not working with the new shortcut improvements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Fixed a bug where it was no longer possible to edit meshes or enable view tools after the new shortcut improvements were added to the editor.
 - [PBLD-75] Fixed a bug where duplicating a GameObject with  `ProBuilderMesh` children would not make unique `Mesh` for the duplicates.
 - [PBLD-87] Fixed a bug where an infinite recursion loop could crash the editor when using the Boolean tool.  
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Fixed a bug where it was no longer possible to edit meshes or enable view tools after the new shortcut improvements were added to the editor.
+- Fixed a bug that prevented editing meshes or enabling view tools after the new shortcut improvements were added to the Editor.
 
 ## [5.2.0] - 2023-10-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [5.2.0] - 2023-10-02
+## [Unreleased]
 
 ### Fixed
 
 - Fixed a bug where it was no longer possible to edit meshes or enable view tools after the new shortcut improvements were added to the editor.
+
+## [5.2.0] - 2023-10-02
+
+### Fixed
+
 - [PBLD-75] Fixed a bug where duplicating a GameObject with  `ProBuilderMesh` children would not make unique `Mesh` for the duplicates.
 - [PBLD-87] Fixed a bug where an infinite recursion loop could crash the editor when using the Boolean tool.  
 

--- a/Editor/EditorCore/ProBuilderEditor.cs
+++ b/Editor/EditorCore/ProBuilderEditor.cs
@@ -567,7 +567,15 @@ namespace UnityEditor.ProBuilder
 
         internal void HandleMouseEvent(SceneView sceneView, int controlID)
         {
-            if(m_CurrentEvent.type == EventType.MouseDown && HandleUtility.nearestControl == controlID)
+#if UNITY_2023_1_OR_NEWER
+            bool isLeftMouseClick = m_CurrentEvent.type == EventType.MouseDown && m_CurrentEvent.keyCode == KeyCode.Mouse0 && HandleUtility.nearestControl == controlID;
+#elif UNITY_2022_3
+            KeyCode keyCode = m_CurrentEvent.isMouse ? m_CurrentEvent.button + KeyCode.Mouse0 : m_CurrentEvent.keyCode;
+            bool isLeftMouseClick = m_CurrentEvent.type == EventType.MouseDown && keyCode == KeyCode.Mouse0 && HandleUtility.nearestControl == controlID;
+#else
+            bool isLeftMouseClick = m_CurrentEvent.type == EventType.MouseDown && HandleUtility.nearestControl == controlID;
+#endif
+            if (isLeftMouseClick)
             {
                 // double clicking object
                 if(m_CurrentEvent.clickCount > 1)

--- a/Editor/EditorCore/ProBuilderEditor.cs
+++ b/Editor/EditorCore/ProBuilderEditor.cs
@@ -567,17 +567,10 @@ namespace UnityEditor.ProBuilder
 
         internal void HandleMouseEvent(SceneView sceneView, int controlID)
         {
-            if ((Event.current.modifiers & EventModifiers.Alt) == EventModifiers.Alt)
+            if ((Event.current.modifiers & EventModifiers.Alt) == EventModifiers.Alt && !m_IsDragging)
                 return;
 
-#if UNITY_2023_1_OR_NEWER
-            bool isLeftMouseClick = m_CurrentEvent.type == EventType.MouseDown && m_CurrentEvent.keyCode == KeyCode.Mouse0 && HandleUtility.nearestControl == controlID;
-#elif UNITY_2022_3
-            KeyCode keyCode = m_CurrentEvent.isMouse ? m_CurrentEvent.button + KeyCode.Mouse0 : m_CurrentEvent.keyCode;
-            bool isLeftMouseClick = m_CurrentEvent.type == EventType.MouseDown && keyCode == KeyCode.Mouse0 && HandleUtility.nearestControl == controlID;
-#else
-            bool isLeftMouseClick = m_CurrentEvent.type == EventType.MouseDown && HandleUtility.nearestControl == controlID;
-#endif
+            bool isLeftMouseClick = m_CurrentEvent.type == EventType.MouseDown && m_CurrentEvent.button == 0 && HandleUtility.nearestControl == controlID;
             if (isLeftMouseClick)
             {
                 // double clicking object

--- a/Editor/EditorCore/ProBuilderEditor.cs
+++ b/Editor/EditorCore/ProBuilderEditor.cs
@@ -154,8 +154,8 @@ namespace UnityEditor.ProBuilder
 
         // prevents leftClickUp from stealing focus after double click
         bool m_WasDoubleClick;
-        // vertex handles
 
+        // vertex handles
         Vector3[][] m_VertexPositions;
         Vector3[] m_VertexOffset;
 
@@ -567,6 +567,9 @@ namespace UnityEditor.ProBuilder
 
         internal void HandleMouseEvent(SceneView sceneView, int controlID)
         {
+            if (Tools.viewToolActive || Tools.current == Tool.View || (Event.current.modifiers & EventModifiers.Alt) == EventModifiers.Alt)
+                return;
+
 #if UNITY_2023_1_OR_NEWER
             bool isLeftMouseClick = m_CurrentEvent.type == EventType.MouseDown && m_CurrentEvent.keyCode == KeyCode.Mouse0 && HandleUtility.nearestControl == controlID;
 #elif UNITY_2022_3

--- a/Editor/EditorCore/ProBuilderEditor.cs
+++ b/Editor/EditorCore/ProBuilderEditor.cs
@@ -545,15 +545,15 @@ namespace UnityEditor.ProBuilder
                     break;
             }
 
-             if (EditorHandleUtility.SceneViewInUse(m_CurrentEvent))
-             {
-                 if(m_IsDragging)
+            if (EditorHandleUtility.SceneViewInUse(m_CurrentEvent))
+            {
+                if (m_IsDragging)
                     m_IsDragging = false;
 
-                 if (GUIUtility.hotControl == m_DefaultControl)
-                     GUIUtility.hotControl = 0;
+                if (GUIUtility.hotControl == m_DefaultControl)
+                    GUIUtility.hotControl = 0;
 
-                 return;
+                return;
             }
 
             // This prevents us from selecting other objects in the scene,
@@ -567,7 +567,7 @@ namespace UnityEditor.ProBuilder
 
         internal void HandleMouseEvent(SceneView sceneView, int controlID)
         {
-            if (Tools.viewToolActive || Tools.current == Tool.View || (Event.current.modifiers & EventModifiers.Alt) == EventModifiers.Alt)
+            if ((Event.current.modifiers & EventModifiers.Alt) == EventModifiers.Alt)
                 return;
 
 #if UNITY_2023_1_OR_NEWER


### PR DESCRIPTION
### Purpose of this PR

This PR fixes an issue where it was no longer possible to do mesh editing or enable view tools after the new shortcut improvements were added to the editor.