### PR TITLE
Fix for 'Extrude by' UI setting having no effect on 'Extrude faces' action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed a bug where Undo was not working correctly with Polyshape creation tool. 
 - [STO-3427] Fixed a bug where Polyshape creation tool was not working with orthographic camera.
 - [STO-3429] Fixed a bug where increment snapping was ignored when drawing ProBuilder shapes.
-- [STO-3432] Fixed a bug where Polyshape creation tool was not placing properly the first point on a custom grids. 
+- [STO-3432] Fixed a bug where Polyshape creation tool was not placing properly the first point on a custom grids.
+- [PBLD-183] Fixed a bug where the 'Extrude by' setting of the 'Extrude Faces' action would always be set to 'Individual Faces'.
 
 ## [6.0.4] - 2024-09-12
 

--- a/Editor/MenuActions/Geometry/ExtrudeFaces.cs
+++ b/Editor/MenuActions/Geometry/ExtrudeFaces.cs
@@ -77,12 +77,12 @@ namespace UnityEditor.ProBuilder.Actions
 
             var extrudeMethodField = new EnumField("Extrude By", extrudeMethod);
             extrudeMethodField.tooltip = " You may also choose to Extrude by Face Normal, Vertex Normal, or as Individual Faces.";
-            extrudeMethodField.RegisterCallback<ChangeEvent<string>>(evt =>
+            extrudeMethodField.RegisterCallback<ChangeEvent<System.Enum>>(evt =>
             {
-                System.Enum.TryParse(evt.newValue, out ExtrudeMethod newValue);
-                if (extrudeMethod != newValue)
+                var newEnumValue = (ExtrudeMethod)evt.newValue;
+                if (extrudeMethod != newEnumValue)
                 {
-                    extrudeMethod = newValue;
+                    extrudeMethod = newEnumValue;
                     extrudeMethodLabel.style.backgroundImage = m_Icons[(int)extrudeMethod];
                     ProBuilderSettings.Save();
                     PreviewActionManager.UpdatePreview();


### PR DESCRIPTION
### Purpose of this PR

PR fixes an issue where selecting any of the `Extrude by` options after hitting `Extrude faces` for a group of faces would always result in `Individual Faces` setting being used under the hood (ignoring the UI selection).

The issue was that the change subscription was done for a `string` argument even when it should have been `System.Enum`. The `System.Enum.Parse` would always fail and return a default value which is `Individual Faces`.

### Links

**Jira:** https://jira.unity3d.com/browse/PBLD-183

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]