### PR TITLE
Fix for PBLD-238 Prevents actions with previews from being undone if you don't press Confirm.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [PBLD-236] Fixed a bug where degenerate triangles were being added to output meshes, causing occasional rendering artifacts.
 - [PBLD-220] Fixed an error in the SoftDeleteEdges sample code that was preventing it from appearing in the context menu.
 - [PBLD-231] Fixed a bug where Extrude was not being disabled in the context menu when 'allow non-manifold actions' was not selected in the ProBuilder preferences.
+- [PBLD-238] Fixed quite a serious bug that could cause users to lose any work that they did on a ProBuilder mesh between two usages of tool actions that had previews (options overlays).
 
 ## [6.0.5] - 2025-03-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [PBLD-236] Fixed a bug where degenerate triangles were being added to output meshes, causing occasional rendering artifacts.
 - [PBLD-220] Fixed an error in the SoftDeleteEdges sample code that was preventing it from appearing in the context menu.
 - [PBLD-231] Fixed a bug where Extrude was not being disabled in the context menu when 'allow non-manifold actions' was not selected in the ProBuilder preferences.
-- [PBLD-238] Fixed quite a serious bug that could cause users to lose any work that they did on a ProBuilder mesh between two usages of tool actions that had previews (options overlays).
+- [PBLD-238] Fixed a bug that could cause users to lose any work that they did on a ProBuilder mesh between two usages of tool actions that had previews (options overlays).
 
 ## [6.0.5] - 2025-03-11
 

--- a/Editor/EditorCore/MenuAction.cs
+++ b/Editor/EditorCore/MenuAction.cs
@@ -150,7 +150,9 @@ namespace UnityEditor.ProBuilder
         public virtual string menuTitle { get { return tooltip.title; } }
 
         /// <summary>
-        /// Gets whether this class should have an entry built into the hardware menu. This is not implemented for custom actions.
+        /// This should be true for actions that have settings that can be changed, allowing the user
+        /// to preview and confirm their changes. For actions that have no settings, this needs to
+        /// be overridden to return false.
         /// </summary>
         protected internal virtual bool hasFileMenuEntry { get { return true; } }
 

--- a/Editor/Overlays/ActionSettings.cs
+++ b/Editor/Overlays/ActionSettings.cs
@@ -72,6 +72,8 @@ namespace UnityEditor.ProBuilder
             ToolManager.activeContextChanged -= Validate;
             ToolManager.activeToolChanged -= Validate;
             Selection.selectionChanged -= ObjectSelectionChanged;
+
+            UndoUtility.ExitAndValidatePreview();
         }
 
         internal static bool IsCurrentAction(MenuAction action)

--- a/Samples~/Editor/SoftDeleteEdgesAction.cs
+++ b/Samples~/Editor/SoftDeleteEdgesAction.cs
@@ -19,9 +19,9 @@ namespace UnityEditor.ProBuilder.Actions
         public override string iconPath => string.Empty;
 		public override Texture2D icon => null;
 		public override TooltipContent tooltip { get { return k_Tooltip; } }
-        
+
         /// <summary>
-        /// This action does not require any file input.
+        /// This action does not have any settings to preview.
         /// </summary>
         protected override bool hasFileMenuEntry { get { return false; } }
 


### PR DESCRIPTION
### Purpose of this PR

[PBLD-238](https://jira.unity3d.com/browse/PBLD-238) details a bug with 'Grow Selection' where your actions between using Grow Selection and the next time you used an action could get undone if you did not explicitly 'Confirm' on the overlay.

As it turns out this bug seems to affect all actions that have a settings dialog with Preview.

The bug also improves the comment on MenuAction.hasFileMenuEntry and its override in the SoftDeleteEdgesAction sample, as the previous comment no longer made sense in the context of ProBuilder 6.

### Links

[[https://jira.unity3d.com/browse/PBLD-238]]

### Comments to Reviewers

So the cause of this bug was tricksy to work out.

Basically, there are a class of actions in ProBuilder that can have different options to them. Grow Selection is one of these, and it has options you can set about whether the selection should grow around sharp corners etc.

For actions such as these, the actual action is shown as a preview. The way this works is that a 'preview' undo point is made in the undo history, and then the action is applied. If the user changes a value in the options overlay, the actions back to the preview undo point are undone and the action is reapplied with the new values.

When the user presses confirm, the preview undo point is cleared. There is some code in there on preview start that if a preview is started and the preview undo point is set, it will undo to that point in order to get rid of the previewed action, and then start the new preview.

The issue was that there were cases when the preview undo point was not getting cleared - if you initiated another action like 'Delete Faces' the action would end, but the undo point wouldn't be cleared. Then you could keep editing for some time, and the next time you triggered an action with a preview, it would see the preview flag, and undo everything back to the previous usage, losing lots of your work!

The solution in this case was to clear the undo flag in the `Dispose()` method of the `ActionSettings` class.
