### PR TITLE
WEBDOCS-1036: Backported fix for filtered API docs

### DIFF
--- a/Documentation~/filter.yml
+++ b/Documentation~/filter.yml
@@ -11,9 +11,6 @@ apiRules:
       uidRegex: Tests(.Framework)$
       type: Namespace
   - exclude:
-      uidRegex: ^Global Namespace.*
-      type: Namespace
-  - exclude:
       uidRegex: ^ProBuilder.Example*
       type: Namespace
   - exclude:

--- a/Documentation~/projectMetadata.json
+++ b/Documentation~/projectMetadata.json
@@ -1,0 +1,3 @@
+{
+    "hideGlobalNamespace": true
+}


### PR DESCRIPTION
Backported fix for filtered API docs from `5.2/doc-filter-update` branch

### Purpose of this PR

Backported the change from [PR#496](https://github.com/Unity-Technologies/com.unity.probuilder/pull/496) to fix the problem with filtering out the ProBuilder API docs with the newer version of the Package Manager DocTools package (v3.x):

- Removed the lines to exclude the **Global Namespace** from the `filter.yml` file
- Enabled the `hideGlobalNamespace` setting in the `projectMetadata.json` file instead

### Links

**[WEBDOCS-1036](https://jira.unity3d.com/browse/WEBDOCS-1036)**

### Comments to Reviewers

No changes to code or doc content.

I didn't include a changelog entry or patch bump here since this is applied to an unpublished version, but I am happy to do that if you want.