### PR TITLE
fixing compilation error when inheriting from Editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- [PBLD-158] Fixed a bug where ProBuilder would prevent classes inheriting from `UnityEditor.Editor` to compile.
 - [PBLD-151] Fixed a bug where the Action Settings overlay would not be displayed when used the first time.
 - [PBLD-141] Fixed a bug where the selection would be incorrect when entering PrefabStage.
 - [PBLD-142] Fixed a bug where it was possible to trigger the probuilderize action twice on the same object.

--- a/Editor/EditorCore/ProBuilderToolsContexts.cs
+++ b/Editor/EditorCore/ProBuilderToolsContexts.cs
@@ -1,11 +1,11 @@
 using System;
 using System.Collections.Generic;
-using Editor.Overlays;
 using UnityEngine;
 using UnityEngine.ProBuilder;
 using UnityEngine.UIElements;
 using UnityEditor.EditorTools;
 using UnityEditor.ProBuilder.Actions;
+using UnityEditor.ProBuilder.Overlays;
 using UnityEditor.Actions;
 using UnityEditor.ShortcutManagement;
 

--- a/Editor/Overlays/SceneInformationOverlay.cs
+++ b/Editor/Overlays/SceneInformationOverlay.cs
@@ -1,9 +1,8 @@
 ﻿using UnityEditor.Overlays;
-using UnityEditor.ProBuilder;
 using UnityEngine;
 using UnityEngine.UIElements;
 
-namespace Editor.Overlays
+namespace UnityEditor.ProBuilder.Overlays
 {
     //[Overlay(typeof(SceneView), "Scene Information", true)]
     class SceneInformationOverlay : Overlay


### PR DESCRIPTION
### Purpose of this PR

Fixed a bug where ProBuilder would prevent classes inheriting from `UnityEditor.Editor` to compile.

### Links

**Jira:** https://jira.unity3d.com/browse/PBLD-158

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]