### PR TITLE
[PBLD-192][PB5-Backport] Fix for vertex snapping to self-object vertices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- [PBLD-192] Fixed a bug where vertices were not able to snap on other vertices from the same mesh for Unity 2020.3 and later.
 - [PBLD-150] Fixed a bug where the orientation handles would not be useful when manipulating a cube shape.
 
 ## [5.2.3] - 2024-08-12

--- a/Editor/EditorCore/ProbuilderMoveTool.cs
+++ b/Editor/EditorCore/ProbuilderMoveTool.cs
@@ -78,7 +78,6 @@ namespace UnityEditor.ProBuilder
                             m_Position = nearest;
 
                         delta = m_Position - handlePositionOrigin;
-                        Debug.Log("Found near vertex");
                     }
                 }
                 else if (EditorSnapping.snapMode == SnapMode.World)

--- a/Editor/EditorCore/ProbuilderMoveTool.cs
+++ b/Editor/EditorCore/ProbuilderMoveTool.cs
@@ -73,8 +73,12 @@ namespace UnityEditor.ProBuilder
                                 handlePositionOrigin + rotationDirection,
                                 handlePositionOrigin - rotationDirection);
 
-                            delta = m_Position - handlePositionOrigin;
                         }
+                        else
+                            m_Position = nearest;
+
+                        delta = m_Position - handlePositionOrigin;
+                        Debug.Log("Found near vertex");
                     }
                 }
                 else if (EditorSnapping.snapMode == SnapMode.World)

--- a/Editor/EditorCore/VertexManipulationTool.cs
+++ b/Editor/EditorCore/VertexManipulationTool.cs
@@ -382,7 +382,7 @@ namespace UnityEditor.ProBuilder
         protected static bool FindNearestVertex(Vector2 mousePosition, out Vector3 vertex)
         {
 #if UNITY_2020_2_OR_NEWER
-            return HandleUtility.FindNearestVertex(mousePosition, out vertex);
+            return HandleUtility.FindNearestVertex(mousePosition, null, null, out vertex);
 #else
             s_FindNearestVertexArguments[0] = mousePosition;
             s_FindNearestVertexArguments[1] = null;


### PR DESCRIPTION
### Purpose of this PR

This PR fixes the Move tool behavior when using Vertex snapping.

The user now has a setting to activate/de-activate in order to enable vertex snapping on the object itself.
This is a settings in the tool settings toolbar, also assignable using a shortcut.

![snaptoself-fix](https://github.com/user-attachments/assets/28bdbd99-1437-48b0-bedf-552cc2e7f094)

Leaving that as a settings as using vertex snapping on really complex objects, it might not be desired by users to snap on the object itself :P 
https://jira.unity3d.com/browse/PBLD-192

@gabrielw-us : I would need a new icon for that settings in the toolbar

### Links

**Jira:** https://jira.unity3d.com/browse/PBLD-192

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]