### PR TITLE
[PBLD-110] Updating prefab instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- [PBLD-110] Fixed a bug where the prefab instances of ProBuilder meshes where not updating after applying all the overrides.
+- [PBLD-113] Fixed a bug where the Polyshape tool would create temporary objects in the hierarchy.
+
 ## [6.0.1] - 2024-03-25
 
 ### Changes
 
 - Moved package out of preview.
-
-## [Unreleased]
-
-### Fixed
-
-- [PBLD-113] Fixed a bug where the Polyshape tool would create temporary objects in the hierarchy.
 
 ## [6.0.1-pre.2] - 2024-02-16
 

--- a/Editor/EditorCore/HierarchyListener.cs
+++ b/Editor/EditorCore/HierarchyListener.cs
@@ -123,6 +123,8 @@ namespace UnityEditor.ProBuilder
             foreach (var mesh in go.GetComponentsInChildren<ProBuilderMesh>())
             {
                 EditorUtility.SynchronizeWithMeshFilter(mesh);
+                mesh.Rebuild();
+                mesh.Optimize();
             }
 
             ProBuilderEditor.Refresh();

--- a/Tests/Editor/Editor/MeshSyncTests.cs
+++ b/Tests/Editor/Editor/MeshSyncTests.cs
@@ -7,12 +7,15 @@ using UnityEngine;
 using UnityEngine.ProBuilder;
 using UnityEngine.ProBuilder.Shapes;
 using UnityEngine.ProBuilder.Tests.Framework;
+using UnityEngine.SceneManagement;
 using UnityEngine.TestTools;
 using EditorUtility = UnityEditor.ProBuilder.EditorUtility;
 
 class MeshSyncTests : TemporaryAssetTest
 {
     static readonly string copyPasteTestScene = $"{TestUtility.testsRootDirectory}/Scenes/CopyPasteDuplicate.unity";
+
+    private Scene m_Scene;
 
     [SetUp]
     public void Setup()
@@ -22,7 +25,13 @@ class MeshSyncTests : TemporaryAssetTest
         window.Repaint();
         window.Focus();
 
-        OpenScene(copyPasteTestScene);
+        m_Scene = OpenScene(copyPasteTestScene);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        CloseScene(m_Scene);
     }
 
     static IEnumerable CopyPasteDuplicate

--- a/Tests/Editor/Object/PrefabTests.cs
+++ b/Tests/Editor/Object/PrefabTests.cs
@@ -9,11 +9,25 @@ using UnityEngine;
 using UnityEngine.ProBuilder;
 using UnityEngine.ProBuilder.MeshOperations;
 using UnityEngine.ProBuilder.Shapes;
+using UnityEngine.SceneManagement;
 using UnityEngine.TestTools;
 
 public class PrefabTests
 {
     List<string> m_CreatedAssets = new List<string>();
+
+    private Scene m_Scene;
+
+    [SetUp]
+    public void Setup()
+    {
+        var window = EditorWindow.GetWindow<SceneView>();
+        window.Show(false);
+        window.Repaint();
+        window.Focus();
+
+        m_Scene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+    }
 
     GameObject CreatePrefab()
     {
@@ -93,10 +107,16 @@ public class PrefabTests
         Assume.That(instance2, Is.Not.Null);
         var mesh1 = instance1.GetComponent<ProBuilderMesh>();
         var mesh2 = instance2.GetComponent<ProBuilderMesh>();
+
         mesh1.Extrude(new [] { mesh1.faces[0] }, ExtrudeMethod.FaceNormal, .25f);
+        mesh1.Rebuild();
+
         PrefabUtility.ApplyPrefabInstance(instance1, InteractionMode.AutomatedAction);
 
         Assert.That(mesh1.mesh.vertexCount, Is.EqualTo(mesh2.mesh.vertexCount));
+
+        Assert.That(mesh1.versionIndex, Is.Not.EqualTo(ProBuilderMesh.k_UnitializedVersionIndex));
+        Assert.That(mesh2.versionIndex, Is.Not.EqualTo(ProBuilderMesh.k_UnitializedVersionIndex));
     }
 
     [Test, Ignore("Requires ENABLE_DRIVEN_PROPERTIES feature")]


### PR DESCRIPTION
### Purpose of this PR

When modifying a pb mesh in a prefab and applying the ovrerrides, some prefabs where not updated.
This is beccause in that case the versionIndex could be set to 0 and as the ProBuilderMesh.meshSyncState says :

                // if the local version index is uninitialized, that means no edits have occurred since loading this
                // mesh. it could mean a new mesh was created and ToMesh has not been called yet, or that this mesh was
                // copy/pasted from an existing instance.
                // in the latter case, it is handled by listening to the ObjectChangeEvent stream in HierarchyListener.
                // this function only cares about the case where modifications have been made during the current session.
This is also the case when the mesh is part of a prefab and as not been modified, but it should be updated as well when the instance is updated.

To solve this, we revert to the former solution where we were forcing the mesh to rebuild.

Also fixing the tests, the previous version of the test was not rebuilding the mesh so the compared data was not correct and the test was wrongly successful. The PR fixes that as well, and adds some extra setup to insure a new scene is created.

Previous behavior:
![Unity_OsQuGzq5VS](https://github.com/Unity-Technologies/com.unity.probuilder/assets/66317117/198d9d3e-7018-4847-8f1f-8422e039355e)


Fixed behavior :
![Unity_FPX5FpSThx](https://github.com/Unity-Technologies/com.unity.probuilder/assets/66317117/3b58e6f1-9190-49b3-b3fe-a2b672b52147)



### Links

**Jira:** https://jira.unity3d.com/browse/PBLD-110

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]