### PR TITLE
[PB 5.2] Backport for the orientation handles removal on the cube shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased 
+
+### Fixed
+
+- [PBLD-150] Fixed a bug where the orientation handles would not be useful when manipulating a cube shape.
+
 ## [5.2.3] - 2024-08-12
 
 ### Added

--- a/Editor/EditorCore/EditShapeTool.cs
+++ b/Editor/EditorCore/EditShapeTool.cs
@@ -244,9 +244,12 @@ namespace UnityEditor.ProBuilder
                 for(int i = 0; i <faces.Length; ++i)
                     s_FaceControlIDs[i] = GUIUtility.GetControlID(FocusType.Passive);
 
-                var absSize = Math.Abs(proBuilderShape.editionBounds.size);
-                if(absSize.x > Mathf.Epsilon && absSize.y > Mathf.Epsilon && absSize.z > Mathf.Epsilon )
-                    DoOrientationHandles(proBuilderShape, updatePrefs);
+                if (!(proBuilderShape.shape is Cube))
+                {
+                    var absSize = Math.Abs(proBuilderShape.editionBounds.size);
+                    if (absSize.x > Mathf.Epsilon && absSize.y > Mathf.Epsilon && absSize.z > Mathf.Epsilon)
+                        DoOrientationHandles(proBuilderShape, updatePrefs);
+                }
 
                 DoSizeHandles(proBuilderShape, updatePrefs);
             }


### PR DESCRIPTION
### Purpose of this PR

[PBLD-150] Fixed a bug where the orientation handles would not be useful when manipulating a cube shape.

### Links

**Jira:** https://jira.unity3d.com/browse/PBLD-150

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]