### PR TITLE
Fix crash when attempting to probuilderize a gameobject that has `isPartOfStaticBatch` set to true.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [PBLD-224] Fixed rect selection in HDRP.
 - [PBLD-236] Fixed a bug where degenerate triangles were being added to output meshes, causing occasional rendering artifacts.
 - [PBLD-231] Fixed a bug where Extrude was not being disabled in the context menu when 'allow non-manifold actions' was not selected in the ProBuilder preferences.
-- [PBLD-222] Fixed crash when attempting to probuilderize a gameobject that has `isPartOfStaticBatch` set to true.
+- [PBLD-222] Fixed crash by preventing user from probuilderizing a gameobject that has isPartOfStaticBatch set to true.
 
 ## [6.0.5] - 2025-03-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changes
 
 - [PBLD-228] Updated function to access shader property types.
+- [PBLD-222] Probuilderizing now works for gameobjects that have isPartOfStaticBatch set to true.
 
 ### Fixed
 
 - [PBLD-224] Fixed rect selection in HDRP.
 - [PBLD-236] Fixed a bug where degenerate triangles were being added to output meshes, causing occasional rendering artifacts.
 - [PBLD-231] Fixed a bug where Extrude was not being disabled in the context menu when 'allow non-manifold actions' was not selected in the ProBuilder preferences.
-- [PBLD-222] Fixed crash by preventing user from probuilderizing a gameobject that has isPartOfStaticBatch set to true.
 
 ## [6.0.5] - 2025-03-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [PBLD-224] Fixed rect selection in HDRP.
 - [PBLD-236] Fixed a bug where degenerate triangles were being added to output meshes, causing occasional rendering artifacts.
 - [PBLD-231] Fixed a bug where Extrude was not being disabled in the context menu when 'allow non-manifold actions' was not selected in the ProBuilder preferences.
+- [PBLD-222] Fixed crash when attempting to probuilderize a gameobject that has `isPartOfStaticBatch` set to true.
 
 ## [6.0.5] - 2025-03-11
 

--- a/Editor/MenuActions/Object/ProBuilderize.cs
+++ b/Editor/MenuActions/Object/ProBuilderize.cs
@@ -250,7 +250,7 @@ namespace UnityEditor.ProBuilder.Actions
                     var renderer = go.GetComponent<MeshRenderer>();
                     if (renderer.isPartOfStaticBatch)
                     {
-                        Debug.LogError($"Probuilderize is not supported for renderers that have `IsPartOfStaticBatch` set.\n {go.name} will not probuilderize.");
+                        Debug.LogError($"Probuilderize is not supported for renderers that have `IsPartOfStaticBatch` set.\n{go.name} will not probuilderize.");
                         continue;
                     }
                     Mesh sourceMesh = mf.sharedMesh;

--- a/Editor/MenuActions/Object/ProBuilderize.cs
+++ b/Editor/MenuActions/Object/ProBuilderize.cs
@@ -247,6 +247,12 @@ namespace UnityEditor.ProBuilder.Actions
                         continue;
 
                     GameObject go = mf.gameObject;
+                    var renderer = go.GetComponent<MeshRenderer>();
+                    if (renderer.isPartOfStaticBatch)
+                    {
+                        Debug.LogError($"Probuilderize is not supported for renderers that have `IsPartOfStaticBatch` set.\n {go.name} will not probuilderize.");
+                        continue;
+                    }
                     Mesh sourceMesh = mf.sharedMesh;
                     Material[] sourceMaterials = go.GetComponent<MeshRenderer>()?.sharedMaterials;
 

--- a/Editor/MenuActions/Object/ProBuilderize.cs
+++ b/Editor/MenuActions/Object/ProBuilderize.cs
@@ -274,9 +274,6 @@ namespace UnityEditor.ProBuilder.Actions
                         // we need to invert the transform matrix to get the points into the correct local space
                         var transform = go.transform;
                         var positions = sourceMesh.vertices;
-                        // static meshes aren't transformed by their immediate parent, but they are transformed by one parent above
-                        if(transform.parent)
-                            transform.parent.TransformPoints(positions);
                         transform.InverseTransformPoints(positions);
                         sourceMesh.vertices = positions;
                     }

--- a/Tests/Editor/Actions/ProBuilderizeActionTest.cs
+++ b/Tests/Editor/Actions/ProBuilderizeActionTest.cs
@@ -6,12 +6,14 @@ using UnityEditor;
 using UnityEditor.ProBuilder;
 using UnityEditor.ProBuilder.Actions;
 using UnityEngine.ProBuilder;
+using UnityEngine.ProBuilder.MeshOperations;
 using UnityEngine.TestTools;
+using EditorUtility = UnityEditor.ProBuilder.EditorUtility;
 
 public class ProBuilderizeActionTest
 {
     [UnityTest]
-    public IEnumerator StaticBatchedGameObjectUnsupported()
+    public IEnumerator StaticBatchedGameObjectSupported()
     {
         var ContainerGO = new GameObject("container");
         var Cubes = new GameObject[3];
@@ -28,8 +30,80 @@ public class ProBuilderizeActionTest
 
         ProBuilderize proBuilderize = new ProBuilderize();
         proBuilderize.PerformAction();
-        yield return null;
-        LogAssert.Expect(LogType.Error, "Probuilderize is not supported for renderers that have `IsPartOfStaticBatch` set.\nCube will not probuilderize.");
-        Assert.IsNull(Cubes[2].GetComponent<ProBuilderMesh>());
+        bool completed = false;
+        // confirm that the delaycall inside the action returns
+        EditorApplication.delayCall += () =>
+        {
+            completed = true;
+        };
+        while (!completed)
+        {
+            EditorApplication.QueuePlayerLoopUpdate();
+            yield return null;
+        }
+        Assert.IsNotNull(Cubes[2].GetComponent<ProBuilderMesh>());
+    }
+    [UnityTest]
+    public IEnumerator StaticBatchedMultiMaterialPartialProbuilderize()
+    {
+        var ContainerGO = new GameObject("container");
+        var Cubes = new GameObject[9];
+        for (int i = 0; i < 9; i++)
+        {
+            var Cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            Cube.transform.position = new Vector3(i, i, i);
+            Cube.transform.SetParent(ContainerGO.transform, true);
+            Cubes[i] = Cube;
+        }
+        var combine = new List<CombineInstance>();
+
+        for (int i = 3; i < 6; i++)
+        {
+            var mf = Cubes[i].GetComponent<MeshFilter>();
+            combine.Add(new CombineInstance()
+            {
+                mesh = mf.sharedMesh,
+                subMeshIndex = 0,
+                transform = Cubes[i].transform.localToWorldMatrix
+            });
+        }
+        // Create new mesh and combine
+        Mesh combinedMesh = new Mesh();
+        combinedMesh.CombineMeshes(combine.ToArray(), false);
+
+        // Create new GameObject with combined mesh
+        GameObject combined = new GameObject("Combined Mesh");
+        MeshFilter filter = combined.AddComponent<MeshFilter>();
+        MeshRenderer renderer = combined.AddComponent<MeshRenderer>();
+        filter.sharedMesh = combinedMesh;
+        var baseMaterial = Cubes[0].GetComponent<Renderer>().sharedMaterial;
+        renderer.sharedMaterials = new[] { new Material(baseMaterial), new Material(baseMaterial), new Material(baseMaterial)};
+        combined.transform.SetParent(ContainerGO.transform);
+
+        StaticBatchingUtility.Combine(ContainerGO);
+
+        MeshSelection.SetSelection(new List<GameObject>( new[]{ combined }));
+        ActiveEditorTracker.sharedTracker.ForceRebuild();
+        ProBuilderize.DoProBuilderize(new []{combined.GetComponent<MeshFilter>()}, new MeshImportSettings()
+        {
+            quads = true,
+            smoothing = true,
+            smoothingAngle = 1
+        });
+        bool completed = false;
+        // confirm that the delaycall inside the action returns
+        EditorApplication.delayCall += () =>
+        {
+            completed = true;
+        };
+        while (!completed)
+        {
+            EditorApplication.QueuePlayerLoopUpdate();
+            yield return null;
+        }
+
+        Assert.IsNotNull(combined.GetComponent<ProBuilderMesh>());
+        Assert.AreEqual(3, combined.GetComponent<MeshRenderer>().sharedMaterials.Length);
+        Assert.AreEqual(18, combined.GetComponent<ProBuilderMesh>().faces.Count);
     }
 }

--- a/Tests/Editor/Actions/ProBuilderizeActionTest.cs
+++ b/Tests/Editor/Actions/ProBuilderizeActionTest.cs
@@ -1,0 +1,35 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEditor.ProBuilder;
+using UnityEditor.ProBuilder.Actions;
+using UnityEngine.ProBuilder;
+using UnityEngine.TestTools;
+
+public class ProBuilderizeActionTest
+{
+    [UnityTest]
+    public IEnumerator StaticBatchedGameObjectUnsupported()
+    {
+        var ContainerGO = new GameObject("container");
+        var Cubes = new GameObject[3];
+        for (int i = 0; i < 3; i++)
+        {
+            var Cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            Cube.transform.position = new Vector3(i, i, i);
+            Cube.transform.SetParent(ContainerGO.transform, true);
+            Cubes[i] = Cube;
+        }
+        StaticBatchingUtility.Combine(ContainerGO);
+        MeshSelection.SetSelection(new List<GameObject>( new[]{ Cubes[2] }));
+        ActiveEditorTracker.sharedTracker.ForceRebuild();
+
+        ProBuilderize proBuilderize = new ProBuilderize();
+        proBuilderize.PerformAction();
+        yield return null;
+        LogAssert.Expect(LogType.Error, "Probuilderize is not supported for renderers that have `IsPartOfStaticBatch` set.\nCube will not probuilderize.");
+        Assert.IsNull(Cubes[2].GetComponent<ProBuilderMesh>());
+    }
+}

--- a/Tests/Editor/Actions/ProBuilderizeActionTest.cs.meta
+++ b/Tests/Editor/Actions/ProBuilderizeActionTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9f191c90fe58ca94fb38889e409d84eb


### PR DESCRIPTION
### Purpose of this PR
- Fixes crash when attempting to probuilderize gameobjects that have isPartOfStaticBatch set to true

### Links

**Jira:** https://jira.unity3d.com/browse/PBLD-222

### Comments to Reviewers

This feature was never supported - The engine doesn't have a way to unset the isPartOfStaticBatch flag, so bypassing these objects is what we can do.