### PR TITLE
[PBLD-129] Fixing redo problem with PB Actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- [PBLD-129] Fixed a bug where redoing actions was not updating the ProBuilder mesh in the scene.
 - [PBLD-120] Replaced the former scene info by a scene view overlay.
 - [PBLD-121] Fixed edit mode and context shortcuts and settings tooltips.
 - [PBLD-110] Fixed a bug where the prefab instances of ProBuilder meshes where not updating after applying all the overrides.

--- a/Editor/EditorCore/UndoUtility.cs
+++ b/Editor/EditorCore/UndoUtility.cs
@@ -23,8 +23,7 @@ namespace UnityEditor.ProBuilder
                 return;
 
             foreach(var mesh in Selection.GetFiltered<ProBuilderMesh>(SelectionMode.TopLevel))
-                using (new ProBuilderMesh.NonVersionedEditScope(mesh))
-                    EditorUtility.SynchronizeWithMeshFilter(mesh);
+                EditorUtility.SynchronizeWithMeshFilter(mesh);
 
             ProBuilderEditor.Refresh();
         }

--- a/Editor/EditorCore/UndoUtility.cs
+++ b/Editor/EditorCore/UndoUtility.cs
@@ -22,8 +22,11 @@ namespace UnityEditor.ProBuilder
             if (SceneDragAndDropListener.isDragging)
                 return;
 
-            foreach(var mesh in Selection.GetFiltered<ProBuilderMesh>(SelectionMode.TopLevel))
-                EditorUtility.SynchronizeWithMeshFilter(mesh);
+            foreach (var mesh in Selection.GetFiltered<ProBuilderMesh>(SelectionMode.TopLevel))
+            {
+                using (new ProBuilderMesh.NonVersionedEditScope(mesh))
+                        EditorUtility.SynchronizeWithMeshFilter(mesh);
+            }
 
             ProBuilderEditor.Refresh();
         }

--- a/Runtime/Core/ProBuilderMesh.cs
+++ b/Runtime/Core/ProBuilderMesh.cs
@@ -193,19 +193,18 @@ namespace UnityEngine.ProBuilder
         internal struct NonVersionedEditScope : IDisposable
         {
             readonly ProBuilderMesh m_Mesh;
-            readonly ushort m_VersionIndex, m_InstanceVersionIndex;
+            readonly ushort m_VersionIndex;
 
             public NonVersionedEditScope(ProBuilderMesh mesh)
             {
                 m_Mesh = mesh;
                 m_VersionIndex = mesh.versionIndex;
-                m_InstanceVersionIndex = mesh.m_InstanceVersionIndex;
             }
 
             public void Dispose()
             {
                 m_Mesh.m_VersionIndex = m_VersionIndex;
-                m_Mesh.m_InstanceVersionIndex = m_InstanceVersionIndex;
+                m_Mesh.m_InstanceVersionIndex = m_VersionIndex;
             }
         }
 

--- a/Runtime/Core/ProBuilderMeshFunction.cs
+++ b/Runtime/Core/ProBuilderMeshFunction.cs
@@ -71,9 +71,6 @@ namespace UnityEngine.ProBuilder
                     Rebuild();
                     meshWasInitialized?.Invoke(this);
                 }
-
-                // only sync instance version index when a new mesh is created
-                m_InstanceVersionIndex = m_VersionIndex;
             }
         }
 


### PR DESCRIPTION
### Purpose of this PR

Removing a NonVersionedEditScope.
This was introduced when the Mesh Version index was not serialized. Now this value is serialized, we need that for the Undo and Redo to work properly.

### Links

**Jira:** https://jira.unity3d.com/browse/PBLD-128

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]