### PR TITLE
Extrude is now disabled in context menu when 'allow non-manifold actions' is not selected in preferences.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - [PBLD-224] Fixed rect selection in HDRP.
 - [PBLD-236] Fixed a bug where degenerate triangles were being added to output meshes, causing occasional rendering artifacts.
+- [PBLD-231] Fixed a bug where Extrude was not being disabled in the context menu when 'allow non-manifold actions' was not selected in the ProBuilder preferences.
 
 ## [6.0.5] - 2025-03-11
 

--- a/Editor/EditorCore/ProBuilderToolsContexts.cs
+++ b/Editor/EditorCore/ProBuilderToolsContexts.cs
@@ -107,7 +107,7 @@ namespace UnityEditor.ProBuilder
                     else if (action.optionsEnabled)
                     {
                         title = GetMenuTitle(action, title);
-                        menu.AppendAction(title, _ => EditorAction.Start(new MenuActionSettings(action, HasPreview(action))));
+                        menu.AppendAction(title, _ => EditorAction.Start(new MenuActionSettings(action, HasPreview(action))), GetStatus(action));
                     }
                     else
                         menu.AppendAction(GetMenuTitle(action, title), _ => action.PerformAction());

--- a/Tests/Editor/Editor/DisabledMenuTests.cs
+++ b/Tests/Editor/Editor/DisabledMenuTests.cs
@@ -1,0 +1,51 @@
+﻿using System.Linq;
+using NUnit.Framework;
+using UnityEditor.ProBuilder;
+using UnityEditor.ProBuilder.Actions;
+using UnityEditor.VersionControl;
+using UnityEngine.ProBuilder;
+using UnityEngine.ProBuilder.Shapes;
+using UnityEngine.UIElements;
+
+
+public class DisabledMenuTests
+{
+    ProBuilderMesh m_Cube;
+    private bool m_ManifoldAllowed;
+
+    [SetUp]
+    public void SetUp()
+    {
+        m_Cube = ShapeFactory.Instantiate(typeof(Cube));
+        MeshSelection.SetSelection(m_Cube.gameObject);
+        m_ManifoldAllowed = ProBuilderEditor.s_AllowNonManifoldActions;
+        ProBuilderEditor.s_AllowNonManifoldActions.SetValue(false);
+    }
+
+    [Test]
+    public void ExtrudeEnabledWithNonManifold()
+    {
+        ProBuilderEditor.selectMode = SelectMode.Edge;
+        m_Cube.SetSelectedEdges(m_Cube.faces.First().edges.ToArray());
+
+        var extrude = EditorToolbarLoader.GetInstance<ExtrudeEdges>();
+        Assert.NotNull(extrude);
+        ProBuilderEditor.s_AllowNonManifoldActions.SetValue(false);
+        Assert.False(extrude.enabled);
+        ProBuilderEditor.s_AllowNonManifoldActions.SetValue(true);
+        Assert.True(extrude.enabled);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (m_Cube != null)
+        {
+            UnityEngine.Object.DestroyImmediate(m_Cube.gameObject);
+            m_Cube = null;
+            ProBuilderEditor.s_AllowNonManifoldActions.SetValue(m_ManifoldAllowed);
+        }
+    }
+
+}
+

--- a/Tests/Editor/Editor/DisabledMenuTests.cs.meta
+++ b/Tests/Editor/Editor/DisabledMenuTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 136fa64d172f475681253f5a5d2765e5
+timeCreated: 1748467466

--- a/Tests/Editor/Export/ExportObj.cs
+++ b/Tests/Editor/Export/ExportObj.cs
@@ -87,9 +87,6 @@ class ExportObj : TemporaryAssetTest
     {
         var cube = ShapeFactory.Instantiate<Cube>();
 
-        string obj;
-        string mtl;
-        List<string> textures;
         string exportPath = TestUtility.temporarySavedAssetsDirectory + "SingleCube.obj";
         string exportedPath = UnityEditor.ProBuilder.Actions.ExportObj.DoExport(
             exportPath,


### PR DESCRIPTION
### Purpose of this PR

Actions that can result in a non-manifold object are meant to be disabled unless the 'allow non-manifold actions' checkbox is selected in the ProBuilder preferences. Although it _was_ disabled in the Tools menu, it _was not_ disabled in the context menu. This fix disables it in the context menu as well.

### Links

**Jira:**  [PBLD-235](https://jira.unity3d.com/browse/PBLD-235)

### Comments to Reviewers

I have added a test that tests whether the extrude action is appropriately enabled and disabled on the preference.
Ideally I would actually test the context menu as well, but it wasn't obvious how to do that.

I also removed some unused variable declarations I saw in another test.