### PR TITLE
[PB 5.2] Fixed visual glitches when drawing PB shapes on macOS 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- [PBLD-134] Fixed a bug where drawing ProBuilder shapes would cause temporary visual glitches on macOS.
 - [PBLD-127] Fixed a bug where undoing a shape creation would reset the deleted shape in the scene.
 - [PBLD-110] Fixed a bug where the prefab instances of ProBuilder meshes where not updating after applying all the overrides.
 - [WEBDOCS-1036] Fixed a documentation generation problem where a setting in the filter.yml file was preventing the ProBuilder API documentation from being generated.

--- a/Editor/StateMachines/ShapeState_DrawHeightShape.cs
+++ b/Editor/StateMachines/ShapeState_DrawHeightShape.cs
@@ -62,7 +62,8 @@ namespace UnityEditor.ProBuilder
                 }
             }
 
-            tool.DrawBoundingBox();
+            if(evt.type == EventType.Repaint)
+                tool.DrawBoundingBox();
 
             if(evt.isMouse)
             {


### PR DESCRIPTION
### Purpose of this PR

Backport PR fixes an issue where drawing the height during PB shape creation would cause visual glitches on macOS.

### Links

**Jira:** https://jira.unity3d.com/browse/PBLD-136

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]