### PR TITLE
Various bugfix from Gabe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Fixed a bug where Undo was not working correctly with Polyshape creation tool. 
 - [STO-3427] Fixed a bug where Polyshape creation tool was not working with orthographic camera.
 - [STO-3429] Fixed a bug where increment snapping was ignored when drawing ProBuilder shapes.
 - [STO-3432] Fixed a bug where Polyshape creation tool was not placing properly the first point on a custom grids. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased 
+
+### Fixed
+
+- [STO-3427] Fixing a bug where Polyshape creation tool was not working with orthographic camera.
+- [STO-3429] Fixing a bug where increment snapping was ignored when drawing ProBuilder shapes.
+- [STO-3432] Fixing a bug where Polyshape creation tool was not placing properly the first point on a custom grids. 
+
 ## [6.0.4] - 2024-09-12
 
 ### Changes

--- a/Editor/EditorCore/EditorHandleUtility.cs
+++ b/Editor/EditorCore/EditorHandleUtility.cs
@@ -508,7 +508,6 @@ namespace UnityEditor.ProBuilder
         /// Get a plane suitable for mouse input in a scene view.
         /// </summary>
         /// <param name="mousePosition"></param>
-        /// <param name="alignOnGrid"></param>
         /// <returns></returns>
         internal static Plane FindBestPlane(Vector2 mousePosition)
         {
@@ -660,7 +659,7 @@ namespace UnityEditor.ProBuilder
             return true;
         }
 
-        static Plane GetPlaneFromSceneView()
+        internal static Plane GetPlaneFromSceneView()
         {
             Plane plane;
             Vector3 normal = Vector3.up;

--- a/Editor/EditorCore/PolyShapeTool.cs
+++ b/Editor/EditorCore/PolyShapeTool.cs
@@ -579,7 +579,7 @@ namespace UnityEditor.ProBuilder
                 // PBLD-137 - continously refresh the material, otherwise if Resident Drawer is on, new faces are drawn without material applied until there's some other trigger:
                 // renderer enable/disable, material re-apply, etc.
                 if (polygon.polyEditMode == PolyShape.PolyEditMode.Height && polygon.m_Points != null &&
-                    polygon.m_Points.Count >= 3)
+                    polygon.m_Points.Count >= 3 && polygon.mesh.renderer.sharedMaterial == null)
                 {
                     Undo.RegisterCompleteObjectUndo(polygon.mesh.renderer, "Adding Material");
                     polygon.mesh.renderer.sharedMaterial = EditorMaterialUtility.GetUserMaterial();
@@ -1101,7 +1101,7 @@ namespace UnityEditor.ProBuilder
                 polygon.polyEditMode =  PolyShape.PolyEditMode.Path;
                 polygon.extrude = 0f;
                 polygon.mesh.Clear();
-                DestroyImmediate(polygon.mesh.mesh);
+                DestroyImmediate(polygon.mesh.mesh, true);
             }
 
             if (polygon != null && polygon.polyEditMode != PolyShape.PolyEditMode.None)

--- a/Editor/EditorCore/PolyShapeTool.cs
+++ b/Editor/EditorCore/PolyShapeTool.cs
@@ -44,9 +44,6 @@ namespace UnityEditor.ProBuilder
             m_PolyShape = null;
             if (m_LastPolyShape)
                 Selection.activeObject = m_LastPolyShape;
-
-            //Cancel the last PolyShapeTool action in undo history (extra GO created)
-            //Undo.RevertAllDownToGroup(Undo.GetCurrentGroup() - 1);
         }
 
         public override void OnToolGUI(EditorWindow window)

--- a/Editor/StateMachines/ShapeState_DrawBaseShape.cs
+++ b/Editor/StateMachines/ShapeState_DrawBaseShape.cs
@@ -83,7 +83,7 @@ namespace UnityEditor.ProBuilder
         {
             var deltaPoint = ray.GetPoint(distance) - tool.m_BB_Origin;
             deltaPoint = Quaternion.Inverse(tool.m_PlaneRotation) * deltaPoint;
-            deltaPoint = tool.GetPoint(deltaPoint, Event.current.control);
+            deltaPoint = tool.GetPoint(deltaPoint, EditorSnapSettings.snapEnabled);
             tool.m_BB_OppositeCorner = tool.m_PlaneRotation * deltaPoint + tool.m_BB_Origin;
             tool.m_BB_HeightCorner = tool.m_BB_OppositeCorner;
             tool.RebuildShape();

--- a/Editor/StateMachines/ShapeState_DrawHeightShape.cs
+++ b/Editor/StateMachines/ShapeState_DrawHeightShape.cs
@@ -78,7 +78,7 @@ namespace UnityEditor.ProBuilder
                         {
                             var deltaPoint = (dot == 0 ? ray.origin - tool.m_Plane.ClosestPointOnPlane(ray.origin) : heightPoint - tool.m_BB_OppositeCorner);
                             deltaPoint = Quaternion.Inverse(tool.m_PlaneRotation) * deltaPoint;
-                            deltaPoint = tool.GetPoint(deltaPoint, evt.control);
+                            deltaPoint = tool.GetPoint(deltaPoint, EditorSnapSettings.snapEnabled);
                             tool.m_BB_HeightCorner = tool.m_PlaneRotation * deltaPoint + tool.m_BB_OppositeCorner;
                             tool.RebuildShape();
                         }


### PR DESCRIPTION
### Purpose of this PR

### Fixed

- [STO-3427] Fixing a bug where Polyshape creation tool was not working with orthographic camera.
![polyshape-iso](https://github.com/user-attachments/assets/3a8cc552-7fee-463a-b93d-4682879d05a7)

- [STO-3429] Fixing a bug where increment snapping was ignored when drawing ProBuilder shapes.
![pbshape-incremental](https://github.com/user-attachments/assets/68095775-d1b8-4f08-a91f-c11e84108ccf)

- [STO-3432] Fixing a bug where Polyshape creation tool was not placing properly the first point on a custom grids. 
![polyshape-grid](https://github.com/user-attachments/assets/69aa4d58-8f35-46bd-880b-0cc37b892f15)

### Links

**Jira:**

- [STO-3427]
- [STO-3429]
- [STO-3432]

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]