### PR TITLE
[PBLD-127] Fixing undo respawning deleted shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- [PBLD-127] Fixed a bug where undoing a shape creation would reset the deleted shape in the scene.
 - [PBLD-129] Fixed a bug where redoing actions was not updating the ProBuilder mesh in the scene.
 - [PBLD-120] Replaced the former scene info by a scene view overlay.
 - [PBLD-121] Fixed edit mode and context shortcuts and settings tooltips.

--- a/Editor/MenuActions/Editors/NewBezierShape.cs
+++ b/Editor/MenuActions/Editors/NewBezierShape.cs
@@ -38,9 +38,9 @@ namespace UnityEditor.ProBuilder.Actions
             go.GetComponent<MeshRenderer>().sharedMaterial = EditorMaterialUtility.GetUserMaterial();
             bezier.Init();
             bezier.Refresh();
+            UndoUtility.RegisterCreatedObjectUndo(go, "Create Bezier Shape");
             EditorUtility.InitObject(bezier.GetComponent<ProBuilderMesh>());
             MeshSelection.SetSelection(go);
-            UndoUtility.RegisterCreatedObjectUndo(go, "Create Bezier Shape");
             bezier.isEditing = true;
 
             return new ActionResult(ActionResult.Status.Success, "Create Bezier Shape");

--- a/Editor/StateMachines/ShapeState_DrawHeightShape.cs
+++ b/Editor/StateMachines/ShapeState_DrawHeightShape.cs
@@ -9,29 +9,33 @@ namespace UnityEditor.ProBuilder
     {
         protected override void EndState()
         {
+            tool.handleSelectionChange = false;
+
+            // Get the current undo group
+            var group = Undo.GetCurrentGroup();
+            var shape = tool.currentShapeInOverlay.gameObject;
+            UndoUtility.RegisterCreatedObjectUndo(shape, "Draw Shape");
+
+            //Actually generate the shape
+            tool.m_ProBuilderShape.pivotGlobalPosition = tool.m_BB_Origin;
+            tool.m_ProBuilderShape.gameObject.hideFlags = HideFlags.None;
+
+            EditorUtility.InitObject(tool.m_ProBuilderShape.mesh);
+
             tool.RebuildShape();
-            UndoUtility.RegisterCreatedObjectUndo(tool.currentShapeInOverlay.gameObject, "Draw Shape");
+            Selection.activeObject = shape;
+            // make sure that the whole shape creation process is a single undo group
+            Undo.CollapseUndoOperations(group);
+
+            //Update tool
+            DrawShapeTool.s_ActiveShapeIndex.value = Array.IndexOf(EditorShapeUtility.availableShapeTypes, tool.m_ProBuilderShape.shape.GetType());
+            DrawShapeTool.SaveShapeParams(tool.m_ProBuilderShape);
             tool.m_LastShapeCreated = tool.m_ProBuilderShape;
             tool.m_ProBuilderShape = null;
         }
 
         ShapeState ValidateShape()
         {
-            tool.handleSelectionChange = false;
-
-            tool.RebuildShape();
-            tool.m_ProBuilderShape.gameObject.hideFlags = HideFlags.None;
-
-            EditorUtility.InitObject(tool.m_ProBuilderShape.mesh);
-
-            DrawShapeTool.s_ActiveShapeIndex.value = Array.IndexOf(EditorShapeUtility.availableShapeTypes, tool.m_ProBuilderShape.shape.GetType());
-            tool.SaveShapeParams(tool.m_ProBuilderShape);
-
-            // make sure that the whole shape creation process is a single undo group
-            var group = Undo.GetCurrentGroup() - 1;
-            Selection.activeObject = tool.m_ProBuilderShape.gameObject;
-            Undo.CollapseUndoOperations(group);
-
             return NextState();
         }
 

--- a/Editor/StateMachines/ShapeState_DrawHeightShape.cs
+++ b/Editor/StateMachines/ShapeState_DrawHeightShape.cs
@@ -16,20 +16,19 @@ namespace UnityEditor.ProBuilder
             var shape = tool.currentShapeInOverlay.gameObject;
             UndoUtility.RegisterCreatedObjectUndo(shape, "Draw Shape");
 
-            //Actually generate the shape
-            tool.m_ProBuilderShape.pivotGlobalPosition = tool.m_BB_Origin;
+            // Actually generate the shape
             tool.m_ProBuilderShape.gameObject.hideFlags = HideFlags.None;
 
             EditorUtility.InitObject(tool.m_ProBuilderShape.mesh);
-
             tool.RebuildShape();
             Selection.activeObject = shape;
-            // make sure that the whole shape creation process is a single undo group
+
+            // Make sure that the whole shape creation process is a single undo group
             Undo.CollapseUndoOperations(group);
 
-            //Update tool
+            // Update tool
             DrawShapeTool.s_ActiveShapeIndex.value = Array.IndexOf(EditorShapeUtility.availableShapeTypes, tool.m_ProBuilderShape.shape.GetType());
-            DrawShapeTool.SaveShapeParams(tool.m_ProBuilderShape);
+            tool.SaveShapeParams(tool.m_ProBuilderShape);
             tool.m_LastShapeCreated = tool.m_ProBuilderShape;
             tool.m_ProBuilderShape = null;
         }

--- a/Tests/Editor/Undo/TestUndo.cs
+++ b/Tests/Editor/Undo/TestUndo.cs
@@ -30,7 +30,7 @@ static class UndoTests
 
         Assert.IsFalse(TestUtility.MeshesAreEqual(cube.mesh, duplicate.mesh));
 
-        UnityEditor.Undo.PerformUndo();
+        Undo.PerformUndo();
 
         // this is usually caught by UndoUtility
         cube.InvalidateCaches();
@@ -40,8 +40,22 @@ static class UndoTests
 
         TestUtility.AssertAreEqual(duplicate.mesh, cube.mesh);
 
-        UnityEngine.Object.DestroyImmediate(cube.gameObject);
-        UnityEngine.Object.DestroyImmediate(duplicate.gameObject);
+        Object.DestroyImmediate(cube.gameObject);
+        Object.DestroyImmediate(duplicate.gameObject);
+    }
+
+    // PBLD-127: Undoing shape creation and BezierShape leaves a PB Mesh in the scene
+    [Test]
+    public static void CreateShape_UndoDoesRemoveTheGameObject()
+    {
+        EditorApplication.ExecuteMenuItem("Tools/ProBuilder/Editors/New Bezier Shape");
+        var shapes = GameObject.FindObjectsByType<ProBuilderMesh>(FindObjectsSortMode.None);
+        Assume.That(shapes.Length, Is.EqualTo(1));
+
+        Undo.PerformUndo();
+
+        shapes = GameObject.FindObjectsByType<ProBuilderMesh>(FindObjectsSortMode.None);
+        Assert.That(shapes.Length, Is.EqualTo(0));
     }
 
     [Test]

--- a/Tests/Editor/Undo/TestUndo.cs
+++ b/Tests/Editor/Undo/TestUndo.cs
@@ -48,7 +48,11 @@ static class UndoTests
     [Test]
     public static void CreateShape_UndoDoesRemoveTheGameObject()
     {
-        EditorApplication.ExecuteMenuItem("Tools/ProBuilder/Editors/New Bezier Shape");
+        var instance = EditorToolbarLoader.GetInstance<NewBezierShape>();
+        Assume.That(instance, Is.Not.Null);
+
+        instance.PerformAction();
+
         var shapes = GameObject.FindObjectsByType<ProBuilderMesh>(FindObjectsSortMode.None);
         Assume.That(shapes.Length, Is.EqualTo(1));
 


### PR DESCRIPTION
Purpose of this PR
[PBLD-127] Fixed a bug where undoing a shape creation would reset the deleted shape in the scene.

This was caused by Undo registering done in the wrong order:
UndoUtility.RegisterCreatedObjectUndo should be called BEFORE EditorUtility.InitObject 
(EditorUtility.InitObject is calling ComponentUtility.MoveComponentRelativeToComponent which was calling this problem)

Links
Jira: https://jira.unity3d.com/browse/PBLD-127