### PR TITLE
Fix PolyShape tool warning when Resident Drawer enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- [PBLD-115] Fixed a bug where using the 'Create PolyShape' tool when GPU Resident Drawer was enabled would throw warnings.
 - [PBLD-134] Fixed a bug where drawing ProBuilder shapes would cause temporary visual glitches on macOS.
 - [PBLD-127] Fixed a bug where undoing a shape creation would reset the deleted shape in the scene.
 - [PBLD-129] Fixed a bug where redoing actions was not updating the ProBuilder mesh in the scene.

--- a/Content/Resources/Materials/ProBuilderDefault.mat
+++ b/Content/Resources/Materials/ProBuilderDefault.mat
@@ -45,7 +45,7 @@ MonoBehaviour:
 --- !u!21 &2100000
 Material:
   serializedVersion: 8
-  m_ObjectHideFlags: 0
+  m_ObjectHideFlags: 32
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
@@ -53,13 +53,13 @@ Material:
   m_Shader: {fileID: 4800000, guid: 8547ec39534635c4289065e5c5033f43, type: 3}
   m_Parent: {fileID: 0}
   m_ModifiedSerializedProperties: 0
-  m_ValidKeywords: []
-  m_InvalidKeywords:
+  m_ValidKeywords:
   - _DISABLE_SSR_TRANSPARENT
+  m_InvalidKeywords: []
   m_LightmapFlags: 1
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
-  m_CustomRenderQueue: 2000
+  m_CustomRenderQueue: -1
   stringTagMap:
     MotionVector: User
   disabledShaderPasses:

--- a/Content/Resources/Materials/ProBuilderDefault.mat
+++ b/Content/Resources/Materials/ProBuilderDefault.mat
@@ -45,7 +45,7 @@ MonoBehaviour:
 --- !u!21 &2100000
 Material:
   serializedVersion: 8
-  m_ObjectHideFlags: 32
+  m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
@@ -53,13 +53,13 @@ Material:
   m_Shader: {fileID: 4800000, guid: 8547ec39534635c4289065e5c5033f43, type: 3}
   m_Parent: {fileID: 0}
   m_ModifiedSerializedProperties: 0
-  m_ValidKeywords:
+  m_ValidKeywords: []
+  m_InvalidKeywords:
   - _DISABLE_SSR_TRANSPARENT
-  m_InvalidKeywords: []
   m_LightmapFlags: 1
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
+  m_CustomRenderQueue: 2000
   stringTagMap:
     MotionVector: User
   disabledShaderPasses:

--- a/Editor/EditorCore/DrawShapeTool.cs
+++ b/Editor/EditorCore/DrawShapeTool.cs
@@ -737,6 +737,10 @@ namespace UnityEditor.ProBuilder
             }
 
             proBuilderShape.Rebuild(pivotLocation == PivotLocation.Center ? m_Bounds.center : m_BB_Origin, m_PlaneRotation, m_Bounds);
+            // PBLD-137 - continously refresh the material, otherwise if Resident Drawer is on, new faces are drawn without material applied until there's some other trigger:
+            // renderer enable/disable, material re-apply, etc.
+            m_ProBuilderShape.mesh.renderer.sharedMaterial = EditorMaterialUtility.GetUserMaterial();
+
             ProBuilderEditor.Refresh(false);
 
             SceneView.RepaintAll();

--- a/Editor/EditorCore/EditorUtility.cs
+++ b/Editor/EditorCore/EditorUtility.cs
@@ -299,8 +299,11 @@ namespace UnityEditor.ProBuilder
             }
 
             pb.unwrapParameters = new UnwrapParameters(Lightmapping.s_UnwrapParameters);
-
             pb.Optimize();
+            
+            // PBLD-137 - if Resident Drawer is on, it will start throwing errors if submeshCount != materialCount
+            if (pb.mesh.subMeshCount == 0)
+                pb.renderer.sharedMaterial = null;
 
             if (meshCreated != null)
                 meshCreated(pb);

--- a/Editor/EditorCore/PolyShapeTool.cs
+++ b/Editor/EditorCore/PolyShapeTool.cs
@@ -533,6 +533,11 @@ namespace UnityEditor.ProBuilder
 
             if (polygon.polyEditMode != PolyShape.PolyEditMode.Path)
             {
+                // PBLD-137 - continously refresh the material, otherwise if Resident Drawer is on, new faces are drawn without material applied until there's some other trigger:
+                // renderer enable/disable, material re-apply, etc.
+                if (polygon.polyEditMode == PolyShape.PolyEditMode.Height && polygon.m_Points != null && polygon.m_Points.Count >= 3)
+                    polygon.mesh.renderer.sharedMaterial = EditorMaterialUtility.GetUserMaterial();
+                
                 var result = polygon.CreateShapeFromPolygon();
                 if(result.status == ActionResult.Status.Failure)
                 {

--- a/Tests/Editor/Object/CreateDestroy.cs
+++ b/Tests/Editor/Object/CreateDestroy.cs
@@ -5,8 +5,10 @@ using NUnit.Framework;
 using UnityEngine.ProBuilder.Tests.Framework;
 using UnityEngine.TestTools;
 using UnityEditor;
+using UnityEditor.ProBuilder;
 using UnityEngine.ProBuilder;
 using UnityEngine.ProBuilder.Shapes;
+using UnityEngine.ProBuilder.MeshOperations;
 
 static class CreateDestroy
 {
@@ -61,5 +63,23 @@ static class CreateDestroy
         Assume.That(mesh.filter, Is.Not.Null);
         Assert.That(mesh.filter.hideFlags & HideFlags.DontSave, Is.EqualTo(HideFlags.DontSave));
         UObject.DestroyImmediate(mesh.gameObject);
+    }
+    
+    [Test]
+    public static void CreateEmptyPolyShape_SubmeshCountIsZero_MaterialCountIsZero()
+    {
+        GameObject go = new GameObject("PolyShape");
+        var polyShape = go.AddComponent<PolyShape>();
+        ProBuilderMesh pb = go.AddComponent<ProBuilderMesh>();
+
+        Assume.That(polyShape, Is.Not.Null, "PolyShape should not be null at this point.");
+        Assume.That(pb, Is.Not.Null, "ProBuilderMesh should not be null at this point.");
+        
+        pb.CreateShapeFromPolygon(polyShape.m_Points, polyShape.extrude, polyShape.flipNormals);
+        UnityEditor.ProBuilder.EditorUtility.InitObject(pb);
+        
+        var zeroSubmeshAndMaterials = (pb.renderer.sharedMaterial == null && pb.mesh.subMeshCount == 0);
+        
+        Assert.That(zeroSubmeshAndMaterials, Is.True, "Creating empty PolyShape should result in mesh with zero sub meshes and zero materials.");
     }
 }


### PR DESCRIPTION
### Purpose of this PR

PR fixes an issue where warnings would be thrown or some parts of PolyShapes would render invisible when Resident Drawer is on.

There's too parts to the fix:
1) `EditorUtility.InitObject` no longer results configurations where there's zero submeshes but one or more materials - this would cause Resident Drawer to throw errors.
2) Material is more aggressively refreshed as otherwise geometry added after setting the material would render as if there's no material set - probably has to do with how Resident Drawer batches geometry.

### Links

**Jira:** https://jira.unity3d.com/browse/PBLD-115

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]