### PR TITLE
Update PB6 lowest supported editor version

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "com.unity.probuilder",
   "displayName": "ProBuilder",
   "version": "6.0.1",
-  "unity": "2023.3",
+  "unity": "6000.0",
   "description": "Build, edit, and texture custom geometry in Unity. Use ProBuilder for in-scene level design, prototyping, collision meshes, all with on-the-fly play-testing.\n\nAdvanced features include UV editing, vertex colors, parametric shapes, and texture blending. With ProBuilder's model export feature it's easy to tweak your levels in any external 3D modelling suite.",
   "keywords": [
     "3d",


### PR DESCRIPTION
### Purpose of this PR

Updated the lowest Unity version the package is compatible with.

Making publish to internal registry happy as otherwise:
```
[19:37:41.808 Information] [UPM-CI-UTILS] ERROR - It doesn't look like any tests were run on Unity editor version 2023.3 that's currently defined in the package manifest.
[19:37:41.809 Information] [UPM-CI-UTILS] ERROR - Tests were run on the following Unity editor versions: 6000.0
[UPM-CI-UTILS] ERROR - Please ensure your package has been tested against the same Unity editor version as specified in your package manifest's "unity" field before publishing.

```
### Links

**Jira:**

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]