### PR TITLE
[PBLD-199] NullReferenceException when using the Cut Tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [PBLD-183] Fixed a bug where the **Extrude by** setting of the **Extrude Faces** action was always set to **Individual Faces**.
 - [STO-3442] Fixed a bug where hover-highlighted elements are not always selected.
 - [PBLD-205] Fixed a bug where the `Edit PolyShape` tool would revert previously merged PolyShape objects.
+- [PBLD-199] Fixed a bug where an exception was thrown if you placed two cut tool vertices on the same edge.
 
 ## [6.0.4] - 2024-09-12
 

--- a/Editor/EditorCore/CutTool.cs
+++ b/Editor/EditorCore/CutTool.cs
@@ -946,12 +946,16 @@ namespace UnityEditor.ProBuilder
 
                      if(index >= 0)
                      {
-                         List<Face> toDelete;
-                         Face newFace = ComputeFaceClosure(polygon, index, cutVertexSharedIndexes, out toDelete);
-                         newFace.submeshIndex = m_TargetFace.submeshIndex;
+                         // In the case of only 2 distinct, a face should not be added.
+                         if (polygon.Distinct().Count() != 2)
+                         {
+                             List<Face> toDelete;
+                             Face newFace = ComputeFaceClosure(polygon, index, cutVertexSharedIndexes, out toDelete);
+                             newFace.submeshIndex = m_TargetFace.submeshIndex;
 
-                         newFaces.Add(newFace);
-                         facesToDelete.AddRange(toDelete);
+                             newFaces.Add(newFace);
+                             facesToDelete.AddRange(toDelete);
+                         }
 
                          //Start a new polygon
                          polygon = new List<int>();

--- a/Editor/EditorCore/CutTool.cs
+++ b/Editor/EditorCore/CutTool.cs
@@ -947,7 +947,7 @@ namespace UnityEditor.ProBuilder
                      if(index >= 0)
                      {
                          // In the case of only 2 distinct, a face should not be added.
-                         if (polygon.Distinct().Count() != 2)
+                         if (polygon.Count != 2)
                          {
                              List<Face> toDelete;
                              Face newFace = ComputeFaceClosure(polygon, index, cutVertexSharedIndexes, out toDelete);


### PR DESCRIPTION
### Purpose of this PR

This PR fixes an issue where if, while using the Cut Tool, two vertices were placed on the same edge, a null reference exception would be thrown in the console. This was due to the face that the tool was attempting to create a face where it should not.

### Links

**Jira:** https://jira.unity3d.com/browse/PBLD-199

### Comments to Reviewers
None.
