### PR TITLE
Fixed visual glitches when drawing PB shapes on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- [PBLD-134] Fixed a bug where drawing ProBuilder shapes would cause temporary visual glitches on macOS.
 - [PBLD-127] Fixed a bug where undoing a shape creation would reset the deleted shape in the scene.
 - [PBLD-129] Fixed a bug where redoing actions was not updating the ProBuilder mesh in the scene.
 - [PBLD-120] Replaced the former scene info by a scene view overlay.

--- a/Editor/StateMachines/ShapeState_DrawHeightShape.cs
+++ b/Editor/StateMachines/ShapeState_DrawHeightShape.cs
@@ -61,7 +61,8 @@ namespace UnityEditor.ProBuilder
                 }
             }
 
-            tool.DrawBoundingBox();
+            if(evt.type == EventType.Repaint)
+                tool.DrawBoundingBox();
 
             if(evt.isMouse)
             {


### PR DESCRIPTION
### Purpose of this PR

PR fixes an issue where drawing the height during PB shape creation would cause visual glitches on macOS.

### Links

**Jira:** https://jira.unity3d.com/browse/PBLD-135

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]