### PR TITLE
[PBLD-189] Fixed auto-stitch shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- [PBLD-189] Fixed a bug where using the auto-stitch functionality of the UV Editor would not work properly on MacOS.
 - [PBLD-187] Fixed a bug where the object size was incorrect when using the DrawShape tool on angled surfaces.
 - [PBLD-180] Fixed an issue in the Material Editor where an exception was thrown because it attempted to retrieve `MenuItem` shortcuts before the main menu was fully loaded.
 - Fixed a bug where Undo was not working correctly with Polyshape creation tool. 

--- a/Editor/EditorCore/EditorSceneViewPicker.cs
+++ b/Editor/EditorCore/EditorSceneViewPicker.cs
@@ -107,10 +107,6 @@ namespace UnityEditor.ProBuilder
 
                 foreach (var face in s_Selection.faces)
                 {
-                    UVEditor uvEditor = UVEditor.instance;
-                    if (uvEditor != null && uvEditor.ClickShortcutCheck(mesh, face))
-                        return null;
-
                     var faces = mesh.faces as Face[] ?? mesh.faces.ToArray();
                     var ind = Array.IndexOf<Face>(faces, face);
                     var sel = mesh.selectedFaceIndexes.IndexOf(ind);


### PR DESCRIPTION
### Purpose of this PR

Fixed a bug where using the auto-stitch functionality of the UV Editor would not work properly on MacOS.
Adding the 2 following auto-stitch functions to the shortcut manager and removing them from custom code handling:
- Auto-stitch UV
- Copy UV Settings

### Links

**Jira:** https://jira.unity3d.com/browse/PBLD-189

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]