### PR TITLE
[PB6] Create PolyShape tool improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+
+### Fixed
+
+- [PBLD-113] Fixed a bug where the Polyshape tool would create temporary objects in the hierarchy.
+
 ## [6.0.1-pre.2] - 2024-02-16
 
 ### Fixed

--- a/Editor/EditorCore/PolyShapeTool.cs
+++ b/Editor/EditorCore/PolyShapeTool.cs
@@ -19,6 +19,8 @@ namespace UnityEditor.ProBuilder
     [Icon("Packages/com.unity.probuilder/Content/Icons/Toolbar/CreatePolyShape.png")]
     public class DrawPolyShapeTool : PolyShapeTool
     {
+        GameObject m_LastPolyShape = null;
+
         [MenuItem(EditorToolbarMenuItem.k_MenuPrefix + "Editors/New PolyShape", false, PreferenceKeys.menuEditor + 1)]
         static void MenuPerform_NewShape()
         {
@@ -39,6 +41,8 @@ namespace UnityEditor.ProBuilder
         public override void OnWillBeDeactivated()
         {
             m_PolyShape = null;
+            if (m_LastPolyShape)
+                Selection.activeObject = m_LastPolyShape;
             base.OnWillBeDeactivated();
         }
 
@@ -62,6 +66,8 @@ namespace UnityEditor.ProBuilder
                     UndoUtility.RecordObject(polygon, "Set Height");
 
                     SetPolyEditMode(PolyShape.PolyEditMode.None);
+                    polygon.gameObject.hideFlags = HideFlags.None;
+                    m_LastPolyShape = polygon.gameObject;
                     polygon = null;
 
                     if (!TryCreatePolyShape())
@@ -102,6 +108,7 @@ namespace UnityEditor.ProBuilder
             if (newPolyshape)
             {
                 GameObject go = new GameObject("PolyShape");
+                go.hideFlags = HideFlags.HideAndDontSave | HideFlags.HideInInspector;
                 UndoUtility.RegisterCreatedObjectUndo(go, "Create Poly Shape");
                 m_PolyShape = Undo.AddComponent<PolyShape>(go);
                 ProBuilderMesh pb = Undo.AddComponent<ProBuilderMesh>(go);

--- a/Editor/EditorCore/PolyShapeTool.cs
+++ b/Editor/EditorCore/PolyShapeTool.cs
@@ -32,9 +32,9 @@ namespace UnityEditor.ProBuilder
 
         public override void OnActivated()
         {
+            m_LastPolyShape = null;
             MeshSelection.SetSelection((GameObject)null);
             ToolManager.SetActiveContext<GameObjectToolContext>();
-
             base.OnActivated();
         }
 
@@ -83,13 +83,14 @@ namespace UnityEditor.ProBuilder
 
         protected override void OnObjectSelectionChanged()
         {
-            if(polygon == null)
+            if(Selection.activeObject != null && polygon == null)
             {
                 ToolManager.RestorePreviousTool();
                 return;
             }
 
-            if((Selection.activeObject is GameObject go && go == polygon.gameObject))
+            if((Selection.activeObject == null && polygon == null) ||
+               (Selection.activeObject is GameObject go && go == polygon.gameObject))
                 return;
 
             if(polygon != null && polygon.polyEditMode == PolyShape.PolyEditMode.Path)


### PR DESCRIPTION
### Purpose of this PR

This PR 
- Prevents the Create Polyshape tool to create 'ghost' game objects in the hierarchy 
- fix a bug where entering the tool with a polyshape already selected wouldn't work

### Links

**Jira:** https://jira.unity3d.com/browse/PBLD-113

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]