### PR TITLE
Remove m_IconContent in favour of [Icon()]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Fixed a bug where "Cut Tool" text was displaying when toolbar was in horizontal position.
 - [PBLD-192] Fixed a bug where vertices were not able to snap on other vertices from the same mesh.
 - [PBLD-189] Fixed a bug where using the auto-stitch functionality of the UV Editor would not work properly on MacOS.
 - [PBLD-187] Fixed a bug where the object size was incorrect when using the DrawShape tool on angled surfaces.

--- a/Editor/EditorCore/CutTool.cs
+++ b/Editor/EditorCore/CutTool.cs
@@ -19,6 +19,7 @@ using Vertex = UnityEngine.ProBuilder.Vertex;
 namespace UnityEditor.ProBuilder
 {
     [EditorTool("Cut Tool", typeof(ProBuilderMesh), typeof(PositionToolContext))]
+    [Icon("Packages/com.unity.probuilder/Content/Icons/Toolbar/CutTool.png")]
     class CutTool : EditorTool
     {
         ProBuilderMesh m_Mesh;
@@ -84,12 +85,6 @@ namespace UnityEditor.ProBuilder
         static readonly Color k_DrawingLineColor = new Color(0.01f, .9f, 0.3f, 1f);
 
         Color m_CurrentHandleColor = k_HandleColor;
-
-        GUIContent m_IconContent;
-        public override GUIContent toolbarIcon
-        {
-            get { return m_IconContent; }
-        }
 
         //Handles and point placement
         int m_ControlId;
@@ -169,13 +164,6 @@ namespace UnityEditor.ProBuilder
 
         void OnEnable()
         {
-            m_IconContent = new GUIContent()
-            {
-                image = IconUtility.GetIcon("Toolbar/CutTool"),
-                text = "Cut Tool",
-                tooltip = "Cut Tool"
-            };
-
             s_HandleColorUseExistingVertex = Handles.selectedColor;
             s_HandleColorAddVertexOnEdge = Handles.selectedColor;
 


### PR DESCRIPTION
### Purpose of this PR

This PR removes the "Cut Tool" text that was previously visible when the toolbar was displayed horizontally. This was due to the cut tool using different Icon import method than other tools, causing the text to display even though normally, since it has an icon, it should not display.

### Links

**Jira:** N/A

### Comments to Reviewers

None.