### PR TITLE
[PBLD-189][PB5-Backport] Fixed auto-stitch shortcuts 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- [PBLD-189] Fixed a bug where using the auto-stitch functionality of the UV Editor would not work properly on MacOS, moved it to Command+Shift+Alt + Click (MacOS only).
 - [PBLD-150] Fixed a bug where the orientation handles would not be useful when manipulating a cube shape.
 
 ## [5.2.3] - 2024-08-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- [PBLD-189] Fixed a bug where using the auto-stitch functionality of the UV Editor would not work properly on MacOS, moved it to Command+Shift+Alt + Click (MacOS only).
+- [PBLD-189] Fixed a bug where using the auto-stitch functionality of the UV Editor would not work properly on MacOS, moved it to Control+Command+Shift + Left click (MacOS only).
 - [PBLD-150] Fixed a bug where the orientation handles would not be useful when manipulating a cube shape.
 
 ## [5.2.3] - 2024-08-12

--- a/Editor/EditorCore/UVEditor.cs
+++ b/Editor/EditorCore/UVEditor.cs
@@ -716,7 +716,7 @@ namespace UnityEditor.ProBuilder
             }
 #if UNITY_EDITOR_OSX
             // PBLD-189: Auto-stitch has incorrect and inconvenient shortcut on MacOS
-            else if (e.modifiers == (EventModifiers.Command | EventModifiers.Shift | EventModifiers.Alt))
+            else if (e.modifiers == (EventModifiers.Control | EventModifiers.Command |  EventModifiers.Shift))
 #else
             else if (e.modifiers == EventModifiers.Control)
 #endif

--- a/Editor/EditorCore/UVEditor.cs
+++ b/Editor/EditorCore/UVEditor.cs
@@ -88,7 +88,7 @@ namespace UnityEditor.ProBuilder
         static readonly Color SELECTED_COLOR_MANUAL = new Color(1f, .68f, 0f, .39f);
         static readonly Color SELECTED_COLOR_AUTO = new Color(0f, .785f, 1f, .39f);
 
-#if UNITY_STANDALONE_OSX
+#if UNITY_EDITOR_OSX
         public bool ControlKey { get { return Event.current.modifiers == EventModifiers.Command; } }
     #else
         public bool ControlKey
@@ -221,7 +221,7 @@ namespace UnityEditor.ProBuilder
 
         void ScreenshotMenu()
         {
-#if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
+#if UNITY_EDITOR_OSX
 
 // On Mac ShowAsDropdown and ShowAuxWindow both throw stack pop exceptions when initialized.
             UVRenderOptions renderOptions = EditorWindow.GetWindow<UVRenderOptions>(true, "Save UV Image", true);
@@ -648,7 +648,7 @@ namespace UnityEditor.ProBuilder
 
         bool IsCopyUVSettingsModifiers(EventModifiers modifiers)
         {
-#if UNITY_STANDALONE_OSX
+#if UNITY_EDITOR_OSX
             return (modifiers == (EventModifiers.Command | EventModifiers.Shift));
 #else
             return (modifiers == (EventModifiers.Control | EventModifiers.Shift));
@@ -714,7 +714,12 @@ namespace UnityEditor.ProBuilder
             {
                 return CopyFaceUVSettings(pb, selectedFace);
             }
+#if UNITY_EDITOR_OSX
+            // PBLD-189: Auto-stitch has incorrect and inconvenient shortcut on MacOS
+            else if (em == (EventModifiers.Command | EventModifiers.Shift | EventModifiers.Alt))
+#else
             else if (e.modifiers == EventModifiers.Control)
+#endif
             {
                 int len = pb.selectedFacesInternal == null ? 0 : pb.selectedFacesInternal.Length;
 

--- a/Editor/EditorCore/UVEditor.cs
+++ b/Editor/EditorCore/UVEditor.cs
@@ -716,7 +716,7 @@ namespace UnityEditor.ProBuilder
             }
 #if UNITY_EDITOR_OSX
             // PBLD-189: Auto-stitch has incorrect and inconvenient shortcut on MacOS
-            else if (em == (EventModifiers.Command | EventModifiers.Shift | EventModifiers.Alt))
+            else if (e.modifiers == (EventModifiers.Command | EventModifiers.Shift | EventModifiers.Alt))
 #else
             else if (e.modifiers == EventModifiers.Control)
 #endif


### PR DESCRIPTION
### Purpose of this PR
Fixed a bug where using the auto-stitch functionality of the UV Editor would not work properly on MacOS.
Adding the 2 following auto-stitch functions to the shortcut manager and removing them from custom code handling:

- Auto-stitch UV
- Copy UV Settings

@modrimkus-unity , can you test:
- opening the ScreenshotMenu from the button (I changed UNITY_STANDALON to EDITOR), the menu should now open
- Auto-stich shortcut for MacOS
- CopyUVSettings (Cmd + Shift shortcut should assign the UV of the selected element to the clicked one)

### Links
Jira: https://jira.unity3d.com/browse/PBLD-189

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]