### PR TITLE
Fix for DrawShape tool not always respecting pivot location

### DIFF
--- a/Editor/EditorCore/DrawShapeTool.cs
+++ b/Editor/EditorCore/DrawShapeTool.cs
@@ -435,6 +435,7 @@ namespace UnityEditor.ProBuilder
         }
 
         internal Vector3 m_LastNonDuplicateCenterToOrigin;
+        PivotLocation m_LastPreviewPivotLocation;
        
         internal Vector3 previewPivotPosition
         {
@@ -685,8 +686,10 @@ namespace UnityEditor.ProBuilder
             m_Bounds.center = cornerPosition + new Vector3(size.x / 2f, 0, size.z / 2f) + (size.y / 2f) * m_Plane.normal;
             var lastPreviewRotation = m_PlaneRotation;
             m_PlaneRotation = Quaternion.LookRotation(m_PlaneForward, m_Plane.normal);
-            var forceRebuildPreview = !m_PlaneRotation.Equals(lastPreviewRotation);
-
+            var forceRebuildPreview = !m_PlaneRotation.Equals(lastPreviewRotation) || 
+                                      m_LastPreviewPivotLocation != pivotLocation;
+            m_LastPreviewPivotLocation = pivotLocation;
+            
             var preview_BB_Origin = m_Bounds.center - m_PlaneRotation * (size / 2f);
             var preview_BB_HeightCorner = m_Bounds.center + m_PlaneRotation * (size / 2f);
             var preview_BB_OppositeCorner = preview_BB_HeightCorner - m_PlaneRotation * new Vector3(0, size.y, 0);

--- a/Editor/EditorCore/DrawShapeTool.cs
+++ b/Editor/EditorCore/DrawShapeTool.cs
@@ -426,7 +426,10 @@ namespace UnityEditor.ProBuilder
                     {
                         var lastShape = instance.m_LastShapeCreated;
                         var lastShapeTrs = lastShape.transform;
-                        var newPivotPosition = value == PivotLocation.Center ? lastShape.shapeWorldCenter : instance.m_BB_Origin;
+                        var newPivotPosition = lastShape.shapeWorldCenter;
+                        if (value != PivotLocation.Center)
+                            newPivotPosition += instance.m_PlaneRotation * m_LastNonDuplicateCenterToOrigin;
+                        
                         instance.m_LastShapeCreated.Rebuild(newPivotPosition, lastShapeTrs.rotation, lastShape.shapeWorldBounds);
                     }
                     shapePivotLocation = value;

--- a/Editor/StateMachines/ShapeState_DrawBaseShape.cs
+++ b/Editor/StateMachines/ShapeState_DrawBaseShape.cs
@@ -60,8 +60,8 @@ namespace UnityEditor.ProBuilder
 
                             if(Vector3.Distance(tool.m_BB_OppositeCorner, tool.m_BB_Origin) <= Mathf.Min(0.01f, tool.minSnapSize))
                                 return ResetState();
-                            
-                      
+
+
                             tool.m_LastNonDuplicateCenterToOrigin = Quaternion.Inverse(tool.m_PlaneRotation) * ((tool.m_BB_Origin - tool.m_BB_OppositeCorner) * 0.5f);
                             return NextState();
                         }
@@ -98,12 +98,9 @@ namespace UnityEditor.ProBuilder
             UndoUtility.RegisterCreatedObjectUndo(shape.gameObject, $"Create Shape");
             EditorUtility.InitObject(shape.mesh);
             tool.ApplyPrefsSettings(shape);
-            
+
             EditorShapeUtility.CopyLastParams(shape.shape, shape.shape.GetType());
             shape.Rebuild(tool.previewPivotPosition, tool.m_PlaneRotation, tool.m_Bounds);
-
-            Debug.Log("DBG: rebuild LAST shape pos: " + tool.previewPivotPosition +
-                      " rot: " + tool.m_PlaneRotation + " bounds: " +  tool.m_Bounds);
 
             //Finish initializing object and collider once it's completed
             ProBuilderEditor.Refresh(false);

--- a/Editor/StateMachines/ShapeState_DrawBaseShape.cs
+++ b/Editor/StateMachines/ShapeState_DrawBaseShape.cs
@@ -61,9 +61,8 @@ namespace UnityEditor.ProBuilder
                             if(Vector3.Distance(tool.m_BB_OppositeCorner, tool.m_BB_Origin) <= Mathf.Min(0.01f, tool.minSnapSize))
                                 return ResetState();
                             
-                            tool.m_LastNonDuplicateCenterToOrigin = (tool.m_BB_Origin - tool.m_BB_OppositeCorner) * 0.5f;
-                            tool.m_LastNonDuplicateRotation = tool.m_PlaneRotation;
-
+                      
+                            tool.m_LastNonDuplicateCenterToOrigin = Quaternion.Inverse(tool.m_PlaneRotation) * ((tool.m_BB_Origin - tool.m_BB_OppositeCorner) * 0.5f);
                             return NextState();
                         }
                         break;
@@ -102,6 +101,9 @@ namespace UnityEditor.ProBuilder
             
             EditorShapeUtility.CopyLastParams(shape.shape, shape.shape.GetType());
             shape.Rebuild(tool.previewPivotPosition, tool.m_PlaneRotation, tool.m_Bounds);
+
+            Debug.Log("DBG: rebuild LAST shape pos: " + tool.previewPivotPosition +
+                      " rot: " + tool.m_PlaneRotation + " bounds: " +  tool.m_Bounds);
 
             //Finish initializing object and collider once it's completed
             ProBuilderEditor.Refresh(false);

--- a/Editor/StateMachines/ShapeState_DrawBaseShape.cs
+++ b/Editor/StateMachines/ShapeState_DrawBaseShape.cs
@@ -52,7 +52,7 @@ namespace UnityEditor.ProBuilder
                     case EventType.MouseUp:
                         if(evt.button == 0)
                         {
-                            if(!m_IsDragging && evt.shift)
+                            if (!m_IsDragging && evt.shift)
                             {
                                 CreateLastShape();
                                 return ResetState();
@@ -60,6 +60,9 @@ namespace UnityEditor.ProBuilder
 
                             if(Vector3.Distance(tool.m_BB_OppositeCorner, tool.m_BB_Origin) <= Mathf.Min(0.01f, tool.minSnapSize))
                                 return ResetState();
+                            
+                            tool.m_LastNonDuplicateCenterToOrigin = (tool.m_BB_Origin - tool.m_BB_OppositeCorner) * 0.5f;
+                            tool.m_LastNonDuplicateRotation = tool.m_PlaneRotation;
 
                             return NextState();
                         }
@@ -96,9 +99,9 @@ namespace UnityEditor.ProBuilder
             UndoUtility.RegisterCreatedObjectUndo(shape.gameObject, $"Create Shape");
             EditorUtility.InitObject(shape.mesh);
             tool.ApplyPrefsSettings(shape);
-
+            
             EditorShapeUtility.CopyLastParams(shape.shape, shape.shape.GetType());
-            shape.Rebuild(tool.m_Bounds, tool.m_PlaneRotation);
+            shape.Rebuild(tool.previewPivotPosition, tool.m_PlaneRotation, tool.m_Bounds);
 
             //Finish initializing object and collider once it's completed
             ProBuilderEditor.Refresh(false);

--- a/Editor/StateMachines/ShapeState_DrawHeightShape.cs
+++ b/Editor/StateMachines/ShapeState_DrawHeightShape.cs
@@ -86,7 +86,10 @@ namespace UnityEditor.ProBuilder
                         break;
 
                     case EventType.MouseUp:
+                    {
+                        tool.m_LastNonDuplicateCenterToOrigin = (tool.m_BB_Origin - tool.m_BB_HeightCorner) * 0.5f;
                         return ValidateShape();
+                    }
                 }
             }
 

--- a/Editor/StateMachines/ShapeState_DrawHeightShape.cs
+++ b/Editor/StateMachines/ShapeState_DrawHeightShape.cs
@@ -87,7 +87,7 @@ namespace UnityEditor.ProBuilder
 
                     case EventType.MouseUp:
                     {
-                        tool.m_LastNonDuplicateCenterToOrigin = (tool.m_BB_Origin - tool.m_BB_HeightCorner) * 0.5f;
+                        tool.m_LastNonDuplicateCenterToOrigin = Quaternion.Inverse(tool.m_PlaneRotation)  * ((tool.m_BB_Origin - tool.m_BB_HeightCorner) * 0.5f);
                         return ValidateShape();
                     }
                 }


### PR DESCRIPTION
### Purpose of this PR

PR fixes DrawShapeTool's shift duplication behaviour:
1) Preview not matching the changes in the original shape when Pivot location is being toggled between previews.
2) Duplicated shape always having center as it's pivot location - regardless what the original shape had.
3) Triggering previews between changes to Pivot location sometimes messed up original shape's pivot - it becomes neither pivot nor center.

Before fix:


https://github.com/user-attachments/assets/086690fd-05e3-4cc1-8277-bc95adb28e35


After fix:

https://github.com/user-attachments/assets/dfa33e15-1601-44b5-a788-26e1ba4b74d6



### Links

**Jira:** https://jira.unity3d.com/browse/PBLD-185

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]