### PR TITLE
Doc fix for 5.2+ to restore api docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [5.2.3] - 2023-12-12
+
+### Fixed
+
+- [WEBDOCS-1036] Fixed a documentation generation problem where a setting in the filter.yml file was preventing the ProBuilder API documentation from being generated.
+
 ## [5.2.2] - 2023-11-27
 
 ### Fixed

--- a/Documentation~/filter.yml
+++ b/Documentation~/filter.yml
@@ -11,9 +11,6 @@ apiRules:
       uidRegex: Tests(.Framework)$
       type: Namespace
   - exclude:
-      uidRegex: ^Global Namespace.*
-      type: Namespace
-  - exclude:
       uidRegex: ^ProBuilder.Example*
       type: Namespace
   - exclude:

--- a/Documentation~/projectMetadata.json
+++ b/Documentation~/projectMetadata.json
@@ -1,0 +1,3 @@
+{
+    "hideGlobalNamespace": true
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.probuilder",
   "displayName": "ProBuilder",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "unity": "2019.4",
   "description": "Build, edit, and texture custom geometry in Unity. Use ProBuilder for in-scene level design, prototyping, collision meshes, all with on-the-fly play-testing.\n\nAdvanced features include UV editing, vertex colors, parametric shapes, and texture blending. With ProBuilder's model export feature it's easy to tweak your levels in any external 3D modelling suite.\n\nIf you are using URP/HDRP, be careful to also import the corresponding sample project in the section below to get the proper materials.",
   "keywords": [


### PR DESCRIPTION
### Purpose of this PR

Fixed a documentation generation problem where a setting in the `filter.yml` file was preventing the ProBuilder API documentation from being generated with the newest version of the Package Manager DocTools package (v3.x).  

- Removed the lines to exclude the **Global Namespace** from the `filter.yml` file
- Enabled the `hideGlobalNamespace` setting in the `projectMetadata.json` file instead


### Links

**[WEBDOCS-1036](https://jira.unity3d.com/browse/WEBDOCS-1036)**

### Comments to Reviewers

No changes to code or doc content.

**Note**: The DocTools team republished the 5.2 docs as an exception so the API docs would be available immediately, but in case any more changes will be made I added a Changelog entry and bumped the version. If you prefer, I can remove those changes and just apply the filter changes. I will also need to backport these changes to the master branch so this doesn't happen to the 6.0 docs too but I'll raise a separate PR on the master branch for that.