### PR TITLE
[PBLD-88] Fixing ProBuilder Window not refreshing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- [PB-88] Fixed a bug that prevented the ProBuilder window to update its content after changing its docking position.
+
 ## [5.2.1] - 2023-11-06
 
 ### Fixed

--- a/Editor/EditorCore/MainToolbar.cs
+++ b/Editor/EditorCore/MainToolbar.cs
@@ -102,9 +102,12 @@ namespace UnityEditor.ProBuilder.UI
 
             CreateGUI();
 
-            ProBuilderEditor.selectModeChanged += RefreshVisibility;
-            MeshSelection.objectSelectionChanged += RefreshVisibility;
-            ProBuilderMesh.elementSelectionChanged += RefreshVisibility;
+            RegisterCallback<AttachToPanelEvent>(_ =>
+            {
+                ProBuilderEditor.selectModeChanged += RefreshVisibility;
+                MeshSelection.objectSelectionChanged += RefreshVisibility;
+                ProBuilderMesh.elementSelectionChanged += RefreshVisibility;
+            });
 
             RegisterCallback<DetachFromPanelEvent>(_ =>
             {


### PR DESCRIPTION
### Purpose of this PR

Fixed a bug that prevented the ProBuilder window to update its content after changing its docking position.

The problem was caused by the fact that the events when registered in the constructor and unregistered when docking was changed from the original position, and then never registered again.
Moving the event registration to the AttachToPanelEvent event fixes this problem.

### Links

**Jira:** https://jira.unity3d.com/browse/PBLD-88

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]