### PR TITLE
[Backport PB 5.2] Fix for Edit PolyShape tool reverting previously merged polyshapes 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [PBLD-189] Fixed a bug where using the auto-stitch functionality of the UV Editor would not work properly on MacOS, moved it to Control+Command+Shift + Left click (MacOS only).
 - [PBLD-192] Fixed a bug where vertices were not able to snap on other vertices from the same mesh for Unity 2020.3 and later.
 - [PBLD-150] Fixed a bug where the orientation handles would not be useful when manipulating a cube shape.
+- [PBLD-205] Fixed a bug where the `Edit PolyShape` tool would revert previously merged PolyShape objects.
 
 ## [5.2.3] - 2024-08-12
 

--- a/Editor/MenuActions/Object/MergeObjects.cs
+++ b/Editor/MenuActions/Object/MergeObjects.cs
@@ -42,6 +42,12 @@ namespace UnityEditor.ProBuilder.Actions
             if (MeshSelection.selectedObjectCount < 2)
                 return new ActionResult(ActionResult.Status.Canceled, "Must Select 2+ Objects");
 
+            DoMergeObjectsAction();
+            return new ActionResult(ActionResult.Status.Success, "Merged Objects");
+        }
+
+        internal List<ProBuilderMesh> DoMergeObjectsAction()
+        {
             var selected = MeshSelection.top.ToArray();
             ProBuilderMesh currentMesh = MeshSelection.activeMesh;
             UndoUtility.RecordObject(currentMesh, "Merge Objects");
@@ -56,8 +62,14 @@ namespace UnityEditor.ProBuilder.Actions
                     {
                         mesh.gameObject.name = Selection.activeGameObject.name + "-Merged";
                         UndoUtility.RegisterCreatedObjectUndo(mesh.gameObject, "Merge Objects");
+                        
                         Selection.objects = res.Select(x => x.gameObject).ToArray();
                     }
+                    
+                    // Remove PolyShape component if one is present post-merge
+                    var polyShapeComp = mesh.gameObject.GetComponent<PolyShape>();
+                    if (polyShapeComp != null )
+                        UndoUtility.DestroyImmediate(polyShapeComp);
                 }
 
                 // Delete donor objects if they are not part of the result
@@ -68,9 +80,8 @@ namespace UnityEditor.ProBuilder.Actions
                 }
             }
 
-            ProBuilderEditor.Refresh();
+            return res;
 
-            return new ActionResult(ActionResult.Status.Success, "Merged Objects");
         }
     }
 }

--- a/Editor/MenuActions/Object/MergeObjects.cs
+++ b/Editor/MenuActions/Object/MergeObjects.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 using UnityEditor;
 using UnityEditor.ProBuilder.UI;
 using UnityEngine.ProBuilder.MeshOperations;
+using UnityEngine.ProBuilder.Shapes;
 
 namespace UnityEditor.ProBuilder.Actions
 {
@@ -66,10 +67,14 @@ namespace UnityEditor.ProBuilder.Actions
                         Selection.objects = res.Select(x => x.gameObject).ToArray();
                     }
                     
-                    // Remove PolyShape component if one is present post-merge
+                    // Remove PolyShape and ProBuilderShape components if any are present post-merge
                     var polyShapeComp = mesh.gameObject.GetComponent<PolyShape>();
                     if (polyShapeComp != null )
                         UndoUtility.DestroyImmediate(polyShapeComp);
+                    
+                    var proBuilderShape = mesh.gameObject.GetComponent<ProBuilderShape>();
+                    if (proBuilderShape != null )
+                        UndoUtility.DestroyImmediate(proBuilderShape);
                 }
 
                 // Delete donor objects if they are not part of the result

--- a/Tests/Editor/Actions/MergeObjectsTest.cs
+++ b/Tests/Editor/Actions/MergeObjectsTest.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using UObject = UnityEngine.Object;
+using UnityEngine;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEditor.ProBuilder;
+using UnityEditor.ProBuilder.Actions;
+using UnityEngine.ProBuilder;
+using UnityEngine.ProBuilder.Shapes;
+
+public class MergeObjectsTest 
+{
+    ProBuilderMesh m_mesh1;
+    ProBuilderMesh m_mesh2;
+    ProBuilderMesh m_mesh3;
+    
+    [SetUp]
+    public void SetUp()
+    {
+        m_mesh1 = ShapeFactory.Instantiate<Cube>();
+        m_mesh2 = ShapeFactory.Instantiate<Cone>();
+        m_mesh3 = ShapeFactory.Instantiate<Cylinder>();
+        m_mesh1.gameObject.AddComponent<BoxCollider>();
+    }
+
+    [TearDown]
+    public void Cleanup()
+    {
+        UObject.DestroyImmediate(m_mesh1);
+        UObject.DestroyImmediate(m_mesh2);
+        UObject.DestroyImmediate(m_mesh3);
+    }
+    
+    [Test]
+    public void MergeObjects_WithPolyShapeCompPresent_ResultNoLongerHasPolyShapeComp()
+    {
+        var meshes = new List<ProBuilderMesh>();
+        meshes.Add(m_mesh1);
+        meshes.Add(m_mesh2);
+        meshes.Add(m_mesh3);
+
+        foreach (var mesh in meshes)
+            mesh.gameObject.AddComponent<PolyShape>();
+
+        MeshSelection.SetSelection(new List<GameObject>( new[]{ m_mesh1.gameObject, m_mesh2.gameObject, m_mesh3.gameObject }));
+        ActiveEditorTracker.sharedTracker.ForceRebuild();
+
+        var mergeObjectsAction = new MergeObjects();
+        var newMeshes = mergeObjectsAction.DoMergeObjectsAction();
+        
+        var polyShapeFound = newMeshes[0].gameObject.GetComponent<PolyShape>() != null;
+        Assert.That(polyShapeFound, Is.Not.True, "There should be no PolyShape component on ProBuilder Meshes after mesh combine.");
+    }
+}

--- a/Tests/Editor/Actions/MergeObjectsTest.cs
+++ b/Tests/Editor/Actions/MergeObjectsTest.cs
@@ -12,15 +12,12 @@ public class MergeObjectsTest
 {
     ProBuilderMesh m_mesh1;
     ProBuilderMesh m_mesh2;
-    ProBuilderMesh m_mesh3;
     
     [SetUp]
     public void SetUp()
     {
         m_mesh1 = ShapeFactory.Instantiate<Cube>();
         m_mesh2 = ShapeFactory.Instantiate<Cone>();
-        m_mesh3 = ShapeFactory.Instantiate<Cylinder>();
-        m_mesh1.gameObject.AddComponent<BoxCollider>();
     }
 
     [TearDown]
@@ -28,39 +25,43 @@ public class MergeObjectsTest
     {
         UObject.DestroyImmediate(m_mesh1);
         UObject.DestroyImmediate(m_mesh2);
-        UObject.DestroyImmediate(m_mesh3);
     }
     
     [Test]
-    [TestCase(typeof(PolyShape))]
-    [TestCase(typeof(ProBuilderShape))]
-    public void MergeObjects_WithShapeCompPresent_ResultNoLongerHasShapeComp(System.Type shapeCompType)
+    [TestCase(typeof(PolyShape),typeof(PolyShape))] 
+    [TestCase(typeof(ProBuilderShape),typeof(ProBuilderShape))] 
+    [TestCase(typeof(ProBuilderShape),typeof(PolyShape))]
+    public void MergeObjects_WithShapeCompPresent_ResultNoLongerHasShapeComp(System.Type shapeCompTypeA, System.Type shapeCompTypeB)
     {
-        var meshes = new List<ProBuilderMesh>();
-        meshes.Add(m_mesh1);
-        meshes.Add(m_mesh2);
-        meshes.Add(m_mesh3);
-
-        foreach (var mesh in meshes)
+        void AttachComponentOfType(ProBuilderMesh mesh, System.Type shapeCompType)
         {
             if (shapeCompType == typeof(PolyShape)) 
                 mesh.gameObject.AddComponent<PolyShape>();
             else
                 mesh.gameObject.AddComponent<ProBuilderShape>();
         }
+        
+        var meshes = new List<ProBuilderMesh>();
+        meshes.Add(m_mesh1);
+        meshes.Add(m_mesh2);
+        
+        Assume.That(meshes.Count, Is.EqualTo(2));
 
-        MeshSelection.SetSelection(new List<GameObject>( new[]{ m_mesh1.gameObject, m_mesh2.gameObject, m_mesh3.gameObject }));
+        AttachComponentOfType(meshes[0], shapeCompTypeA);
+        AttachComponentOfType(meshes[1], shapeCompTypeB);
+        
+        MeshSelection.SetSelection(new List<GameObject>( new[]{ m_mesh1.gameObject, m_mesh2.gameObject }));
         ActiveEditorTracker.sharedTracker.ForceRebuild();
 
         var mergeObjectsAction = new MergeObjects();
         var newMeshes = mergeObjectsAction.DoMergeObjectsAction();
+        
+        Assume.That(newMeshes.Count, Is.EqualTo(1), "There should only be one mesh after merging objects.");
 
         var shapeCompFound = false; 
-        if (shapeCompType == typeof(PolyShape)) 
-            shapeCompFound = newMeshes[0].gameObject.GetComponent<PolyShape>() != null;
-        else 
-            shapeCompFound = newMeshes[0].gameObject.GetComponent<ProBuilderShape>() != null;
+        shapeCompFound |= newMeshes[0].gameObject.GetComponent<PolyShape>() != null;
+        shapeCompFound |= newMeshes[0].gameObject.GetComponent<ProBuilderShape>() != null;
         
-        Assert.That(shapeCompFound, Is.Not.True, $"There should be no {shapeCompType.Name} component on ProBuilder Meshes after mesh combine.");
+        Assert.That(shapeCompFound, Is.Not.True, $"There should be no {shapeCompTypeA.Name} or {shapeCompTypeB.Name} component on ProBuilder Meshes after mesh combine.");
     }
 }

--- a/Tests/Editor/Actions/MergeObjectsTest.cs
+++ b/Tests/Editor/Actions/MergeObjectsTest.cs
@@ -32,7 +32,9 @@ public class MergeObjectsTest
     }
     
     [Test]
-    public void MergeObjects_WithPolyShapeCompPresent_ResultNoLongerHasPolyShapeComp()
+    [TestCase(typeof(PolyShape))]
+    [TestCase(typeof(ProBuilderShape))]
+    public void MergeObjects_WithShapeCompPresent_ResultNoLongerHasShapeComp(System.Type shapeCompType)
     {
         var meshes = new List<ProBuilderMesh>();
         meshes.Add(m_mesh1);
@@ -40,15 +42,25 @@ public class MergeObjectsTest
         meshes.Add(m_mesh3);
 
         foreach (var mesh in meshes)
-            mesh.gameObject.AddComponent<PolyShape>();
+        {
+            if (shapeCompType == typeof(PolyShape)) 
+                mesh.gameObject.AddComponent<PolyShape>();
+            else
+                mesh.gameObject.AddComponent<ProBuilderShape>();
+        }
 
         MeshSelection.SetSelection(new List<GameObject>( new[]{ m_mesh1.gameObject, m_mesh2.gameObject, m_mesh3.gameObject }));
         ActiveEditorTracker.sharedTracker.ForceRebuild();
 
         var mergeObjectsAction = new MergeObjects();
         var newMeshes = mergeObjectsAction.DoMergeObjectsAction();
+
+        var shapeCompFound = false; 
+        if (shapeCompType == typeof(PolyShape)) 
+            shapeCompFound = newMeshes[0].gameObject.GetComponent<PolyShape>() != null;
+        else 
+            shapeCompFound = newMeshes[0].gameObject.GetComponent<ProBuilderShape>() != null;
         
-        var polyShapeFound = newMeshes[0].gameObject.GetComponent<PolyShape>() != null;
-        Assert.That(polyShapeFound, Is.Not.True, "There should be no PolyShape component on ProBuilder Meshes after mesh combine.");
+        Assert.That(shapeCompFound, Is.Not.True, $"There should be no {shapeCompType.Name} component on ProBuilder Meshes after mesh combine.");
     }
 }

--- a/Tests/Editor/Actions/MergeObjectsTest.cs.meta
+++ b/Tests/Editor/Actions/MergeObjectsTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b6a62a89fd1c04df6a68c2f1ba7e72dd


### PR DESCRIPTION
Purpose of this PR
PR fixes issue where merging two or more polyshape objects would not remove the PolyShape component resulting in issue down the line when Edit PolyShape tool would be activated.

Links
Jira: https://jira.unity3d.com/browse/PBLD-205

Comments to Reviewers
[List known issues, planned work, provide any extra context for your code.]