### PR TITLE
Fixes PBLD-236 degenerate triangles causing rendering issues.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - [PBLD-224] Fixed rect selection in HDRP.
+- [PBLD-236] Fixed a bug where degenerate triangles were being added to output meshes, causing occasional rendering artifacts.
 
 ## [6.0.5] - 2025-03-11
 

--- a/Tests/Editor/Geometry/ProbuilderMeshDegenerateTriangleTest.cs
+++ b/Tests/Editor/Geometry/ProbuilderMeshDegenerateTriangleTest.cs
@@ -1,0 +1,48 @@
+﻿using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.ProBuilder;
+using UnityEngine.ProBuilder.Shapes;
+using System.Linq;
+
+public class ProbuilderMeshDegenerateTriangleTest
+{
+    private ProBuilderMesh m_Mesh;
+
+    [SetUp]
+    public void SetUp()
+    {
+        // Create a Probuilder cube
+        m_Mesh = ShapeFactory.Instantiate(typeof(Cube));
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        // Clean up the created GameObject
+        GameObject.DestroyImmediate(m_Mesh.gameObject);
+    }
+
+    [Test]
+    public void TestNormalsWithDegenerateTriangles()
+    {
+        // Collapse two of the shared vertices together.
+        var positions = new List<Vector3>(m_Mesh.positions);
+        Vector3 svPosition = positions[m_Mesh.sharedVertices[0][0]];
+        for (int v = 0; v < m_Mesh.sharedVertices[1].Count; ++v)
+        {
+            positions[m_Mesh.sharedVertices[1][v]] = svPosition;
+        }
+        m_Mesh.positions = positions.ToList();
+        m_Mesh.Rebuild();
+
+        // Check all the normals in use by faces to ensure none have invalid values.
+        foreach (int index in m_Mesh.mesh.triangles)
+        {
+            var normal = m_Mesh.normals[index];
+            Assert.IsFalse(float.IsNaN(normal.x) || float.IsNaN(normal.y) || float.IsNaN(normal.z), "Normals should not contain NaN values.");
+            Assert.IsFalse(float.IsInfinity(normal.x) || float.IsInfinity(normal.y) || float.IsInfinity(normal.z), "Normals should not contain Infinite values.");
+            Assert.IsFalse(normal == Vector3.zero, "Normals should not be zero vectors.");
+        }
+    }
+}

--- a/Tests/Editor/Geometry/ProbuilderMeshDegenerateTriangleTest.cs.meta
+++ b/Tests/Editor/Geometry/ProbuilderMeshDegenerateTriangleTest.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1e6d901ab8f94eec9c046028dfa6a043
+timeCreated: 1748380557


### PR DESCRIPTION
### Purpose of this PR

This fixes [PBLD-236](https://jira.unity3d.com/browse/PBLD-236) in which degenerate triangles in the output mesh with zero value normals were causing rendering artifacts, especially with bloom in URP.

In the `ProBuilderMesh.ToMesh` method, all the triangles in the mesh are checked to see if they are degenerate, and if they are, they are not added to the output mesh.

This does not remove any vertices that are not used in any faces.

### Links

**Jira:**  [PBLD-236](https://jira.unity3d.com/browse/PBLD-236)

### Comments to Reviewers

A new test has been added - it makes two of the corners of a cube coincident, which prior to this fix would result in a mesh being created with degenerate triangles. It fails if the fix is disabled; passes when it is enabled.