### PR TITLE
Fixes the SoftDeleteEdges sample code so that it will show in the context menu.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - [PBLD-224] Fixed rect selection in HDRP.
 - [PBLD-236] Fixed a bug where degenerate triangles were being added to output meshes, causing occasional rendering artifacts.
+- [PBLD-220] Fixed an error in the SoftDeleteEdges sample code that was preventing it from appearing in the context menu.
 
 ## [6.0.5] - 2025-03-11
 

--- a/Samples~/Editor/SoftDeleteEdgesAction.cs
+++ b/Samples~/Editor/SoftDeleteEdgesAction.cs
@@ -19,6 +19,11 @@ namespace UnityEditor.ProBuilder.Actions
         public override string iconPath => string.Empty;
 		public override Texture2D icon => null;
 		public override TooltipContent tooltip { get { return k_Tooltip; } }
+        
+        /// <summary>
+        /// This action does not require any file input.
+        /// </summary>
+        protected override bool hasFileMenuEntry { get { return false; } }
 
 		/// <summary>
 		/// What to show in the hover tooltip window.


### PR DESCRIPTION
### Purpose of this PR

Fixes the SoftDeleteEdges sample code so that it will appear in the context menu.

### Links

[PBLD-220: ustom actions of the ProBuilder are disabled when trying to select them in the Context Menu](https://jira.unity3d.com/browse/PBLD-220)

### Comments to Reviewers

There are several other problems with the sample code - seems like we need [a task to improve the sample code](https://jira.unity3d.com/browse/WBTR-1295) in general.