### PR TITLE
Second round of ProBuilder 6 documentation edits

### DIFF
--- a/Documentation~/modes.md
+++ b/Documentation~/modes.md
@@ -15,6 +15,8 @@ To change edit modes within the ProBuilder context, in the **Tool Settings** ove
 
 ## Keyboard shortcuts
 
+For a list of all shortcuts, and to add shortcuts, go to **Edit > Shortcuts** to open the [Shortcuts Manager](xref:ShortcutsManager).
+
+
 * **Escape** to return from the ProBuilder context to the GameObject context.
 * **G** to cycle through the ProBuilder edit modes.
-* **Shift+Drag** while using any of the standard Unity Transform controls to extrude or inset the element(s).

--- a/Documentation~/modes.md
+++ b/Documentation~/modes.md
@@ -17,6 +17,7 @@ To change edit modes within the ProBuilder context, in the **Tool Settings** ove
 
 For a list of all shortcuts, and to add shortcuts, go to **Edit > Shortcuts** to open the [Shortcuts Manager](xref:ShortcutsManager).
 
+These are some common shortcuts you can use with ProBuilder:
 
-* **Escape** to return from the ProBuilder context to the GameObject context.
-* **G** to cycle through the ProBuilder edit modes.
+* Press **Escape** to return from the ProBuilder context to the GameObject context.
+* Press **G** to cycle through the ProBuilder edit modes.

--- a/Documentation~/tool-options-overlay.md
+++ b/Documentation~/tool-options-overlay.md
@@ -5,5 +5,5 @@ You can change settings for some ProBuilder options like extrude, collapse, and 
 To access the tool settings:
 
 1. Select a tool, for example **Main Menu** > **Tools** > **ProBuilder** > **Selection** > **Grow Selection**.
-1. From the **Overlay Men** overlay, select the corresponding action's button. For example, for the Grow Selection action, the button is **GS**.
+1. From the **Overlay Menu** overlay, select the corresponding action's button. For example, for the Grow Selection action, the button is **GS**.
 1. The **Tool Options Overlay** opens with the current tool's settings.

--- a/Documentation~/tool-options-overlay.md
+++ b/Documentation~/tool-options-overlay.md
@@ -5,5 +5,5 @@ You can change settings for some ProBuilder options like extrude, collapse, and 
 To access the tool settings:
 
 1. Select a tool, for example **Main Menu** > **Tools** > **ProBuilder** > **Selection** > **Grow Selection**.
-1. From the **Overlay Men**" overlay, select the corresponding action's button. For example, for the Grow Selection action, the button is **GS**.
+1. From the **Overlay Men** overlay, select the corresponding action's button. For example, for the Grow Selection action, the button is **GS**.
 1. The **Tool Options Overlay** opens with the current tool's settings.

--- a/Documentation~/tool-options-overlay.md
+++ b/Documentation~/tool-options-overlay.md
@@ -5,5 +5,5 @@ You can change settings for some ProBuilder options like extrude, collapse, and 
 To access the tool settings:
 
 1. Select a tool, for example **Main Menu** > **Tools** > **ProBuilder** > **Selection** > **Grow Selection**.
-1. From the **Overlay** menu, select the action button. For example, for the Grow Selection action, the button is **GS**. 
+1. From the **Overlay Men**" overlay, select the corresponding action's button. For example, for the Grow Selection action, the button is **GS**.
 1. The **Tool Options Overlay** opens with the current tool's settings.

--- a/Documentation~/workflow-edit-smoothing.md
+++ b/Documentation~/workflow-edit-smoothing.md
@@ -26,9 +26,9 @@ To smooth a part of your mesh:
 1. In the **Scene** view, in the **Tools** overlay, enable the **ProBuilder** tool context.
 1. In the **Tool Settings** overlay, select the **Face** editing mode.
 1. Select the faces that you want to have smooth adjoining edges. Use **Shift** to select multiple faces.
-1. Click an unused smooth group number on the [Smooth Group Editor](smoothing-groups.md) window.
+1. Click an unused smoothing group number on the [Smooth Group Editor](smoothing-groups.md) window. If a group is already in use, its button [highlights in blue when you hover over it](smoothing-groups.md#preview-colors).
 
-    > **Tip:** Smooth groups already in use appear with a color below the button, which corresponds to the color of the group in the **Scene** view.
+    > **Tip**: If you enable the **Preview** option in the **Smooth Group Editor** window, smoothing groups that are in use have a color below their respective button. This color corresponds to the color of the group in the **Scene** view.  
 
 You can repeat these steps using different number buttons to create more groups.
 


### PR DESCRIPTION

### Purpose of this PR

* Added link and lead-in paragraph to Keyboard Shortcuts section of "Edit modes and active contexts"
* Specified Overlay menu overlay instead of Overlay menu (overlayoverlayoverlayoverlay).
* Fixed tip in Smoothing Editor documentation.

### Links

**Jira:** https://jira.unity3d.com/browse/DOCATT-6651

### Comments to Reviewers

