### PR TITLE
Preview improvement

### DIFF
--- a/Debug/Editor/GenerateMenuItems.cs
+++ b/Debug/Editor/GenerateMenuItems.cs
@@ -208,8 +208,11 @@ namespace UnityEditor.ProBuilder
                     sb.AppendLine($"\t\t\t\tEditorAction.Start(new MenuActionSettings(instance,{data.hasPreview.ToString().ToLower()}));");
                 }
                 else // Last case, just perform the action if this is an instant action with no options
+                {
+                    sb.AppendLine("\t\t\t\tPreviewActionManager.EndPreview();");
                     sb.AppendLine("\t\t\t\tinstance.PerformAction();");
-            }
+                }
+        }
 
             sb.AppendLine( "\t\t\t\tProBuilderAnalytics.SendActionEvent(instance);");
             sb.AppendLine( "\t\t\t}");

--- a/Editor/EditorCore/EditorToolbarMenuItems.cs
+++ b/Editor/EditorCore/EditorToolbarMenuItems.cs
@@ -936,7 +936,7 @@ namespace UnityEditor.ProBuilder
 			var instance = EditorToolbarLoader.GetInstance<GrowSelection>();
 			if(instance != null && instance.enabled)
 			{
-				instance.PerformAction();
+				EditorAction.Start(new MenuActionSettings(instance,true));
 				ProBuilderAnalytics.SendActionEvent(instance);
 			}
 		}
@@ -1066,7 +1066,7 @@ namespace UnityEditor.ProBuilder
 			var instance = EditorToolbarLoader.GetInstance<SelectVertexColor>();
 			if(instance != null && instance.enabled)
 			{
-				instance.PerformAction();
+				EditorAction.Start(new MenuActionSettings(instance,true));
 				ProBuilderAnalytics.SendActionEvent(instance);
 			}
 		}

--- a/Editor/EditorCore/EditorToolbarMenuItems.cs
+++ b/Editor/EditorCore/EditorToolbarMenuItems.cs
@@ -30,6 +30,7 @@ namespace UnityEditor.ProBuilder
 			var instance = EditorToolbarLoader.GetInstance<NewBezierShape>();
 			if(instance != null && instance.enabled)
 			{
+				PreviewActionManager.EndPreview();
 				instance.PerformAction();
 				ProBuilderAnalytics.SendActionEvent(instance);
 			}
@@ -48,6 +49,7 @@ namespace UnityEditor.ProBuilder
 			var instance = EditorToolbarLoader.GetInstance<OpenLightmapUVEditor>();
 			if(instance != null && instance.enabled)
 			{
+				PreviewActionManager.EndPreview();
 				instance.PerformAction();
 				ProBuilderAnalytics.SendActionEvent(instance);
 			}
@@ -66,6 +68,7 @@ namespace UnityEditor.ProBuilder
 			var instance = EditorToolbarLoader.GetInstance<OpenMaterialEditor>();
 			if(instance != null && instance.enabled)
 			{
+				PreviewActionManager.EndPreview();
 				instance.PerformAction();
 				ProBuilderAnalytics.SendActionEvent(instance);
 			}
@@ -84,6 +87,7 @@ namespace UnityEditor.ProBuilder
 			var instance = EditorToolbarLoader.GetInstance<OpenSmoothingEditor>();
 			if(instance != null && instance.enabled)
 			{
+				PreviewActionManager.EndPreview();
 				instance.PerformAction();
 				ProBuilderAnalytics.SendActionEvent(instance);
 			}
@@ -102,6 +106,7 @@ namespace UnityEditor.ProBuilder
 			var instance = EditorToolbarLoader.GetInstance<OpenUVEditor>();
 			if(instance != null && instance.enabled)
 			{
+				PreviewActionManager.EndPreview();
 				instance.PerformAction();
 				ProBuilderAnalytics.SendActionEvent(instance);
 			}
@@ -120,6 +125,7 @@ namespace UnityEditor.ProBuilder
 			var instance = EditorToolbarLoader.GetInstance<OpenVertexColorEditor>();
 			if(instance != null && instance.enabled)
 			{
+				PreviewActionManager.EndPreview();
 				instance.PerformAction();
 				ProBuilderAnalytics.SendActionEvent(instance);
 			}
@@ -138,6 +144,7 @@ namespace UnityEditor.ProBuilder
 			var instance = EditorToolbarLoader.GetInstance<OpenVertexPositionEditor>();
 			if(instance != null && instance.enabled)
 			{
+				PreviewActionManager.EndPreview();
 				instance.PerformAction();
 				ProBuilderAnalytics.SendActionEvent(instance);
 			}
@@ -156,6 +163,7 @@ namespace UnityEditor.ProBuilder
 			var instance = EditorToolbarLoader.GetInstance<ExportAsset>();
 			if(instance != null && instance.enabled)
 			{
+				PreviewActionManager.EndPreview();
 				instance.PerformAction();
 				ProBuilderAnalytics.SendActionEvent(instance);
 			}
@@ -174,6 +182,7 @@ namespace UnityEditor.ProBuilder
 			var instance = EditorToolbarLoader.GetInstance<ExportObj>();
 			if(instance != null && instance.enabled)
 			{
+				PreviewActionManager.EndPreview();
 				instance.PerformAction();
 				ProBuilderAnalytics.SendActionEvent(instance);
 			}
@@ -192,6 +201,7 @@ namespace UnityEditor.ProBuilder
 			var instance = EditorToolbarLoader.GetInstance<ExportPly>();
 			if(instance != null && instance.enabled)
 			{
+				PreviewActionManager.EndPreview();
 				instance.PerformAction();
 				ProBuilderAnalytics.SendActionEvent(instance);
 			}
@@ -210,6 +220,7 @@ namespace UnityEditor.ProBuilder
 			var instance = EditorToolbarLoader.GetInstance<ExportStlAscii>();
 			if(instance != null && instance.enabled)
 			{
+				PreviewActionManager.EndPreview();
 				instance.PerformAction();
 				ProBuilderAnalytics.SendActionEvent(instance);
 			}
@@ -228,6 +239,7 @@ namespace UnityEditor.ProBuilder
 			var instance = EditorToolbarLoader.GetInstance<ExportStlBinary>();
 			if(instance != null && instance.enabled)
 			{
+				PreviewActionManager.EndPreview();
 				instance.PerformAction();
 				ProBuilderAnalytics.SendActionEvent(instance);
 			}
@@ -266,6 +278,7 @@ namespace UnityEditor.ProBuilder
 			var instance = EditorToolbarLoader.GetInstance<BridgeEdges>();
 			if(instance != null && instance.enabled)
 			{
+				PreviewActionManager.EndPreview();
 				instance.PerformAction();
 				ProBuilderAnalytics.SendActionEvent(instance);
 			}
@@ -304,6 +317,7 @@ namespace UnityEditor.ProBuilder
 			var instance = EditorToolbarLoader.GetInstance<ConformFaceNormals>();
 			if(instance != null && instance.enabled)
 			{
+				PreviewActionManager.EndPreview();
 				instance.PerformAction();
 				ProBuilderAnalytics.SendActionEvent(instance);
 			}
@@ -323,6 +337,7 @@ namespace UnityEditor.ProBuilder
 			var instance = EditorToolbarLoader.GetInstance<DeleteFaces>();
 			if(instance != null && instance.enabled)
 			{
+				PreviewActionManager.EndPreview();
 				instance.PerformAction();
 				ProBuilderAnalytics.SendActionEvent(instance);
 			}
@@ -426,6 +441,7 @@ namespace UnityEditor.ProBuilder
 			var instance = EditorToolbarLoader.GetInstance<FlipFaceEdge>();
 			if(instance != null && instance.enabled)
 			{
+				PreviewActionManager.EndPreview();
 				instance.PerformAction();
 				ProBuilderAnalytics.SendActionEvent(instance);
 			}
@@ -445,6 +461,7 @@ namespace UnityEditor.ProBuilder
 			var instance = EditorToolbarLoader.GetInstance<FlipFaceNormals>();
 			if(instance != null && instance.enabled)
 			{
+				PreviewActionManager.EndPreview();
 				instance.PerformAction();
 				ProBuilderAnalytics.SendActionEvent(instance);
 			}
@@ -464,6 +481,7 @@ namespace UnityEditor.ProBuilder
 			var instance = EditorToolbarLoader.GetInstance<InsertEdgeLoop>();
 			if(instance != null && instance.enabled)
 			{
+				PreviewActionManager.EndPreview();
 				instance.PerformAction();
 				ProBuilderAnalytics.SendActionEvent(instance);
 			}
@@ -483,6 +501,7 @@ namespace UnityEditor.ProBuilder
 			var instance = EditorToolbarLoader.GetInstance<MergeFaces>();
 			if(instance != null && instance.enabled)
 			{
+				PreviewActionManager.EndPreview();
 				instance.PerformAction();
 				ProBuilderAnalytics.SendActionEvent(instance);
 			}
@@ -521,6 +540,7 @@ namespace UnityEditor.ProBuilder
 			var instance = EditorToolbarLoader.GetInstance<SetPivotToSelection>();
 			if(instance != null && instance.enabled)
 			{
+				PreviewActionManager.EndPreview();
 				instance.PerformAction();
 				ProBuilderAnalytics.SendActionEvent(instance);
 			}
@@ -540,6 +560,7 @@ namespace UnityEditor.ProBuilder
 			var instance = EditorToolbarLoader.GetInstance<SmartConnect>();
 			if(instance != null && instance.enabled)
 			{
+				PreviewActionManager.EndPreview();
 				instance.PerformAction();
 				ProBuilderAnalytics.SendActionEvent(instance);
 			}
@@ -586,6 +607,7 @@ namespace UnityEditor.ProBuilder
 			var instance = EditorToolbarLoader.GetInstance<SplitVertices>();
 			if(instance != null && instance.enabled)
 			{
+				PreviewActionManager.EndPreview();
 				instance.PerformAction();
 				ProBuilderAnalytics.SendActionEvent(instance);
 			}
@@ -605,6 +627,7 @@ namespace UnityEditor.ProBuilder
 			var instance = EditorToolbarLoader.GetInstance<TriangulateFaces>();
 			if(instance != null && instance.enabled)
 			{
+				PreviewActionManager.EndPreview();
 				instance.PerformAction();
 				ProBuilderAnalytics.SendActionEvent(instance);
 			}
@@ -643,6 +666,7 @@ namespace UnityEditor.ProBuilder
 			var instance = EditorToolbarLoader.GetInstance<ToggleDragRectMode>();
 			if(instance != null && instance.enabled)
 			{
+				PreviewActionManager.EndPreview();
 				instance.PerformAction();
 				ProBuilderAnalytics.SendActionEvent(instance);
 			}
@@ -662,6 +686,7 @@ namespace UnityEditor.ProBuilder
 			var instance = EditorToolbarLoader.GetInstance<ToggleDragSelectionMode>();
 			if(instance != null && instance.enabled)
 			{
+				PreviewActionManager.EndPreview();
 				instance.PerformAction();
 				ProBuilderAnalytics.SendActionEvent(instance);
 			}
@@ -681,6 +706,7 @@ namespace UnityEditor.ProBuilder
 			var instance = EditorToolbarLoader.GetInstance<ToggleHandleOrientation>();
 			if(instance != null && instance.enabled)
 			{
+				PreviewActionManager.EndPreview();
 				instance.PerformAction();
 				ProBuilderAnalytics.SendActionEvent(instance);
 			}
@@ -700,6 +726,7 @@ namespace UnityEditor.ProBuilder
 			var instance = EditorToolbarLoader.GetInstance<ToggleSelectBackFaces>();
 			if(instance != null && instance.enabled)
 			{
+				PreviewActionManager.EndPreview();
 				instance.PerformAction();
 				ProBuilderAnalytics.SendActionEvent(instance);
 			}
@@ -719,6 +746,7 @@ namespace UnityEditor.ProBuilder
 			var instance = EditorToolbarLoader.GetInstance<ToggleXRay>();
 			if(instance != null && instance.enabled)
 			{
+				PreviewActionManager.EndPreview();
 				instance.PerformAction();
 				ProBuilderAnalytics.SendActionEvent(instance);
 			}
@@ -737,6 +765,7 @@ namespace UnityEditor.ProBuilder
 			var instance = EditorToolbarLoader.GetInstance<CenterPivot>();
 			if(instance != null && instance.enabled)
 			{
+				PreviewActionManager.EndPreview();
 				instance.PerformAction();
 				ProBuilderAnalytics.SendActionEvent(instance);
 			}
@@ -755,6 +784,7 @@ namespace UnityEditor.ProBuilder
 			var instance = EditorToolbarLoader.GetInstance<ConformObjectNormals>();
 			if(instance != null && instance.enabled)
 			{
+				PreviewActionManager.EndPreview();
 				instance.PerformAction();
 				ProBuilderAnalytics.SendActionEvent(instance);
 			}
@@ -773,6 +803,7 @@ namespace UnityEditor.ProBuilder
 			var instance = EditorToolbarLoader.GetInstance<FlipObjectNormals>();
 			if(instance != null && instance.enabled)
 			{
+				PreviewActionManager.EndPreview();
 				instance.PerformAction();
 				ProBuilderAnalytics.SendActionEvent(instance);
 			}
@@ -791,6 +822,7 @@ namespace UnityEditor.ProBuilder
 			var instance = EditorToolbarLoader.GetInstance<FreezeTransform>();
 			if(instance != null && instance.enabled)
 			{
+				PreviewActionManager.EndPreview();
 				instance.PerformAction();
 				ProBuilderAnalytics.SendActionEvent(instance);
 			}
@@ -809,6 +841,7 @@ namespace UnityEditor.ProBuilder
 			var instance = EditorToolbarLoader.GetInstance<MergeObjects>();
 			if(instance != null && instance.enabled)
 			{
+				PreviewActionManager.EndPreview();
 				instance.PerformAction();
 				ProBuilderAnalytics.SendActionEvent(instance);
 			}
@@ -863,6 +896,7 @@ namespace UnityEditor.ProBuilder
 			var instance = EditorToolbarLoader.GetInstance<SetCollider>();
 			if(instance != null && instance.enabled)
 			{
+				PreviewActionManager.EndPreview();
 				instance.PerformAction();
 				ProBuilderAnalytics.SendActionEvent(instance);
 			}
@@ -881,6 +915,7 @@ namespace UnityEditor.ProBuilder
 			var instance = EditorToolbarLoader.GetInstance<SetTrigger>();
 			if(instance != null && instance.enabled)
 			{
+				PreviewActionManager.EndPreview();
 				instance.PerformAction();
 				ProBuilderAnalytics.SendActionEvent(instance);
 			}
@@ -899,6 +934,7 @@ namespace UnityEditor.ProBuilder
 			var instance = EditorToolbarLoader.GetInstance<SubdivideObject>();
 			if(instance != null && instance.enabled)
 			{
+				PreviewActionManager.EndPreview();
 				instance.PerformAction();
 				ProBuilderAnalytics.SendActionEvent(instance);
 			}
@@ -917,6 +953,7 @@ namespace UnityEditor.ProBuilder
 			var instance = EditorToolbarLoader.GetInstance<TriangulateObject>();
 			if(instance != null && instance.enabled)
 			{
+				PreviewActionManager.EndPreview();
 				instance.PerformAction();
 				ProBuilderAnalytics.SendActionEvent(instance);
 			}
@@ -955,6 +992,7 @@ namespace UnityEditor.ProBuilder
 			var instance = EditorToolbarLoader.GetInstance<SelectHole>();
 			if(instance != null && instance.enabled)
 			{
+				PreviewActionManager.EndPreview();
 				instance.PerformAction();
 				ProBuilderAnalytics.SendActionEvent(instance);
 			}
@@ -1047,7 +1085,7 @@ namespace UnityEditor.ProBuilder
 			var instance = EditorToolbarLoader.GetInstance<SelectSmoothingGroup>();
 			if(instance != null && instance.enabled)
 			{
-				instance.PerformAction();
+				EditorAction.Start(new MenuActionSettings(instance,true));
 				ProBuilderAnalytics.SendActionEvent(instance);
 			}
 		}
@@ -1085,6 +1123,7 @@ namespace UnityEditor.ProBuilder
 			var instance = EditorToolbarLoader.GetInstance<ShrinkSelection>();
 			if(instance != null && instance.enabled)
 			{
+				PreviewActionManager.EndPreview();
 				instance.PerformAction();
 				ProBuilderAnalytics.SendActionEvent(instance);
 			}

--- a/Editor/MenuActions/Geometry/BevelEdges.cs
+++ b/Editor/MenuActions/Geometry/BevelEdges.cs
@@ -45,7 +45,7 @@ namespace UnityEditor.ProBuilder.Actions
 
             var floatField = new FloatField(gc_BevelDistance.text);
             floatField.tooltip = gc_BevelDistance.tooltip;
-            floatField.isDelayed = PreviewActionManager.autoUpdatePreview;
+            floatField.isDelayed = PreviewActionManager.delayedPreview;
             floatField.SetValueWithoutNotify(m_BevelSize.value);
             floatField.RegisterCallback<ChangeEvent<float>>(evt =>
             {

--- a/Editor/MenuActions/Geometry/BevelEdges.cs
+++ b/Editor/MenuActions/Geometry/BevelEdges.cs
@@ -45,7 +45,7 @@ namespace UnityEditor.ProBuilder.Actions
 
             var floatField = new FloatField(gc_BevelDistance.text);
             floatField.tooltip = gc_BevelDistance.tooltip;
-            floatField.isDelayed = true;
+            floatField.isDelayed = PreviewActionManager.autoUpdatePreview;
             floatField.SetValueWithoutNotify(m_BevelSize.value);
             floatField.RegisterCallback<ChangeEvent<float>>(evt =>
             {
@@ -58,6 +58,7 @@ namespace UnityEditor.ProBuilder.Actions
                     }
                     else
                         m_BevelSize.SetValue(evt.newValue);
+                    PreviewActionManager.UpdatePreview();
                 }
             });
             root.Add(floatField);

--- a/Editor/MenuActions/Geometry/CollapseVertices.cs
+++ b/Editor/MenuActions/Geometry/CollapseVertices.cs
@@ -57,6 +57,7 @@ namespace UnityEditor.ProBuilder.Actions
             toggle.RegisterCallback<ChangeEvent<bool>>(evt =>
             {
                 m_CollapseToFirst.SetValue(evt.newValue);
+                PreviewActionManager.UpdatePreview();
             });
             root.Add(toggle);
 

--- a/Editor/MenuActions/Geometry/CollapseVertices.cs
+++ b/Editor/MenuActions/Geometry/CollapseVertices.cs
@@ -57,6 +57,7 @@ namespace UnityEditor.ProBuilder.Actions
             toggle.RegisterCallback<ChangeEvent<bool>>(evt =>
             {
                 m_CollapseToFirst.SetValue(evt.newValue);
+
                 PreviewActionManager.UpdatePreview();
             });
             root.Add(toggle);

--- a/Editor/MenuActions/Geometry/DetachFaces.cs
+++ b/Editor/MenuActions/Geometry/DetachFaces.cs
@@ -108,10 +108,7 @@ namespace UnityEditor.ProBuilder.Actions
                 count += pb.selectedFaceCount;
             }
 
-            using (new PreviewActionManager.SelectionScope())
-            {
-                ProBuilderEditor.Refresh();
-            }
+            ProBuilderEditor.Refresh();
 
             if (count > 0)
                 return new ActionResult(ActionResult.Status.Success, "Detach " + count + (count > 1 ? " Faces" : " Face"));
@@ -173,11 +170,8 @@ namespace UnityEditor.ProBuilder.Actions
                 detached.Add(copy.gameObject);
             }
 
-            using (new PreviewActionManager.SelectionScope())
-            {
-                MeshSelection.SetSelection(detached);
-                ProBuilderEditor.Refresh();
-            }
+            MeshSelection.SetSelection(detached);
+            ProBuilderEditor.Refresh();
 
             if (detachedFaceCount > 0)
                 return new ActionResult(ActionResult.Status.Success, "Detach " + detachedFaceCount + " faces to new Object");

--- a/Editor/MenuActions/Geometry/DetachFaces.cs
+++ b/Editor/MenuActions/Geometry/DetachFaces.cs
@@ -54,6 +54,7 @@ namespace UnityEditor.ProBuilder.Actions
             {
                 Enum.TryParse(evt.newValue, out DetachSetting newValue);
                 m_DetachSetting.SetValue(newValue);
+                PreviewActionManager.UpdatePreview();
             });
             root.Add(detachFace);
 

--- a/Editor/MenuActions/Geometry/DetachFaces.cs
+++ b/Editor/MenuActions/Geometry/DetachFaces.cs
@@ -108,7 +108,10 @@ namespace UnityEditor.ProBuilder.Actions
                 count += pb.selectedFaceCount;
             }
 
-            ProBuilderEditor.Refresh();
+            using (new PreviewActionManager.SelectionScope())
+            {
+                ProBuilderEditor.Refresh();
+            }
 
             if (count > 0)
                 return new ActionResult(ActionResult.Status.Success, "Detach " + count + (count > 1 ? " Faces" : " Face"));
@@ -170,8 +173,11 @@ namespace UnityEditor.ProBuilder.Actions
                 detached.Add(copy.gameObject);
             }
 
-            MeshSelection.SetSelection(detached);
-            ProBuilderEditor.Refresh();
+            using (new PreviewActionManager.SelectionScope())
+            {
+                MeshSelection.SetSelection(detached);
+                ProBuilderEditor.Refresh();
+            }
 
             if (detachedFaceCount > 0)
                 return new ActionResult(ActionResult.Status.Success, "Detach " + detachedFaceCount + " faces to new Object");

--- a/Editor/MenuActions/Geometry/DetachFaces.cs
+++ b/Editor/MenuActions/Geometry/DetachFaces.cs
@@ -48,13 +48,12 @@ namespace UnityEditor.ProBuilder.Actions
         {
             var root = new VisualElement();
 
-            var detachFace = new EnumField("Duplicate To", m_DetachSetting);
+            var detachFace = new EnumField("Detach To", m_DetachSetting);
             detachFace.tooltip = "You can create a new Game Object with the selected face(s), or keep them as part of this object by using a Submesh.";
             detachFace.RegisterCallback<ChangeEvent<string>>(evt =>
             {
                 Enum.TryParse(evt.newValue, out DetachSetting newValue);
                 m_DetachSetting.SetValue(newValue);
-                PreviewActionManager.UpdatePreview();
             });
             root.Add(detachFace);
 

--- a/Editor/MenuActions/Geometry/DuplicateFaces.cs
+++ b/Editor/MenuActions/Geometry/DuplicateFaces.cs
@@ -58,6 +58,8 @@ namespace UnityEditor.ProBuilder.Actions
 
                 m_DuplicateFaceSetting.value = newValue;
                 ProBuilderSettings.Save();
+
+                PreviewActionManager.UpdatePreview();
             });
             root.Add(duplicateType);
 

--- a/Editor/MenuActions/Geometry/DuplicateFaces.cs
+++ b/Editor/MenuActions/Geometry/DuplicateFaces.cs
@@ -112,7 +112,10 @@ namespace UnityEditor.ProBuilder.Actions
                 count += pb.selectedFaceCount;
             }
 
-            ProBuilderEditor.Refresh();
+            using (new PreviewActionManager.SelectionScope())
+            {
+                ProBuilderEditor.Refresh();
+            }
 
             if (count > 0)
                 return new ActionResult(ActionResult.Status.Success, "Duplicate " + count + (count > 1 ? " Faces" : " Face"));
@@ -165,9 +168,11 @@ namespace UnityEditor.ProBuilder.Actions
                 duplicated.Add(copy.gameObject);
             }
 
-            MeshSelection.SetSelection(duplicated);
-            PreviewActionManager.selectionChangedByAction = true;
-            ProBuilderEditor.Refresh();
+            using (new PreviewActionManager.SelectionScope())
+            {
+                MeshSelection.SetSelection(duplicated);
+                ProBuilderEditor.Refresh();
+            }
 
             if (duplicatedFaceCount > 0)
                 return new ActionResult(ActionResult.Status.Success, "Duplicate " + duplicatedFaceCount + " faces to new Object");

--- a/Editor/MenuActions/Geometry/DuplicateFaces.cs
+++ b/Editor/MenuActions/Geometry/DuplicateFaces.cs
@@ -112,10 +112,7 @@ namespace UnityEditor.ProBuilder.Actions
                 count += pb.selectedFaceCount;
             }
 
-            using (new PreviewActionManager.SelectionScope())
-            {
-                ProBuilderEditor.Refresh();
-            }
+            ProBuilderEditor.Refresh();
 
             if (count > 0)
                 return new ActionResult(ActionResult.Status.Success, "Duplicate " + count + (count > 1 ? " Faces" : " Face"));
@@ -168,11 +165,8 @@ namespace UnityEditor.ProBuilder.Actions
                 duplicated.Add(copy.gameObject);
             }
 
-            using (new PreviewActionManager.SelectionScope())
-            {
-                MeshSelection.SetSelection(duplicated);
-                ProBuilderEditor.Refresh();
-            }
+            MeshSelection.SetSelection(duplicated);
+            ProBuilderEditor.Refresh();
 
             if (duplicatedFaceCount > 0)
                 return new ActionResult(ActionResult.Status.Success, "Duplicate " + duplicatedFaceCount + " faces to new Object");

--- a/Editor/MenuActions/Geometry/DuplicateFaces.cs
+++ b/Editor/MenuActions/Geometry/DuplicateFaces.cs
@@ -58,8 +58,6 @@ namespace UnityEditor.ProBuilder.Actions
 
                 m_DuplicateFaceSetting.value = newValue;
                 ProBuilderSettings.Save();
-
-                PreviewActionManager.UpdatePreview();
             });
             root.Add(duplicateType);
 
@@ -168,6 +166,7 @@ namespace UnityEditor.ProBuilder.Actions
             }
 
             MeshSelection.SetSelection(duplicated);
+            PreviewActionManager.selectionChangedByAction = true;
             ProBuilderEditor.Refresh();
 
             if (duplicatedFaceCount > 0)

--- a/Editor/MenuActions/Geometry/ExtrudeEdges.cs
+++ b/Editor/MenuActions/Geometry/ExtrudeEdges.cs
@@ -49,7 +49,7 @@ namespace UnityEditor.ProBuilder.Actions
             root.Add(toggle);
 
             var floatField = new FloatField("Distance");
-            floatField.isDelayed = true;
+            floatField.isDelayed = PreviewActionManager.autoUpdatePreview;
             floatField.tooltip = "Extrude Amount determines how far an edge will be moved along it's normal when extruding. This value can be negative.";
             floatField.SetValueWithoutNotify(m_ExtrudeEdgeDistance);
             floatField.RegisterCallback<ChangeEvent<float>>(OnExtrudeChanged);
@@ -61,11 +61,13 @@ namespace UnityEditor.ProBuilder.Actions
         void OnEdgesAsGroupChanged(ChangeEvent<bool> evt)
         {
             VertexManipulationTool.s_ExtrudeEdgesAsGroup.SetValue(evt.newValue);
+            PreviewActionManager.UpdatePreview();
         }
 
         void OnExtrudeChanged(ChangeEvent<float> evt)
         {
             m_ExtrudeEdgeDistance.SetValue(evt.newValue);
+            PreviewActionManager.UpdatePreview();
         }
 
         protected override void OnSettingsGUI()

--- a/Editor/MenuActions/Geometry/ExtrudeEdges.cs
+++ b/Editor/MenuActions/Geometry/ExtrudeEdges.cs
@@ -49,7 +49,7 @@ namespace UnityEditor.ProBuilder.Actions
             root.Add(toggle);
 
             var floatField = new FloatField("Distance");
-            floatField.isDelayed = PreviewActionManager.autoUpdatePreview;
+            floatField.isDelayed = PreviewActionManager.delayedPreview;
             floatField.tooltip = "Extrude Amount determines how far an edge will be moved along it's normal when extruding. This value can be negative.";
             floatField.SetValueWithoutNotify(m_ExtrudeEdgeDistance);
             floatField.RegisterCallback<ChangeEvent<float>>(OnExtrudeChanged);

--- a/Editor/MenuActions/Geometry/ExtrudeFaces.cs
+++ b/Editor/MenuActions/Geometry/ExtrudeFaces.cs
@@ -85,6 +85,7 @@ namespace UnityEditor.ProBuilder.Actions
                     extrudeMethod = newValue;
                     extrudeMethodLabel.style.backgroundImage = m_Icons[(int)extrudeMethod];
                     ProBuilderSettings.Save();
+                    PreviewActionManager.UpdatePreview();
                 }
             });
             extrudeMethodField.style.flexGrow = 1;
@@ -97,10 +98,11 @@ namespace UnityEditor.ProBuilder.Actions
             var distanceField = new FloatField("Distance");
             distanceField.tooltip = "Extrude Amount determines how far a face will be moved along it's normal when extruding. This value can be negative.";
             distanceField.SetValueWithoutNotify(m_ExtrudeDistance.value);
-            distanceField.isDelayed = true;
+            distanceField.isDelayed = PreviewActionManager.autoUpdatePreview;
             distanceField.RegisterCallback<ChangeEvent<float>>(evt =>
             {
                 m_ExtrudeDistance.SetValue(evt.newValue);
+                PreviewActionManager.UpdatePreview();
             });
             root.Add(distanceField);
 

--- a/Editor/MenuActions/Geometry/ExtrudeFaces.cs
+++ b/Editor/MenuActions/Geometry/ExtrudeFaces.cs
@@ -98,7 +98,7 @@ namespace UnityEditor.ProBuilder.Actions
             var distanceField = new FloatField("Distance");
             distanceField.tooltip = "Extrude Amount determines how far a face will be moved along it's normal when extruding. This value can be negative.";
             distanceField.SetValueWithoutNotify(m_ExtrudeDistance.value);
-            distanceField.isDelayed = PreviewActionManager.autoUpdatePreview;
+            distanceField.isDelayed = PreviewActionManager.delayedPreview;
             distanceField.RegisterCallback<ChangeEvent<float>>(evt =>
             {
                 m_ExtrudeDistance.SetValue(evt.newValue);

--- a/Editor/MenuActions/Geometry/FillHole.cs
+++ b/Editor/MenuActions/Geometry/FillHole.cs
@@ -64,6 +64,7 @@ namespace UnityEditor.ProBuilder.Actions
         void OnFillHoleToggleChanged(ChangeEvent<bool> evt)
         {
             m_SelectEntirePath.SetValue(evt.newValue);
+            PreviewActionManager.UpdatePreview();
         }
 
         protected override void OnSettingsGUI()

--- a/Editor/MenuActions/Geometry/OffsetElements.cs
+++ b/Editor/MenuActions/Geometry/OffsetElements.cs
@@ -57,14 +57,18 @@ namespace UnityEditor.ProBuilder.Actions
                 if (s_CoordinateSpace.value == newValue)
                     return;
                 s_CoordinateSpace.SetValue(newValue);
+                PreviewActionManager.UpdatePreview();
             });
 
             var distField = new Vector3Field("Translate");
             distField.SetValueWithoutNotify(dist);
+            if(PreviewActionManager.autoUpdatePreview)
+                distField.Query<FloatField>().ForEach(ff => ff.isDelayed = true);
             root.Add(distField);
             distField.RegisterCallback<ChangeEvent<Vector3>>(evt =>
             {
                 s_Translation.SetValue(evt.newValue, true);
+                PreviewActionManager.UpdatePreview();
             });
 
             return root;

--- a/Editor/MenuActions/Geometry/OffsetElements.cs
+++ b/Editor/MenuActions/Geometry/OffsetElements.cs
@@ -62,7 +62,7 @@ namespace UnityEditor.ProBuilder.Actions
 
             var distField = new Vector3Field("Translate");
             distField.SetValueWithoutNotify(dist);
-            if(PreviewActionManager.autoUpdatePreview)
+            if(PreviewActionManager.delayedPreview)
                 distField.Query<FloatField>().ForEach(ff => ff.isDelayed = true);
             root.Add(distField);
             distField.RegisterCallback<ChangeEvent<Vector3>>(evt =>

--- a/Editor/MenuActions/Geometry/SubdivideEdges.cs
+++ b/Editor/MenuActions/Geometry/SubdivideEdges.cs
@@ -78,7 +78,7 @@ namespace UnityEditor.ProBuilder.Actions
             m_Slider.RegisterCallback<ChangeEvent<int>>(OnSliderChanged);
             m_Slider.style.flexGrow = 1f;
             m_SubdivCount = new IntegerField();
-            m_SubdivCount.isDelayed = PreviewActionManager.autoUpdatePreview;
+            m_SubdivCount.isDelayed = PreviewActionManager.delayedPreview;
             m_SubdivCount.SetValueWithoutNotify(m_SubdivisionCount.value);
             m_SubdivCount.tooltip = tooltip;
             m_SubdivCount.RegisterCallback<ChangeEvent<int>>(OnCountChanged);

--- a/Editor/MenuActions/Geometry/SubdivideEdges.cs
+++ b/Editor/MenuActions/Geometry/SubdivideEdges.cs
@@ -78,7 +78,7 @@ namespace UnityEditor.ProBuilder.Actions
             m_Slider.RegisterCallback<ChangeEvent<int>>(OnSliderChanged);
             m_Slider.style.flexGrow = 1f;
             m_SubdivCount = new IntegerField();
-            m_SubdivCount.isDelayed = true;
+            m_SubdivCount.isDelayed = PreviewActionManager.autoUpdatePreview;
             m_SubdivCount.SetValueWithoutNotify(m_SubdivisionCount.value);
             m_SubdivCount.tooltip = tooltip;
             m_SubdivCount.RegisterCallback<ChangeEvent<int>>(OnCountChanged);
@@ -143,6 +143,7 @@ namespace UnityEditor.ProBuilder.Actions
 
             m_SubdivisionCount.SetValue(evt.newValue);
             m_SubdivCount.SetValueWithoutNotify(m_SubdivisionCount.value);
+            PreviewActionManager.UpdatePreview();
         }
 
         void OnCountChanged(ChangeEvent<int> evt)
@@ -164,6 +165,7 @@ namespace UnityEditor.ProBuilder.Actions
                 m_RangeField.SetValueWithoutNotify(new Vector2Int(m_SubdivisionUIMin.value, m_SubdivisionUIMax.value));
             }
             m_Slider.SetValueWithoutNotify(m_SubdivisionCount.value);
+            PreviewActionManager.UpdatePreview();
         }
 
         void OnMinChanged(ChangeEvent<int> evt)
@@ -179,6 +181,7 @@ namespace UnityEditor.ProBuilder.Actions
                 m_SubdivisionCount.SetValue(m_SubdivisionUIMin.value);
                 m_SubdivCount.SetValueWithoutNotify(m_SubdivisionCount.value);
                 m_Slider.SetValueWithoutNotify(m_SubdivisionCount.value);
+                PreviewActionManager.UpdatePreview();
             }
         }
 
@@ -195,6 +198,7 @@ namespace UnityEditor.ProBuilder.Actions
                 m_SubdivisionCount.SetValue(m_SubdivisionUIMax.value);
                 m_SubdivCount.SetValueWithoutNotify(m_SubdivisionCount.value);
                 m_Slider.SetValueWithoutNotify(m_SubdivisionCount.value);
+                PreviewActionManager.UpdatePreview();
             }
         }
 

--- a/Editor/MenuActions/Geometry/WeldVertices.cs
+++ b/Editor/MenuActions/Geometry/WeldVertices.cs
@@ -54,7 +54,7 @@ namespace UnityEditor.ProBuilder.Actions
             root.style.minWidth = 150;
 
             var floatField = new FloatField(gc_weldDistance.text);
-            floatField.isDelayed = true;
+            floatField.isDelayed = PreviewActionManager.autoUpdatePreview;
             floatField.tooltip = gc_weldDistance.tooltip;
             floatField.SetValueWithoutNotify(m_WeldDistance);
             floatField.Q("unity-text-input").style.minWidth = 50;
@@ -67,6 +67,7 @@ namespace UnityEditor.ProBuilder.Actions
                 }
                 else
                     m_WeldDistance.SetValue(evt.newValue);
+                PreviewActionManager.UpdatePreview();
             });
             root.Add(floatField);
             return root;

--- a/Editor/MenuActions/Geometry/WeldVertices.cs
+++ b/Editor/MenuActions/Geometry/WeldVertices.cs
@@ -54,7 +54,7 @@ namespace UnityEditor.ProBuilder.Actions
             root.style.minWidth = 150;
 
             var floatField = new FloatField(gc_weldDistance.text);
-            floatField.isDelayed = PreviewActionManager.autoUpdatePreview;
+            floatField.isDelayed = PreviewActionManager.delayedPreview;
             floatField.tooltip = gc_weldDistance.tooltip;
             floatField.SetValueWithoutNotify(m_WeldDistance);
             floatField.Q("unity-text-input").style.minWidth = 50;

--- a/Editor/MenuActions/Object/MirrorObjects.cs
+++ b/Editor/MenuActions/Object/MirrorObjects.cs
@@ -150,12 +150,9 @@ namespace UnityEditor.ProBuilder.Actions
             foreach (ProBuilderMesh pb in MeshSelection.topInternal)
                 res.Add(Mirror(pb, scale, duplicate).gameObject);
 
-            using (new PreviewActionManager.SelectionScope())
-            {
-                PreviewActionManager.disableSelectionUpdate = true;
-                MeshSelection.SetSelection(res);
-                ProBuilderEditor.Refresh();
-            }
+            MeshSelection.SetSelection(res);
+            PreviewActionManager.selectionUpdateDisabled = true;
+            ProBuilderEditor.Refresh();
 
             return res.Count > 0 ?
                 new ActionResult(ActionResult.Status.Success, string.Format("Mirror {0} {1}", res.Count, res.Count > 1 ? "Objects" : "Object")) :

--- a/Editor/MenuActions/Object/MirrorObjects.cs
+++ b/Editor/MenuActions/Object/MirrorObjects.cs
@@ -145,8 +145,6 @@ namespace UnityEditor.ProBuilder.Actions
                     (m_MirrorAxes & MirrorSettings.Z) > 0 ? -1f : 1f);
 
             bool duplicate = (m_MirrorAxes & MirrorSettings.Duplicate) != 0;
-            Debug.Log("Duplicate ? "+duplicate);
-
             List<GameObject> res  = new List<GameObject>();
 
             foreach (ProBuilderMesh pb in MeshSelection.topInternal)

--- a/Editor/MenuActions/Object/MirrorObjects.cs
+++ b/Editor/MenuActions/Object/MirrorObjects.cs
@@ -64,29 +64,41 @@ namespace UnityEditor.ProBuilder.Actions
             var toggle = new Toggle("X");
             toggle.tooltip = tooltip;
             toggle.SetValueWithoutNotify(x);
-            toggle.RegisterValueChangedCallback( evt =>
-                m_MirrorAxes.SetValue((evt.newValue ? MirrorSettings.X : 0) | (y ? MirrorSettings.Y : 0) | (z ? MirrorSettings.Z : 0) | (d ? MirrorSettings.Duplicate : 0)));
+            toggle.RegisterValueChangedCallback(evt =>
+            {
+                m_MirrorAxes.SetValue((evt.newValue ? MirrorSettings.X : 0) | m_MirrorAxes & MirrorSettings.Y | m_MirrorAxes & MirrorSettings.Z | m_MirrorAxes & MirrorSettings.Duplicate);
+                PreviewActionManager.UpdatePreview();
+            });
             root.Add(toggle);
 
             toggle = new Toggle("Y");
             toggle.tooltip = tooltip;
             toggle.SetValueWithoutNotify(y);
-            toggle.RegisterValueChangedCallback( evt =>
-                m_MirrorAxes.SetValue((x ? MirrorSettings.X : 0) | (evt.newValue ? MirrorSettings.Y : 0) | (z ? MirrorSettings.Z : 0) | (d ? MirrorSettings.Duplicate : 0)));
+            toggle.RegisterValueChangedCallback(evt =>
+            {
+                m_MirrorAxes.SetValue(m_MirrorAxes & MirrorSettings.X | (evt.newValue ? MirrorSettings.Y : 0) | m_MirrorAxes & MirrorSettings.Z | m_MirrorAxes & MirrorSettings.Duplicate);
+                PreviewActionManager.UpdatePreview();
+            });
             root.Add(toggle);
 
             toggle = new Toggle("Z");
             toggle.tooltip = tooltip;
             toggle.SetValueWithoutNotify(z);
-            toggle.RegisterValueChangedCallback( evt =>
-                m_MirrorAxes.SetValue((x ? MirrorSettings.X : 0) | (y ? MirrorSettings.Y : 0) | (evt.newValue ? MirrorSettings.Z : 0) | (d ? MirrorSettings.Duplicate : 0)));
+            toggle.RegisterValueChangedCallback(evt =>
+            {
+                m_MirrorAxes.SetValue(m_MirrorAxes & MirrorSettings.X | m_MirrorAxes & MirrorSettings.Y | (evt.newValue ? MirrorSettings.Z : 0) | m_MirrorAxes & MirrorSettings.Duplicate);
+                PreviewActionManager.UpdatePreview();
+            });
             root.Add(toggle);
 
             toggle = new Toggle("Duplicate");
             toggle.tooltip = "If Duplicate is toggled a new object will be instantiated from the selection and mirrored, or if disabled the selection will be moved.";
             toggle.SetValueWithoutNotify(d);
-            toggle.RegisterValueChangedCallback( evt =>
-                m_MirrorAxes.SetValue((x ? MirrorSettings.X : 0) | (y ? MirrorSettings.Y : 0) | (z ? MirrorSettings.Z : 0) | (evt.newValue ? MirrorSettings.Duplicate : 0)));
+            toggle.RegisterValueChangedCallback(evt =>
+            {
+                m_MirrorAxes.SetValue(m_MirrorAxes & MirrorSettings.X | m_MirrorAxes & MirrorSettings.Y | m_MirrorAxes & MirrorSettings.Z | (evt.newValue ? MirrorSettings.Duplicate : 0));
+                PreviewActionManager.UpdatePreview();
+            });
             root.Add(toggle);
 
             return root;
@@ -100,10 +112,10 @@ namespace UnityEditor.ProBuilder.Actions
 
             MirrorSettings scale = m_MirrorAxes;
 
-            bool x = (scale & MirrorSettings.X) != 0 ? true : false;
-            bool y = (scale & MirrorSettings.Y) != 0 ? true : false;
-            bool z = (scale & MirrorSettings.Z) != 0 ? true : false;
-            bool d = (scale & MirrorSettings.Duplicate) != 0 ? true : false;
+            bool x = (scale & MirrorSettings.X) != 0;
+            bool y = (scale & MirrorSettings.Y) != 0;
+            bool z = (scale & MirrorSettings.Z) != 0;
+            bool d = (scale & MirrorSettings.Duplicate) != 0;
 
             EditorGUI.BeginChangeCheck();
 
@@ -132,7 +144,8 @@ namespace UnityEditor.ProBuilder.Actions
                     (m_MirrorAxes & MirrorSettings.Y) > 0 ? -1f : 1f,
                     (m_MirrorAxes & MirrorSettings.Z) > 0 ? -1f : 1f);
 
-            bool duplicate = (m_MirrorAxes & MirrorSettings.Duplicate) > 0;
+            bool duplicate = (m_MirrorAxes & MirrorSettings.Duplicate) != 0;
+            Debug.Log("Duplicate ? "+duplicate);
 
             List<GameObject> res  = new List<GameObject>();
 
@@ -140,7 +153,7 @@ namespace UnityEditor.ProBuilder.Actions
                 res.Add(Mirror(pb, scale, duplicate).gameObject);
 
             MeshSelection.SetSelection(res);
-            MenuActionSettingsOverlay.selectionChangedByAction = true;
+            PreviewActionManager.selectionChangedByAction = true;
 
             ProBuilderEditor.Refresh();
 

--- a/Editor/MenuActions/Object/MirrorObjects.cs
+++ b/Editor/MenuActions/Object/MirrorObjects.cs
@@ -140,20 +140,22 @@ namespace UnityEditor.ProBuilder.Actions
         protected override ActionResult PerformActionImplementation()
         {
             Vector3 scale = new Vector3(
-                    (m_MirrorAxes & MirrorSettings.X) > 0 ? -1f : 1f,
-                    (m_MirrorAxes & MirrorSettings.Y) > 0 ? -1f : 1f,
-                    (m_MirrorAxes & MirrorSettings.Z) > 0 ? -1f : 1f);
+                (m_MirrorAxes & MirrorSettings.X) > 0 ? -1f : 1f,
+                (m_MirrorAxes & MirrorSettings.Y) > 0 ? -1f : 1f,
+                (m_MirrorAxes & MirrorSettings.Z) > 0 ? -1f : 1f);
 
             bool duplicate = (m_MirrorAxes & MirrorSettings.Duplicate) != 0;
-            List<GameObject> res  = new List<GameObject>();
+            List<GameObject> res = new List<GameObject>();
 
             foreach (ProBuilderMesh pb in MeshSelection.topInternal)
                 res.Add(Mirror(pb, scale, duplicate).gameObject);
 
-            MeshSelection.SetSelection(res);
-            PreviewActionManager.selectionChangedByAction = true;
-
-            ProBuilderEditor.Refresh();
+            using (new PreviewActionManager.SelectionScope())
+            {
+                PreviewActionManager.disableSelectionUpdate = true;
+                MeshSelection.SetSelection(res);
+                ProBuilderEditor.Refresh();
+            }
 
             return res.Count > 0 ?
                 new ActionResult(ActionResult.Status.Success, string.Format("Mirror {0} {1}", res.Count, res.Count > 1 ? "Objects" : "Object")) :

--- a/Editor/MenuActions/Selection/GrowSelection.cs
+++ b/Editor/MenuActions/Selection/GrowSelection.cs
@@ -58,7 +58,7 @@ Grow by angle is enabled by Option + Clicking the <b>Grow Selection</b> button."
 
             var floatField = new FloatField("Max Angle");
             floatField.SetValueWithoutNotify(m_GrowSelectionAngleValue);
-            floatField.isDelayed = true;
+            floatField.isDelayed = PreviewActionManager.autoUpdatePreview;
             floatField.SetEnabled(m_GrowSelectionWithAngle);
             root.Add(floatField);
 
@@ -73,14 +73,17 @@ Grow by angle is enabled by Option + Clicking the <b>Grow Selection</b> button."
                 floatField.SetEnabled(m_GrowSelectionWithAngle);
                 iterativeToggle.SetValueWithoutNotify(m_GrowSelectionWithAngle ? m_GrowSelectionAngleIterative : true);
                 iterativeToggle.SetEnabled(m_GrowSelectionWithAngle);
+                PreviewActionManager.UpdatePreview();
             });
             floatField.RegisterValueChangedCallback(evt =>
             {
                 m_GrowSelectionAngleValue.SetValue(evt.newValue);
+                PreviewActionManager.UpdatePreview();
             });
             iterativeToggle.RegisterCallback<ChangeEvent<bool>>(evt =>
             {
                 m_GrowSelectionAngleIterative.SetValue(evt.newValue);
+                PreviewActionManager.UpdatePreview();
             });
 
             return root;

--- a/Editor/MenuActions/Selection/GrowSelection.cs
+++ b/Editor/MenuActions/Selection/GrowSelection.cs
@@ -45,20 +45,12 @@ Grow by angle is enabled by Option + Clicking the <b>Grow Selection</b> button."
             get { return base.enabled && VerifyGrowSelection(); }
         }
 
-        protected override MenuActionState optionsMenuState
-        {
-            get
-            {
-                if (enabled && ProBuilderEditor.selectMode == SelectMode.Face)
-                    return MenuActionState.VisibleAndEnabled;
-
-                return MenuActionState.Hidden;
-            }
-        }
+        protected override MenuActionState optionsMenuState => MenuActionState.VisibleAndEnabled;
 
         public override VisualElement CreateSettingsContent()
         {
             var root = new VisualElement();
+            root.enabledSelf = enabled && ProBuilderEditor.selectMode == SelectMode.Face;
 
             var angleToggle = new Toggle("Restrict to Angle");
             angleToggle.SetValueWithoutNotify(m_GrowSelectionWithAngle);

--- a/Editor/MenuActions/Selection/GrowSelection.cs
+++ b/Editor/MenuActions/Selection/GrowSelection.cs
@@ -58,7 +58,7 @@ Grow by angle is enabled by Option + Clicking the <b>Grow Selection</b> button."
 
             var floatField = new FloatField("Max Angle");
             floatField.SetValueWithoutNotify(m_GrowSelectionAngleValue);
-            floatField.isDelayed = PreviewActionManager.autoUpdatePreview;
+            floatField.isDelayed = PreviewActionManager.delayedPreview;
             floatField.SetEnabled(m_GrowSelectionWithAngle);
             root.Add(floatField);
 

--- a/Editor/MenuActions/Selection/SelectEdgeLoop.cs
+++ b/Editor/MenuActions/Selection/SelectEdgeLoop.cs
@@ -109,6 +109,7 @@ namespace UnityEditor.ProBuilder.Actions
             toggle.RegisterCallback<ChangeEvent<bool>>(evt =>
             {
                 m_SelectIterative.SetValue(evt.newValue);
+                PreviewActionManager.UpdatePreview();
             });
             root.Add(toggle);
 

--- a/Editor/MenuActions/Selection/SelectEdgeRing.cs
+++ b/Editor/MenuActions/Selection/SelectEdgeRing.cs
@@ -110,6 +110,7 @@ namespace UnityEditor.ProBuilder.Actions
             toggle.RegisterCallback<ChangeEvent<bool>>(evt =>
             {
                 m_SelectIterative.SetValue(evt.newValue);
+                PreviewActionManager.UpdatePreview();
             });
             root.Add(toggle);
 

--- a/Editor/MenuActions/Selection/SelectFaceLoop.cs
+++ b/Editor/MenuActions/Selection/SelectFaceLoop.cs
@@ -1,8 +1,6 @@
 using System.Collections.Generic;
 using UnityEngine;
-using System.Linq;
 using UnityEngine.ProBuilder;
-using UnityEditor.ProBuilder;
 using UnityEngine.ProBuilder.MeshOperations;
 
 namespace UnityEditor.ProBuilder.Actions

--- a/Editor/MenuActions/Selection/SelectMaterial.cs
+++ b/Editor/MenuActions/Selection/SelectMaterial.cs
@@ -55,6 +55,7 @@ namespace UnityEditor.ProBuilder.Actions
             toggle.RegisterCallback<ChangeEvent<bool>>(evt =>
             {
                 m_RestrictToSelectedObjects.SetValue(evt.newValue);
+                PreviewActionManager.UpdatePreview();
             });
             root.Add(toggle);
 

--- a/Editor/MenuActions/Selection/SelectVertexColor.cs
+++ b/Editor/MenuActions/Selection/SelectVertexColor.cs
@@ -59,6 +59,7 @@ namespace UnityEditor.ProBuilder.Actions
             toggle.RegisterCallback<ChangeEvent<bool>>(evt =>
             {
                 m_SearchSelectedObjectsOnly.SetValue(evt.newValue);
+                PreviewActionManager.UpdatePreview();
             });
             root.Add(toggle);
 

--- a/Editor/Overlays/ActionSettings.cs
+++ b/Editor/Overlays/ActionSettings.cs
@@ -72,6 +72,12 @@ namespace UnityEditor.ProBuilder
             SceneView.AddOverlayToActiveView(s_Overlay = new MenuActionSettingsOverlay());
         }
 
+        internal static void EndPreview()
+        {
+            if (s_CurrentAction != null)
+                Clear();
+        }
+
         static void Clear()
         {
             SceneView.RemoveOverlayFromActiveView(s_Overlay);

--- a/Editor/Overlays/ActionSettings.cs
+++ b/Editor/Overlays/ActionSettings.cs
@@ -104,19 +104,13 @@ namespace UnityEditor.ProBuilder
 
         internal static void UpdatePreview()
         {
-            Profiler.BeginSample("UpdatingPreview");
             //Undo action might be triggering a refresh of the mesh and of the selection, so we need to temporarily unregister to these events
             ProBuilderEditor.selectionUpdated -= OnSelectionUpdated;
             Selection.selectionChanged -= ObjectSelectionChanged;
-            Profiler.BeginSample("Undo");
             UndoUtility.StartPreview();
-            Profiler.EndSample();
-            Profiler.BeginSample("PerformAction");
             s_CurrentAction.PerformAction();
-            Profiler.EndSample();
             ProBuilderEditor.selectionUpdated += OnSelectionUpdated;
             Selection.selectionChanged += ObjectSelectionChanged;
-            Profiler.EndSample();
         }
     }
 
@@ -149,16 +143,6 @@ namespace UnityEditor.ProBuilder
 
             var settingsElement = PreviewActionManager.currentAction.CreateSettingsContent();
             root.Add(settingsElement);
-
-            if (PreviewActionManager.hasPreview)
-            {
-                var previewButton = new Button(PreviewActionManager.UpdatePreview);
-                previewButton.text = "Preview";
-                previewButton.style.flexDirection = FlexDirection.Row;
-                previewButton.style.flexGrow = 1;
-                root.Add(previewButton);
-            }
-
             root.Add(lastLine);
             return root;
         }


### PR DESCRIPTION
### Purpose of this PR

Regarding last week reviews, the main blocker for PB6 was the preview button, this was also casing inconsistencies between the parameter settings and the applied values...
This PR fixes that by improving live preview.
Also adding a parameter in case of dealing with large meshes and in that case only updating preview on mouse release/field edition.

![Unity_cOs9AfG39f](https://github.com/Unity-Technologies/com.unity.probuilder/assets/66317117/d80eaed2-2c5a-4a00-9227-12eea5cb2306)


**Jira:**

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]