### PR TITLE
Fix Polyshape Tool Exiting Behaviours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Fixed a bug where you could progress to the Edit Height stage of the Polyshape creation tool without forming a base polygon with at least three points.
+- Fixed a bug where shapes created by pressing Enter or Space using the Polyshape creation tool were not interactible nor added to the Scene hierarchy.
+- [PBLD-213] Fixed a bug where selection changes with the Polyshape creation tool active were being reverted.
 - [PBLD-192] Fixed a bug where vertices were not able to snap on other vertices from the same mesh.
 - [PBLD-189] Fixed a bug where using the auto-stitch functionality of the UV Editor would not work properly on MacOS.
 - [PBLD-187] Fixed a bug where the object size was incorrect when using the DrawShape tool on angled surfaces.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [PBLD-189] Fixed a bug where using the auto-stitch functionality of the UV Editor would not work properly on MacOS.
 - [PBLD-187] Fixed a bug where the object size was incorrect when using the DrawShape tool on angled surfaces.
 - [PBLD-180] Fixed a bug in the Material Editor where an exception was thrown because it attempted to retrieve `MenuItem` shortcuts before the main menu was fully loaded.
-- Fixed a bug where Undo was not working correctly with the Polyshape creation tool. 
+- [PBLD-210] Fixed a bug where Undo was not working correctly with the Polyshape creation tool. 
 - [PBLD-196] Fixed a bug where the Polyshape creation tool was not working with an orthographic camera.
 - [STO-3429] Fixed a bug where increment snapping was ignored when drawing ProBuilder shapes.
 - [STO-3432] Fixed a bug where the Polyshape creation tool was not placing the first point on a custom grids correctly.


### PR DESCRIPTION
### Purpose of this PR

Please try the tool locally to see if anything is still broken. This change doesn't fix Redo not working, but I will do that in another change. This PR appears to fix every other issue Polyshape Tool has. 

Enter/Space, Escape, Selection change, and clicking the exit button in the overlay are all valid ways to leave the polyshape tool. There are different behaviours we want for each of these ways of leaving the tool, and different behaviours at varying stages of the tool. This PR makes sure they all correctly exhibit their intended behaviours.

**DrawPolyShapeTool**
- In Path mode, press Enter/Space with less than 3 polygon points placed -> do nothing (was broken) 
- In Path mode, press Enter/Space with 3 or more polygon points placed -> progress to Height mode
- In Path mode, press Escape -> destroy polygon being drawn and move selection back to last drawn polyshape (such that one additional CTRL-Z undoes that last drawn polyshape as well)
- In Height mode, press Enter/Space -> finalize shape creation  (was broken) 
- In Height mode, press Escape -> finalize shape creation (this is aligned with how Edit PolyShape Tool is working where it doesn't revert the changes). (was broken) 
- In Path mode, change selection via Hierarchy window -> select the new game object and cancel polyshape creation (and destroy the polygon go) (was broken)
- In Height mode, change selection via Hierarchy window -> select the new game object and finalize shape creation (was broken) 

**EditPolyShapeTool** (Only has Edit mode)
- In Edit mode, press Enter/Space/Escape -> finalize changes and exit tool
- In Edit mode, click the exit button in the overlay -> finalize changes and exit tool

### Links

**Jira:** https://jira.unity3d.com/browse/PBLD-213

### Comments to Reviewers

DrawPolyShapeTool being a child of Edit PolyShapeTool is unnecessary af. It is not a superset of PolyShapeTool, it's a completely other thing.