### PR TITLE
[PBLD-127] Fixing undo respawning deleted shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [5.2.3] - 2023-12-12
+## [Unreleased]
 
 ### Fixed
 
+- [PBLD-127] Fixed a bug where undoing a shape creation would reset the deleted shape in the scene.
 - [PBLD-110] Fixed a bug where the prefab instances of ProBuilder meshes where not updating after applying all the overrides.
 - [WEBDOCS-1036] Fixed a documentation generation problem where a setting in the filter.yml file was preventing the ProBuilder API documentation from being generated.
 

--- a/Editor/MenuActions/Editors/NewBezierShape.cs
+++ b/Editor/MenuActions/Editors/NewBezierShape.cs
@@ -36,9 +36,9 @@ namespace UnityEditor.ProBuilder.Actions
             go.GetComponent<MeshRenderer>().sharedMaterial = EditorMaterialUtility.GetUserMaterial();
             bezier.Init();
             bezier.Refresh();
+            UndoUtility.RegisterCreatedObjectUndo(go, "Create Bezier Shape");
             EditorUtility.InitObject(bezier.GetComponent<ProBuilderMesh>());
             MeshSelection.SetSelection(go);
-            UndoUtility.RegisterCreatedObjectUndo(go, "Create Bezier Shape");
             bezier.isEditing = true;
 
             return new ActionResult(ActionResult.Status.Success, "Create Bezier Shape");

--- a/Editor/StateMachines/ShapeState_DrawHeightShape.cs
+++ b/Editor/StateMachines/ShapeState_DrawHeightShape.cs
@@ -9,30 +9,33 @@ namespace UnityEditor.ProBuilder
     {
         protected override void EndState()
         {
+            tool.handleSelectionChange = false;
+
+            // Get the current undo group
+            var group = Undo.GetCurrentGroup();
+            var shape = tool.currentShapeInOverlay.gameObject;
+            UndoUtility.RegisterCreatedObjectUndo(shape, "Draw Shape");
+
+            //Actually generate the shape
+            tool.m_ProBuilderShape.pivotGlobalPosition = tool.m_BB_Origin;
+            tool.m_ProBuilderShape.gameObject.hideFlags = HideFlags.None;
+
+            EditorUtility.InitObject(tool.m_ProBuilderShape.mesh);
+
             tool.RebuildShape();
-            UndoUtility.RegisterCreatedObjectUndo(tool.currentShapeInOverlay.gameObject, "Draw Shape");
+            Selection.activeObject = shape;
+            // make sure that the whole shape creation process is a single undo group
+            Undo.CollapseUndoOperations(group);
+
+            //Update tool
+            DrawShapeTool.s_ActiveShapeIndex.value = Array.IndexOf(EditorShapeUtility.availableShapeTypes, tool.m_ProBuilderShape.shape.GetType());
+            DrawShapeTool.SaveShapeParams(tool.m_ProBuilderShape);
             tool.m_LastShapeCreated = tool.m_ProBuilderShape;
             tool.m_ProBuilderShape = null;
         }
 
         ShapeState ValidateShape()
         {
-            tool.handleSelectionChange = false;
-
-            tool.RebuildShape();
-            tool.m_ProBuilderShape.pivotGlobalPosition = tool.m_BB_Origin;
-            tool.m_ProBuilderShape.gameObject.hideFlags = HideFlags.None;
-
-            EditorUtility.InitObject(tool.m_ProBuilderShape.mesh);
-
-            DrawShapeTool.s_ActiveShapeIndex.value = Array.IndexOf(EditorShapeUtility.availableShapeTypes, tool.m_ProBuilderShape.shape.GetType());
-            DrawShapeTool.SaveShapeParams(tool.m_ProBuilderShape);
-
-            // make sure that the whole shape creation process is a single undo group
-            var group = Undo.GetCurrentGroup() - 1;
-            Selection.activeObject = tool.m_ProBuilderShape.gameObject;
-            Undo.CollapseUndoOperations(group);
-
             return NextState();
         }
 


### PR DESCRIPTION
TEST IS NEEDED BEFORE OPENING THE PR

### Purpose of this PR

[PBLD-127] Fixed a bug where undoing a shape creation would reset the deleted shape in the scene.

This was caused by Undo registering done in the wrong order:
`UndoUtility.RegisterCreatedObjectUndo` should be called BEFORE `EditorUtility.InitObject `
(`EditorUtility.InitObject` is calling `ComponentUtility.MoveComponentRelativeToComponent` which was calling this problem)


### Links

**Jira:** https://jira.unity3d.com/browse/PBLD-127

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]