### PR TITLE
[PBLD-199] [PB 5.2 Backport] NullReferenceException when using the Cut Tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [PBLD-192] Fixed a bug where vertices were not able to snap on other vertices from the same mesh for Unity 2020.3 and later.
 - [PBLD-150] Fixed a bug where the orientation handles would not be useful when manipulating a cube shape.
 - [PBLD-205] Fixed a bug where the `Edit PolyShape` tool would revert previously merged PolyShape objects.
+- [PBLD-199] Fixed a bug where an exception was thrown if you placed two cut tool vertices on the same edge.
 
 ## [5.2.3] - 2024-08-12
 

--- a/Editor/EditorCore/CutTool.cs
+++ b/Editor/EditorCore/CutTool.cs
@@ -913,12 +913,16 @@ namespace UnityEditor.ProBuilder
 
                      if(index >= 0)
                      {
-                         List<Face> toDelete;
-                         Face newFace = ComputeFaceClosure(polygon, index, cutVertexSharedIndexes, out toDelete);
-                         newFace.submeshIndex = m_TargetFace.submeshIndex;
+                         // In the case of only 2 distinct, a face should not be added.
+                         if (polygon.Count != 2)
+                         {
+                             List<Face> toDelete;
+                             Face newFace = ComputeFaceClosure(polygon, index, cutVertexSharedIndexes, out toDelete);
+                             newFace.submeshIndex = m_TargetFace.submeshIndex;
 
-                         newFaces.Add(newFace);
-                         facesToDelete.AddRange(toDelete);
+                             newFaces.Add(newFace);
+                             facesToDelete.AddRange(toDelete);
+                         }
 
                          //Start a new polygon
                          polygon = new List<int>();


### PR DESCRIPTION
### Purpose of this PR

This PR fixes an issue where if, while using the Cut Tool, two vertices were placed on the same edge, a null reference exception would be thrown in the console. This was due to the face that the tool was attempting to create a face where it should not.

**Jira:** https://jira.unity3d.com/browse/PBLD-199

### Comments to Reviewers

None.