### PR TITLE
Fix PB context switch shortcut throwing an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changes
+
+- [PBLD-167] Removed "Toggle ProBuilder Context" shortcut - the built-in "Cycle Tool Modes" shortcut should be used instead.
+
 ## [6.0.3] - 2024-08-20
 
 ### Fixed

--- a/Editor/EditorCore/ProBuilderEditorShortcuts.cs
+++ b/Editor/EditorCore/ProBuilderEditorShortcuts.cs
@@ -28,15 +28,6 @@ namespace UnityEditor.ProBuilder
 			ProBuilderEditor.selectMode = SelectMode.Face;
 		}
 
-        [Shortcut("ProBuilder/Editor/Toggle ProBuilder Context", typeof(SceneViewMotion.SceneViewContext), KeyCode.G)]
-        static void Toggle_ObjectElementMode()
-        {
-            if (ToolManager.activeContextType == typeof(GameObjectToolContext))
-                ToolManager.SetActiveContext<PositionToolContext>();
-            else if(ToolManager.activeContextType == typeof(PositionToolContext))
-                ToolManager.SetActiveContext<GameObjectToolContext>();
-        }
-
 		[Shortcut("ProBuilder/Editor/Toggle Edit Mode", typeof(PositionToolContext.ProBuilderShortcutContext), KeyCode.H)]
 		static void Toggle_SelectMode()
 		{


### PR DESCRIPTION
### Purpose of this PR

Fixes issue where using PB context switch shortcut on a non-PB GameObject would throw. The "Toggle ProBuilder Context" shortcut has been removed so that built-in "Cycle Tool Modes" is used instead.

### Links

**Jira:** https://jira.unity3d.com/browse/PBLD-167

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]