### PR TITLE
Edit Vert/Edge/Face shortcuts now auto-enter PB context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changes
+
+- [PBLD-169] "Edit Vertices/Edges/Faces" shortcuts now automatically enter the ProBuilder context.
+
 ## [6.0.3] - 2024-08-20
 
 ### Fixed

--- a/Editor/EditorCore/ProBuilderEditorShortcuts.cs
+++ b/Editor/EditorCore/ProBuilderEditorShortcuts.cs
@@ -10,21 +10,30 @@ namespace UnityEditor.ProBuilder
 	/// </summary>
 	static class ProBuilderEditorShortcuts
 	{
-		[Shortcut("ProBuilder/Editor/Edit Vertices", typeof(PositionToolContext.ProBuilderShortcutContext))]
+		[Shortcut("ProBuilder/Editor/Edit Vertices", typeof(SceneViewMotion.SceneViewContext))]
 		static void SetSelectMode_Vertex()
 		{
+			if (!CheckAndEnterPBContextIfNeeded())
+				return;
+
 			ProBuilderEditor.selectMode = SelectMode.Vertex;
 		}
-
-		[Shortcut("ProBuilder/Editor/Edit Edges", typeof(PositionToolContext.ProBuilderShortcutContext))]
+		
+		[Shortcut("ProBuilder/Editor/Edit Edges", typeof(SceneViewMotion.SceneViewContext))]
 		static void SetSelectMode_Edge()
-		{
+		{			
+			if (!CheckAndEnterPBContextIfNeeded())
+				return;
+			
 			ProBuilderEditor.selectMode = SelectMode.Edge;
 		}
-
-		[Shortcut("ProBuilder/Editor/Edit Faces", typeof(PositionToolContext.ProBuilderShortcutContext))]
+		
+		[Shortcut("ProBuilder/Editor/Edit Faces", typeof(SceneViewMotion.SceneViewContext))]
 		static void SetSelectMode_Faces()
 		{
+			if (!CheckAndEnterPBContextIfNeeded())
+				return;
+			
 			ProBuilderEditor.selectMode = SelectMode.Face;
 		}
 
@@ -42,6 +51,20 @@ namespace UnityEditor.ProBuilder
 		{
 			if(ProBuilderEditor.instance != null)
 				ProBuilderEditor.instance.ToggleSelectionMode();
+		}
+
+		static bool CheckAndEnterPBContextIfNeeded()
+		{
+			if (ToolManager.activeContextType == typeof(GameObjectToolContext))
+			{
+				// Check if PositionToolContext can actually be entered
+				if (EditorToolManager.GetComponentContext(typeof(PositionToolContext), true) == null)
+					return false;
+				
+				ToolManager.SetActiveContext<PositionToolContext>();
+			}
+
+			return true;
 		}
 	}
 }

--- a/Editor/EditorCore/ProBuilderEditorShortcuts.cs
+++ b/Editor/EditorCore/ProBuilderEditorShortcuts.cs
@@ -55,7 +55,7 @@ namespace UnityEditor.ProBuilder
 
 		static bool CheckAndEnterPBContextIfNeeded()
 		{
-			if (ToolManager.activeContextType == typeof(GameObjectToolContext))
+			if (ToolManager.activeContextType != typeof(PositionToolContext))
 			{
 				// Check if PositionToolContext can actually be entered
 				if (EditorToolManager.GetComponentContext(typeof(PositionToolContext), true) == null)


### PR DESCRIPTION
### Purpose of this PR

"Edit Vertices/Edges/Faces" shortcuts now automatically enter the ProBuilder context if that's possible. This is part of the 3 step fix where we remove PB's context switch shortcut, add this change and update trunk so that context cycle shortcut include game object context.

### Links

**Jira:** https://jira.unity3d.com/browse/PBLD-169

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]