### PR TITLE
Removing menu-open from TOC

### DIFF
--- a/Documentation~/TableOfContents.md
+++ b/Documentation~/TableOfContents.md
@@ -15,7 +15,6 @@
 		* [Edge actions](edge)
 		* [Face actions](face)
 	* [The ProBuilder menu](menu)
-		* [ProBuilder Window](menu-open)
 		* [Editors](menu-editors)
 		* [Dimensions Overlay](menu-dimover)
 		* [Selection](menu-selection)

--- a/Documentation~/menu-open.md
+++ b/Documentation~/menu-open.md
@@ -1,8 +1,0 @@
-# ProBuilder Window
-
-This opens the [ProBuilder toolbar](toolbar.md) and [Edit mode toolbar](edit-mode-toolbar.md) together. 
-
-![ProBuilder toolbar and Edit mode toolbar open and close at the same time](images/menu-open.png)
-
-By default, the Edit mode toolbar appears in the upper center of your Unity workspace, and the ProBuilder toolbar appears on the left side. See [Customizing ProBuilder](customizing.md) for information on how to customize the location and appearance of these toolbars and other ProBuilder windows.
-


### PR DESCRIPTION
### Purpose of this PR

Remove the ProBuilder Window page, because that window doesn't exist in ProBuilder 6.

### Links

https://jira.unity3d.com/browse/DOCATT-5819

### Comments to Reviewers

Documentation only