### PR TITLE
Fixes for obsolete API warnings in Unity 6.2.

### DIFF
--- a/AssetIdRemapUtility/Editor/AssetIdRemapBuilderTreeView.cs
+++ b/AssetIdRemapUtility/Editor/AssetIdRemapBuilderTreeView.cs
@@ -33,11 +33,13 @@ namespace UnityEngine.ProBuilder.AssetIdRemapUtility
             extraSpaceBeforeIconAndLabel = 18f;
         }
 
+#pragma warning disable CS0618 // Type or member is obsolete
         protected override TreeViewItem BuildRoot()
         {
             StringTupleTreeElement root = new StringTupleTreeElement(0, -1, -1, "Root", "", "");
 
             var all = new List<TreeViewItem>();
+#pragma warning restore CS0618
 
             int index = 1;
 
@@ -106,7 +108,9 @@ namespace UnityEngine.ProBuilder.AssetIdRemapUtility
             GUI.Label(rect, m_CellContents);
         }
 
+#pragma warning disable CS0618 // Type or member is obsolete
         protected override bool DoesItemMatchSearch(TreeViewItem element, string search)
+#pragma warning restore CS0618
         {
             StringTupleTreeElement tup = element as StringTupleTreeElement;
 
@@ -197,7 +201,9 @@ namespace UnityEngine.ProBuilder.AssetIdRemapUtility
         }
     }
 
+#pragma warning disable CS0618 // Type or member is obsolete
     class StringTupleTreeElement : TreeViewItem
+#pragma warning restore CS0618
     {
         public string item1;
         public string item2;

--- a/AssetIdRemapUtility/Editor/AssetIdRemapEditor.cs
+++ b/AssetIdRemapUtility/Editor/AssetIdRemapEditor.cs
@@ -129,8 +129,10 @@ namespace UnityEngine.ProBuilder.AssetIdRemapUtility
         AssetTreeView m_AssetsToDeleteTreeView;
         MultiColumnHeader m_MultiColumnHeader;
         Rect m_AssetTreeRect = new Rect(0, 0, 0, 0);
+#pragma warning disable CS0618 // Type or member is obsolete
         [SerializeField]
         TreeViewState m_TreeViewState = null;
+#pragma warning restore CS0618
         [SerializeField]
         MultiColumnHeaderState m_MultiColumnHeaderState = null;
         GUIContent m_AssetTreeSettingsContent = null;
@@ -176,8 +178,10 @@ namespace UnityEngine.ProBuilder.AssetIdRemapUtility
                 Debug.LogWarning("Could not find a valid asset id remap file!");
             }
 
+#pragma warning disable CS0618 // Type or member is obsolete
             if (m_TreeViewState == null)
                 m_TreeViewState = new TreeViewState();
+#pragma warning restore CS0618
 
             if (m_MultiColumnHeaderState == null)
                 m_MultiColumnHeaderState = new MultiColumnHeaderState(new MultiColumnHeaderState.Column[]
@@ -473,7 +477,9 @@ namespace UnityEngine.ProBuilder.AssetIdRemapUtility
             m_ConversionReadyState = GetReadyState();
         }
 
+#pragma warning disable CS0618 // Type or member is obsolete
         bool RemoveAssetStoreFiles(TreeViewItem root, StringBuilder log)
+#pragma warning restore CS0618
         {
             AssetTreeItem node = root as AssetTreeItem;
 

--- a/AssetIdRemapUtility/Editor/AssetTreeView.cs
+++ b/AssetIdRemapUtility/Editor/AssetTreeView.cs
@@ -11,7 +11,9 @@ using UObject = UnityEngine.Object;
 
 namespace UnityEngine.ProBuilder.AssetIdRemapUtility
 {
+#pragma warning disable CS0618 // Type or member is obsolete
     sealed class AssetTreeItem : TreeViewItem
+#pragma warning restore CS0618
     {
         string m_RelativePath;
         string m_FullPath;
@@ -99,6 +101,7 @@ namespace UnityEngine.ProBuilder.AssetIdRemapUtility
         }
     }
 
+#pragma warning disable CS0618 // Type or member is obsolete
     class AssetTreeView : TreeView
     {
         string m_RootDirectory = null;
@@ -137,7 +140,6 @@ namespace UnityEngine.ProBuilder.AssetIdRemapUtility
             columnIndexForTreeFoldouts = 0;
             rowHeight = 18f;
         }
-
         protected override TreeViewItem BuildRoot()
         {
             AssetTreeItem root = new AssetTreeItem(0, Application.dataPath, "")
@@ -307,4 +309,5 @@ namespace UnityEngine.ProBuilder.AssetIdRemapUtility
                         GatherTreeItems(child as AssetTreeItem, list);
         }
     }
+#pragma warning restore CS0618 // Type or member is obsolete
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [PBLD-231] Fixed a bug where Extrude was not being disabled in the context menu when 'allow non-manifold actions' was not selected in the ProBuilder preferences.
 - [PBLD-238] Fixed a bug that could cause users to lose any work that they did on a ProBuilder mesh between two usages of tool actions that had previews (options overlays).
 - [PBLD-222] Fixed crash by preventing user from probuilderizing a gameobject that has isPartOfStaticBatch set to true.
+- [PBLD-245] Fixed warnings about obsolete API usage when using Unity 6.2 and later. Updated the API usage where the alternatives were available in Unity 2022.3.
 
 ## [6.0.5] - 2025-03-11
 

--- a/Editor/EditorCore/EditorMaterialUtility.cs
+++ b/Editor/EditorCore/EditorMaterialUtility.cs
@@ -17,11 +17,11 @@ namespace UnityEditor.ProBuilder
 
             Texture2D best = null;
 
-            for (int i = 0; i < ShaderUtil.GetPropertyCount(material.shader); i++)
+            for (int i = 0; i < material.shader.GetPropertyCount(); i++)
             {
                 if (material.shader.GetPropertyType(i) == UnityEngine.Rendering.ShaderPropertyType.Texture)
                 {
-                    string propertyName = ShaderUtil.GetPropertyName(material.shader, i);
+                    string propertyName = material.shader.GetPropertyName(i);
 
                     Texture2D tex = material.GetTexture(propertyName) as Texture2D;
 

--- a/Editor/EditorCore/HierarchyListener.cs
+++ b/Editor/EditorCore/HierarchyListener.cs
@@ -48,7 +48,9 @@ namespace UnityEditor.ProBuilder
                     // of names to assume that scene mesh assets were created by probuilder.
                     stream.GetChangeGameObjectStructureHierarchyEvent(i, out var data);
 
+#pragma warning disable CS0618 // Type or member is obsolete
                     if (UnityEditor.EditorUtility.InstanceIDToObject(data.instanceId) is GameObject go)
+#pragma warning restore CS0618
                     {
                         var meshes = go.GetComponentsInChildren<ProBuilderMesh>();
                         foreach (var mesh in meshes)
@@ -64,7 +66,9 @@ namespace UnityEditor.ProBuilder
         {
             // if the created object is a probuilder mesh, check if it is a copy of an existing instance.
             // if so, we need to create a new mesh asset.
+#pragma warning disable CS0618 // Type or member is obsolete
             if (UnityEditor.EditorUtility.InstanceIDToObject(instanceId) is GameObject go)
+#pragma warning restore CS0618
                 CheckForProBuilderMeshesCreatedOrModified(go);
         }
 

--- a/Editor/EditorCore/ObjExporter.cs
+++ b/Editor/EditorCore/ObjExporter.cs
@@ -324,12 +324,12 @@ namespace UnityEditor.ProBuilder
                 // Texture maps
                 if (mat.shader != null)
                 {
-                    for (int i = 0; i < ShaderUtil.GetPropertyCount(mat.shader); i++)
+                    for (int i = 0; i < mat.shader.GetPropertyCount(); i++)
                     {
                         if (mat.shader.GetPropertyType(i) != UnityEngine.Rendering.ShaderPropertyType.Texture)
                             continue;
 
-                        string texPropertyName = ShaderUtil.GetPropertyName(mat.shader, i);
+                        string texPropertyName = mat.shader.GetPropertyName(i);
 
                         Texture texture = mat.GetTexture(texPropertyName);
 


### PR DESCRIPTION
### Purpose of this PR

This fixes [PBLD-245](https://jira.unity3d.com/browse/PBLD-245), where loading ProBuilder in to Unity 6.2 or later would result in a lot of warnings related to obsolete API.

The replacements for the obsolete TreeView API and EditorUtility.InstanceIDToObject do not exist prior to Unity 6.2, so in those cases I added pragmas to suppress the warnings. In the case of ShaderUtil.GetProperty___ I replaced the obsolete API calls with the correct ones as they exist as far back as Unity 2021.
