### PR TITLE
Update boolean.md

### DIFF
--- a/Documentation~/boolean.md
+++ b/Documentation~/boolean.md
@@ -10,6 +10,7 @@ Each type of operation takes two ProBuilder Mesh objects as the left and right i
 
 You can only access this feature from the menu, because it is experimental:
 
+1. Turn on [experimental features](/preferences.md).
 1. To open the Boolean (Experimental) window, navigate to Unity's top menu and go to **Tools** > **ProBuilder** > **Experimental** > **Boolean (CSG) Tool**.
 2. Set references to the ProBuilder Meshes just under the preview windows on the left and the right side.
 3. Select one of the boolean operation types from the **Operation** drop-down menu: [Intersection](#intersect), [Union](#union), or [Subtraction](#subtract).

--- a/Documentation~/boolean.md
+++ b/Documentation~/boolean.md
@@ -10,7 +10,7 @@ Each type of operation takes two ProBuilder Mesh objects as the left and right i
 
 You can only access this feature from the menu, because it is experimental:
 
-1. Turn on [experimental features](/preferences.md).
+1. [Enable experimental features](/preferences.md).
 1. To open the Boolean (Experimental) window, navigate to Unity's top menu and go to **Tools** > **ProBuilder** > **Experimental** > **Boolean (CSG) Tool**.
 2. Set references to the ProBuilder Meshes just under the preview windows on the left and the right side.
 3. Select one of the boolean operation types from the **Operation** drop-down menu: [Intersection](#intersect), [Union](#union), or [Subtraction](#subtract).

--- a/Documentation~/boolean.md
+++ b/Documentation~/boolean.md
@@ -10,7 +10,7 @@ Each type of operation takes two ProBuilder Mesh objects as the left and right i
 
 You can only access this feature from the menu, because it is experimental:
 
-1. [Enable experimental features](/preferences.md).
+1. [Enable experimental features](preferences.md#experimental).
 1. To open the Boolean (Experimental) window, navigate to Unity's top menu and go to **Tools** > **ProBuilder** > **Experimental** > **Boolean (CSG) Tool**.
 2. Set references to the ProBuilder Meshes just under the preview windows on the left and the right side.
 3. Select one of the boolean operation types from the **Operation** drop-down menu: [Intersection](#intersect), [Union](#union), or [Subtraction](#subtract).

--- a/Documentation~/workflow-create-bezier.md
+++ b/Documentation~/workflow-create-bezier.md
@@ -6,7 +6,7 @@ The Bezier Shape tool uses a Bezier spline (curve) and extrudes along it to crea
 
 To define a Mesh based on a bezier (curve) shape:
 
-1. Make sure the [Experimental Features Enabled](preferences.md#experimental) preference is enabled (go to **Edit** > **Preferences** in Windows or **Unity** > **Preferences** in macOS from the main menu in Unity, then select the **ProBuilder** category from the list).
+1. [Enable experimental features](preferences.md#experimental).
 
 2. Open the ProBuilder window (in Unity's top menu: **Tools** > **ProBuilder window**).
 


### PR DESCRIPTION
Adding a link to https://docs.unity3d.com/Packages/com.unity.probuilder@6.0/manual/preferences.html because users don't realise they don't have experimental features turned on

### Purpose of this PR

Clarify that users must enable experimental features before they can use Boolean. 

### Links

[**Jira:**
](https://jira.unity3d.com/browse/DOCATT-5500) https://jira.unity3d.com/browse/DOCATT-5500

### Comments to Reviewers

Text only