### PR TITLE
[PBLD-187] Fix Drawshape pivot on rotated surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- [PBLD-187] Fixed a bug where the object size was incorrect when using the DrawShape tool on angled surfaces.
 - [PBLD-180] Fixed an issue in the Material Editor where an exception was thrown because it attempted to retrieve `MenuItem` shortcuts before the main menu was fully loaded.
 - Fixed a bug where Undo was not working correctly with Polyshape creation tool. 
 - [PBLD-196] Fixed a bug where Polyshape creation tool was not working with orthographic camera.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased 
 
+### Changes
+
+- Improved DrawShape tool performance when placing the first vertex.
+
 ### Fixed
 
 - [PBLD-187] Fixed a bug where the object size was incorrect when using the DrawShape tool on angled surfaces.

--- a/Editor/EditorCore/DrawShapeTool.cs
+++ b/Editor/EditorCore/DrawShapeTool.cs
@@ -429,7 +429,7 @@ namespace UnityEditor.ProBuilder
                         var newPivotPosition = lastShape.shapeWorldCenter;
                         if (value != PivotLocation.Center)
                             newPivotPosition += instance.m_PlaneRotation * m_LastNonDuplicateCenterToOrigin;
-                        
+
                         instance.m_LastShapeCreated.Rebuild(newPivotPosition, lastShapeTrs.rotation, lastShape.shapeWorldBounds);
                     }
                     shapePivotLocation = value;
@@ -439,7 +439,7 @@ namespace UnityEditor.ProBuilder
 
         internal Vector3 m_LastNonDuplicateCenterToOrigin;
         PivotLocation m_LastPreviewPivotLocation;
-       
+
         internal Vector3 previewPivotPosition
         {
             get
@@ -448,14 +448,14 @@ namespace UnityEditor.ProBuilder
                 {
                     var lastCenterToOrigin = instance.m_LastNonDuplicateCenterToOrigin;
                     var lastCenterToOriginNorm = lastCenterToOrigin.normalized;
-                    
+
                     var deltaRot = instance.m_PlaneRotation;
                     lastCenterToOriginNorm = deltaRot * lastCenterToOriginNorm;
 
                     var pivotOffset = lastCenterToOriginNorm * lastCenterToOrigin.magnitude;
                     return pivotOffset + instance.m_Bounds.center;
                 }
-                
+
                 return m_Bounds.center;
             }
         }
@@ -685,14 +685,14 @@ namespace UnityEditor.ProBuilder
             position = GetPoint(position);
             var cornerPosition = position - size / 2f;
             cornerPosition.y = position.y;
-            
+
             m_Bounds.center = cornerPosition + new Vector3(size.x / 2f, 0, size.z / 2f) + (size.y / 2f) * m_Plane.normal;
             var lastPreviewRotation = m_PlaneRotation;
             m_PlaneRotation = Quaternion.LookRotation(m_PlaneForward, m_Plane.normal);
-            var forceRebuildPreview = !m_PlaneRotation.Equals(lastPreviewRotation) || 
+            var forceRebuildPreview = !m_PlaneRotation.Equals(lastPreviewRotation) ||
                                       m_LastPreviewPivotLocation != pivotLocation;
             m_LastPreviewPivotLocation = pivotLocation;
-            
+
             var preview_BB_Origin = m_Bounds.center - m_PlaneRotation * (size / 2f);
             var preview_BB_HeightCorner = m_Bounds.center + m_PlaneRotation * (size / 2f);
             var preview_BB_OppositeCorner = preview_BB_HeightCorner - m_PlaneRotation * new Vector3(0, size.y, 0);
@@ -710,7 +710,7 @@ namespace UnityEditor.ProBuilder
 
                 EditorShapeUtility.CopyLastParams(shape.shape, shape.shape.GetType());
                 shape.Rebuild(previewPivotPosition, m_PlaneRotation, m_Bounds);
-                
+
                 ProBuilderEditor.Refresh(false);
             }
             else
@@ -740,7 +740,7 @@ namespace UnityEditor.ProBuilder
             else
                 pivot = previewPivotPosition;
             m_DuplicateGO.transform.SetPositionAndRotation(pivot, Quaternion.LookRotation(m_PlaneForward, m_Plane.normal));
-            
+
             DrawBoundingBox(preview_BB_Origin, preview_BB_HeightCorner, preview_BB_OppositeCorner, false);
         }
 
@@ -749,8 +749,9 @@ namespace UnityEditor.ProBuilder
         /// </summary>
         void RecalculateBounds()
         {
-            var forward = HandleUtility.PointOnLineParameter(m_BB_OppositeCorner, m_BB_Origin, m_PlaneForward);
-            var right = HandleUtility.PointOnLineParameter(m_BB_OppositeCorner, m_BB_Origin, m_PlaneRight);
+            var diag = m_BB_OppositeCorner - m_BB_Origin;
+            var forward = Vector3.Dot(diag, m_PlaneForward.normalized);
+            var right = Vector3.Dot(diag, m_PlaneRight.normalized);
 
             var localHeight = Quaternion.Inverse(m_PlaneRotation) * (m_BB_HeightCorner - m_BB_OppositeCorner);
             var height = localHeight.y;
@@ -850,7 +851,7 @@ namespace UnityEditor.ProBuilder
                 Handles.DotHandleCap(-1, heightCorner, Quaternion.identity, HandleUtility.GetHandleSize(heightCorner) * 0.05f, EventType.Repaint);
             }
         }
-        
+
         internal void DrawBoundingBox(bool drawCorners = true)
         {
             DrawBoundingBox(m_BB_Origin, m_BB_OppositeCorner, m_BB_HeightCorner, drawCorners);

--- a/Editor/StateMachines/ShapeState_InitShape.cs
+++ b/Editor/StateMachines/ShapeState_InitShape.cs
@@ -47,52 +47,60 @@ namespace UnityEditor.ProBuilder
 
             if(evt.isMouse && HandleUtility.nearestControl == tool.controlID)
             {
-                var res = EditorHandleUtility.FindBestPlaneAndBitangent(evt.mousePosition, tool.m_DuplicateGO);
-                Ray ray = HandleUtility.GUIPointToWorldRay(evt.mousePosition);
-                float hit;
-
-                if(evt.button == 0 && res.item1.Raycast(ray, out hit))
+                if (evt.type != EventType.MouseDown)
                 {
-                    //Plane init
-                    tool.m_Plane = res.item1;
-                    tool.m_PlaneForward = res.item2;
-                    tool.m_PlaneRight = Vector3.Cross(tool.m_Plane.normal, tool.m_PlaneForward);
-
-                    var planeNormal = tool.m_Plane.normal;
-                    var planeCenter = tool.m_Plane.normal * -tool.m_Plane.distance;
-                    // if hit point on plane is cardinal axis and on grid, snap to grid.
-                    if(Math.IsCardinalAxis(planeNormal))
-                    {
-                        const float epsilon = .00001f;
-                        bool offGrid = false;
-                        Vector3 snapVal = EditorSnapping.activeMoveSnapValue;
-                        Vector3 center =
-                            Vector3.Scale(ProBuilderSnapping.GetSnappingMaskBasedOnNormalVector(planeNormal),
-                                planeCenter);
-                        for(int i = 0; i < 3; i++)
-                            offGrid |= Mathf.Abs(snapVal[i] % center[i]) > epsilon;
-                        tool.m_IsOnGrid = !offGrid;
-                    }
-                    else
-                    {
-                        tool.m_IsOnGrid = false;
-                    }
-
-                    m_HitPosition = tool.GetPoint(ray.GetPoint(hit));
-
-                    //Click has been done => Define a plane for the tool
-                    if(evt.type == EventType.MouseDown && evt.button == 0)
-                    {
-                        //BB init
-                        tool.m_BB_Origin = m_HitPosition;
-                        tool.m_BB_HeightCorner = tool.m_BB_Origin;
-                        tool.m_BB_OppositeCorner = tool.m_BB_Origin;
-
-                        return NextState();
-                    }
+                    HandleUtility.PlaceObject(evt.mousePosition, out m_HitPosition, out _);
+                    m_HitPosition = tool.GetPoint(m_HitPosition);
                 }
                 else
-                    m_HitPosition = Vector3.positiveInfinity;
+                {
+                    var res = EditorHandleUtility.FindBestPlaneAndBitangent(evt.mousePosition, tool.m_DuplicateGO);
+                    Ray ray = HandleUtility.GUIPointToWorldRay(evt.mousePosition);
+                    float hit;
+
+                    if (evt.button == 0 && res.item1.Raycast(ray, out hit))
+                    {
+                        //Plane init
+                        tool.m_Plane = res.item1;
+                        tool.m_PlaneForward = res.item2;
+                        tool.m_PlaneRight = Vector3.Cross(tool.m_Plane.normal, tool.m_PlaneForward);
+
+                        var planeNormal = tool.m_Plane.normal;
+                        var planeCenter = tool.m_Plane.normal * -tool.m_Plane.distance;
+                        // if hit point on plane is cardinal axis and on grid, snap to grid.
+                        if (Math.IsCardinalAxis(planeNormal))
+                        {
+                            const float epsilon = .00001f;
+                            bool offGrid = false;
+                            Vector3 snapVal = EditorSnapping.activeMoveSnapValue;
+                            Vector3 center =
+                                Vector3.Scale(ProBuilderSnapping.GetSnappingMaskBasedOnNormalVector(planeNormal),
+                                    planeCenter);
+                            for (int i = 0; i < 3; i++)
+                                offGrid |= Mathf.Abs(snapVal[i] % center[i]) > epsilon;
+                            tool.m_IsOnGrid = !offGrid;
+                        }
+                        else
+                        {
+                            tool.m_IsOnGrid = false;
+                        }
+
+                        m_HitPosition = tool.GetPoint(ray.GetPoint(hit));
+
+                        //Click has been done => Define a plane for the tool
+                        if (evt.type == EventType.MouseDown && evt.button == 0)
+                        {
+                            //BB init
+                            tool.m_BB_Origin = m_HitPosition;
+                            tool.m_BB_HeightCorner = tool.m_BB_Origin;
+                            tool.m_BB_OppositeCorner = tool.m_BB_Origin;
+
+                            return NextState();
+                        }
+                    }
+                    else
+                        m_HitPosition = Vector3.positiveInfinity;
+                }
             }
 
             if (!Math.IsNumber(m_HitPosition))


### PR DESCRIPTION
### Purpose of this PR

[PBLD-187] Fixed an issue where the shape size was incorrect when drawing the shape on an angled surface.
Before fix:
<img width="228" alt="pivot-bug" src="https://github.com/user-attachments/assets/e2612200-2861-4ce7-9718-a57b53952f2c" />

After fix:
<img width="179" alt="pivot-fix" src="https://github.com/user-attachments/assets/fccbce1d-fb58-46d9-8cda-8d606c64bdad" />

Also small performance optimization on the DrawShape tool init phase:
Before:
<img width="937" alt="before-fix" src="https://github.com/user-attachments/assets/c9b10682-bb11-450d-9640-4682e12c7e0b" />

After:
<img width="932" alt="after-fix" src="https://github.com/user-attachments/assets/2508fa03-a2d3-4fb4-941e-05a4e0905832" />


### Links

**Jira:** https://jira.unity3d.com/browse/PBLD-187

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]