### PR TITLE
[Backport 5.2] Fixed issue where duplicating pb mesh would dirty all scenes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- [PBLD-138] Fixed a bug where duplicating a ProBuilder mesh would mark all scenes as dirty.
 - [PBLD-134] Fixed a bug where drawing ProBuilder shapes would cause temporary visual glitches on macOS.
 - [PBLD-127] Fixed a bug where undoing a shape creation would reset the deleted shape in the scene.
 - [PBLD-110] Fixed a bug where the prefab instances of ProBuilder meshes where not updating after applying all the overrides.

--- a/Editor/EditorCore/HierarchyListener.cs
+++ b/Editor/EditorCore/HierarchyListener.cs
@@ -121,7 +121,7 @@ namespace UnityEditor.ProBuilder
                 mesh.nonSerializedVersionIndex == ProBuilderMesh.k_UnitializedVersionIndex)
             {
                 mesh.MakeUnique();
-                Undo.RegisterCreatedObjectUndo(mesh.mesh, "Paste ProBuilderMesh");
+                Undo.RegisterCompleteObjectUndo( mesh.gameObject, "Paste ProBuilderMesh");
                 mesh.Optimize();
             }
         }

--- a/Tests/Framework/TestUtility.cs
+++ b/Tests/Framework/TestUtility.cs
@@ -46,11 +46,11 @@ namespace UnityEngine.ProBuilder.Tests.Framework
             AssetDatabase.Refresh();
         }
 
-        public Scene OpenScene(string path)
+        public Scene OpenScene(string path, OpenSceneMode openMode = OpenSceneMode.Single)
         {
             var tempPath = $"{tempDirectory}/{Path.GetFileName(path)}";
             AssetDatabase.CopyAsset(path, tempPath);
-            return EditorSceneManager.OpenScene(tempPath);
+            return EditorSceneManager.OpenScene(tempPath, openMode);
         }
     }
 

--- a/Tests/Framework/TestUtility.cs
+++ b/Tests/Framework/TestUtility.cs
@@ -52,6 +52,11 @@ namespace UnityEngine.ProBuilder.Tests.Framework
             AssetDatabase.CopyAsset(path, tempPath);
             return EditorSceneManager.OpenScene(tempPath, openMode);
         }
+        
+        public bool CloseScene(Scene scene)
+        {
+            return EditorSceneManager.CloseScene(scene, true);
+        }
     }
 
     public static class TestUtility

--- a/Tests/Scenes/EmptyScene.unity
+++ b/Tests/Scenes/EmptyScene.unity
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a84ca4f8a2bd93e33ea957d8d28a11acab17fd92320ba1fe84137f18f5539585
+size 3516

--- a/Tests/Scenes/EmptyScene.unity.meta
+++ b/Tests/Scenes/EmptyScene.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6c93961dd6cf442288b119a80598a8ec
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Purpose of this PR

Backport of: https://github.com/Unity-Technologies/com.unity.probuilder/pull/543

### Links

**Jira:** https://jira.unity3d.com/browse/PBLD-139

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]