### PR TITLE
Bugfix/pbld 226 hidden face selection fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- [PBLD-226] Fixed a bug where ProBuilder faces could not selected when obscured by another GameObject
+
 ## [6.0.6] - 2025-07-01
 
 ### Changes
@@ -20,7 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [PBLD-238] Fixed a bug that could cause users to lose any work that they did on a ProBuilder mesh between two usages of tool actions that had previews (options overlays).
 - [PBLD-222] Fixed crash by preventing user from probuilderizing a gameobject that has isPartOfStaticBatch set to true.
 - [PBLD-245] Fixed warnings about obsolete API usage when using Unity 6.2 and later. Updated the API usage where the alternatives were available in Unity 2022.3.
-- [PBLD-226] Fixed a bug where ProBuilder faces could not selected when obscured by another GameObject
+
 
 ## [6.0.5] - 2025-03-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [PBLD-238] Fixed a bug that could cause users to lose any work that they did on a ProBuilder mesh between two usages of tool actions that had previews (options overlays).
 - [PBLD-222] Fixed crash by preventing user from probuilderizing a gameobject that has isPartOfStaticBatch set to true.
 - [PBLD-245] Fixed warnings about obsolete API usage when using Unity 6.2 and later. Updated the API usage where the alternatives were available in Unity 2022.3.
+- [PBLD-226] Fixed a bug where ProBuilder faces could not selected when obscured by another GameObject
 
 ## [6.0.5] - 2025-03-11
 

--- a/Editor/EditorCore/EditorSceneViewPicker.cs
+++ b/Editor/EditorCore/EditorSceneViewPicker.cs
@@ -406,6 +406,8 @@ namespace UnityEditor.ProBuilder
             return FaceRaycast(mousePosition, pickerOptions, allowUnselected, selection, 0, true);
         }
 
+        static List<(ProBuilderMesh mesh, Face face, float dist, int hash)> s_PbHits = new List<(ProBuilderMesh, Face, float, int)>();
+
         static float FaceRaycast(Vector3 mousePosition,
             ScenePickerPreferences pickerOptions,
             bool allowUnselected,
@@ -413,11 +415,12 @@ namespace UnityEditor.ProBuilder
             int deepClickOffset = 0,
             bool isPreview = true)
         {
-            GameObject pickedGo = null;
-            ProBuilderMesh pickedPb = null;
-            Face pickedFace = null;
+            GameObject candidateGo = null;
+            ProBuilderMesh candidatePb = null;
+            Face        candidateFace = null;
+            float       candidateDistance = Mathf.Infinity;
 
-            int newHash = 0;
+            s_PbHits.Clear();
 
             // If any event modifiers are engaged don't cycle the deep click
             EventModifiers em = Event.current.modifiers;
@@ -427,7 +430,7 @@ namespace UnityEditor.ProBuilder
             if ((em != EventModifiers.None) != s_AppendModifierPreviousState)
             {
                 s_AppendModifierPreviousState = (em != EventModifiers.None);
-                s_DeepSelectionPrevious = newHash;
+                s_DeepSelectionPrevious = 0;
             }
 
             if (isPreview || em != EventModifiers.None)
@@ -437,78 +440,121 @@ namespace UnityEditor.ProBuilder
 
             selection.Clear();
 
-            float distance = Mathf.Infinity;
-
-            for (int i = 0, next = 0, pickedCount = s_OverlappingGameObjects.Count; i < pickedCount; i++)
+            // First, find all ProBuilder meshes and their hit faces under the mouse
+            for (int i = 0, pickedCount = s_OverlappingGameObjects.Count; i < pickedCount; i++)
             {
                 var go = s_OverlappingGameObjects[i];
                 var mesh = go.GetComponent<ProBuilderMesh>();
-                Face face = null;
 
                 if (mesh != null && (allowUnselected || MeshSelection.topInternal.Contains(mesh)))
                 {
                     Ray ray = UHandleUtility.GUIPointToWorldRay(mousePosition);
                     RaycastHit hit;
 
+                    // The pickerOptions.cullMode should be set appropriately (e.g., CullingMode.None)
+                    // by the caller if "Select Hidden" implies ignoring backface culling or normal direction for picking.
                     if (UnityEngine.ProBuilder.HandleUtility.FaceRaycast(ray,
                             mesh,
                             out hit,
                             Mathf.Infinity,
                             pickerOptions.cullMode))
                     {
-                        face = mesh.facesInternal[hit.face];
-                        distance = Vector2.SqrMagnitude(((Vector2)mousePosition) - HandleUtility.WorldToGUIPoint(mesh.transform.TransformPoint(hit.point)));
+                        Face face = mesh.facesInternal[hit.face];
+                        float dist = Vector2.SqrMagnitude(((Vector2)mousePosition) - HandleUtility.WorldToGUIPoint(mesh.transform.TransformPoint(hit.point)));
+                        s_PbHits.Add((mesh, face, dist, face.GetHashCode()));
                     }
-                }
-
-                // pb_Face doesn't define GetHashCode, meaning it falls to object.GetHashCode (reference comparison)
-                int hash = face == null ? go.GetHashCode() : face.GetHashCode();
-
-                if (s_DeepSelectionPrevious == hash)
-                    next = (i + (1 + deepClickOffset)) % pickedCount;
-
-                if (next == i)
-                {
-                    pickedGo = go;
-                    pickedPb = mesh;
-                    pickedFace = face;
-
-                    newHash = hash;
-
-                    // a prior hash was matched, this is the next. if
-                    // it's just the first iteration don't break (but do
-                    // set the default).
-                    if (next != 0)
-                        break;
                 }
             }
 
-            if (!isPreview)
-                s_DeepSelectionPrevious = newHash;
+            if (s_PbHits.Count > 0)
+            {
+                // Sort ProBuilder hits by distance (closest first)
+                s_PbHits.Sort((a, b) => a.dist.CompareTo(b.dist));
 
-            if (pickedGo != null)
+                int chosenIndex = 0;
+
+                // Apply deep click cycling logic only if it's an actual click and a previous selection exists
+                if (!isPreview && s_DeepSelectionPrevious != 0)
+                {
+                    int currentSelectionIndex = -1;
+                    // Find the index of the previously selected item (if it's still in the list)
+                    for (int i = 0; i < s_PbHits.Count; i++)
+                    {
+                        if (s_PbHits[i].hash == s_DeepSelectionPrevious)
+                        {
+                            currentSelectionIndex = i;
+                            break;
+                        }
+                    }
+
+                    if (currentSelectionIndex != -1)
+                    {
+                        // Calculate the next index for cycling
+                        chosenIndex = (currentSelectionIndex + (1 + deepClickOffset)) % s_PbHits.Count;
+                        // Handle negative result from modulo for deepClickOffset = -1 if currentSelectionIndex is 0
+                        if (chosenIndex < 0) chosenIndex += s_PbHits.Count;
+                    }
+                    // If s_DeepSelectionPrevious was set but no matching PB hit is found in current list,
+                    // fall back to the closest one (chosenIndex remains 0)
+                }
+                // else for first click or if s_DeepSelectionPrevious is 0, chosenIndex remains 0 (selects closest)
+
+                var selectedHit = s_PbHits[chosenIndex];
+                candidateGo = selectedHit.mesh.gameObject;
+                candidatePb = selectedHit.mesh;
+                candidateFace = selectedHit.face;
+                candidateDistance = selectedHit.dist;
+
+                // Update the newHash for the element actually picked after cycling/filtering
+                int newHash = selectedHit.hash;
+
+                // Update s_DeepSelectionPrevious only for actual clicks (not hovers)
+                if (!isPreview)
+                {
+                    s_DeepSelectionPrevious = newHash;
+                }
+            }
+            else // No ProBuilder meshes were hit, fallback to standard GameObject picking
+            {
+                // This means the mouse is over a non-ProBuilder GameObject, or nothing at all.
+                // We should still allow picking of that topmost non-ProBuilder GameObject.
+                GameObject topmostGo = HandleUtility.PickGameObject(mousePosition, false);
+                if (topmostGo != null)
+                {
+                    candidateGo = topmostGo;
+                    candidateDistance = 0f; // Indicate a direct hit (distance not relevant for non-PB pick)
+                    s_DeepSelectionPrevious = 0; // Reset deep selection if a non-PB object is picked
+                }
+                else
+                {
+                    return Mathf.Infinity; // Nothing at all hit
+                }
+            }
+
+            // Final selection update
+            if (candidateGo != null)
             {
                 Event.current.Use();
 
-                if (pickedPb != null)
+                if (candidatePb != null)
                 {
-                    if (pickedPb.selectable)
+                    if (candidatePb.selectable)
                     {
-                        selection.gameObject = pickedGo;
-                        selection.mesh = pickedPb;
-                        selection.SetSingleFace(pickedFace);
+                        selection.gameObject = candidateGo;
+                        selection.mesh = candidatePb;
+                        selection.SetSingleFace(candidateFace);
 
-                        return Mathf.Sqrt(distance);
+                        return Mathf.Sqrt(candidateDistance);
                     }
                 }
 
                 // If clicked off a pb_Object but onto another gameobject, set the selection
                 // and dip out.
-                selection.gameObject = pickedGo;
-                return Mathf.Sqrt(distance);
+                selection.gameObject = candidateGo;
+                return Mathf.Sqrt(candidateDistance);
             }
 
-            return distance;
+            return Mathf.Infinity;
         }
 
         static float VertexRaycast(Vector3 mousePosition, ScenePickerPreferences pickerOptions, bool allowUnselected, SceneSelection selection)

--- a/Editor/EditorCore/EditorSceneViewPicker.cs
+++ b/Editor/EditorCore/EditorSceneViewPicker.cs
@@ -423,7 +423,9 @@ namespace UnityEditor.ProBuilder
             s_PbHits.Clear();
 
             // If any event modifiers are engaged don't cycle the deep click
-            EventModifiers em = Event.current.modifiers;
+            EventModifiers em = EventModifiers.None;
+            if (Event.current != null)
+                em = Event.current.modifiers;
 
             // Reset cycle if we used an event modifier previously.
             // Move state back to single selection.
@@ -534,7 +536,7 @@ namespace UnityEditor.ProBuilder
             // Final selection update
             if (candidateGo != null)
             {
-                Event.current.Use();
+                Event.current?.Use();
 
                 if (candidatePb != null)
                 {

--- a/Tests/Editor/Export/ExportObj.cs
+++ b/Tests/Editor/Export/ExportObj.cs
@@ -80,6 +80,8 @@ class ExportObj : TemporaryAssetTest
 
         Assume.That(imported, Is.Not.Null);
         Assert.That(imported.vertexCount, Is.GreaterThan(0));
+
+        Object.DestroyImmediate(cube.gameObject);
     }
 
     [Test]
@@ -108,13 +110,17 @@ class ExportObj : TemporaryAssetTest
         Assert.That(meshRenderer.sharedMaterials[0].mainTexture, Is.Not.Null);
         var mainTex = meshRenderer.sharedMaterials[0].mainTexture;
         Assert.That(AssetDatabase.GetAssetPath(mainTex), Is.EqualTo(TestUtility.temporarySavedAssetsDirectory+mainTex.name+".png"));
+
+        Object.DestroyImmediate(cube.gameObject);
     }
 
     [Test]
     public static void ExportMultipleMeshes_CreatesModelWithTwoGroups()
     {
-        var cube1 = new Model("Cube A", ShapeFactory.Instantiate<Cube>());
-        var cube2 = new Model("Cube B", ShapeFactory.Instantiate<Cube>());
+        var cubeA = ShapeFactory.Instantiate<Cube>();
+        var cubeB = ShapeFactory.Instantiate<Cube>();
+        var cube1 = new Model("Cube A", cubeA);
+        var cube2 = new Model("Cube B", cubeB);
         string exportedPath = TestUtility.temporarySavedAssetsDirectory + "ObjGroup.obj";
 
         UnityEditor.ProBuilder.Actions.ExportObj.DoExport(exportedPath, new Model[] { cube1, cube2 }, new ObjOptions()
@@ -133,5 +139,8 @@ class ExportObj : TemporaryAssetTest
         var all = AssetDatabase.LoadAllAssetRepresentationsAtPath(exportedPath);
 
         Assert.That(all.Count(x => x is Mesh), Is.EqualTo(2));
+
+        Object.DestroyImmediate(cubeA.gameObject);
+        Object.DestroyImmediate(cubeB.gameObject);
     }
 }

--- a/Tests/Editor/Picking/FacePickerTests.cs
+++ b/Tests/Editor/Picking/FacePickerTests.cs
@@ -20,21 +20,14 @@ public class FacePickerTests
     private Vector3 GetFaceCenterWorld(ProBuilderMesh mesh, Face face)
     {
         Vector3 centerLocal = Vector3.zero;
-        if (face.indexesInternal == null || face.indexesInternal.Length == 0)
-            return Vector3.zero; // Should not happen for valid ProBuilder faces
+        Assume.That(face.indexesInternal != null);
+        Assume.That(face.indexesInternal.Length != 0);
 
         Vector3[] positions = mesh.positionsInternal;
         foreach (int index in face.indexesInternal)
         {
-            if (index >= 0 && index < positions.Length)
-            {
-                centerLocal += positions[index];
-            }
-            else
-            {
-                Debug.LogError($"Invalid vertex index {index} found in face indexes.");
-                return Vector3.zero; // Or handle error appropriately
-            }
+            Assume.That(index >= 0 && index < positions.Length);
+            centerLocal += positions[index];
         }
         centerLocal /= face.indexesInternal.Length;
 

--- a/Tests/Editor/Picking/FacePickerTests.cs
+++ b/Tests/Editor/Picking/FacePickerTests.cs
@@ -1,0 +1,383 @@
+﻿using System;
+using System.Linq;
+using UnityEngine;
+using UObject = UnityEngine.Object;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEditor.EditorTools;
+using UnityEditor.ProBuilder;
+using UnityEngine.ProBuilder;
+using UnityEngine.TestTools;
+
+[TestFixture]
+public class FacePickerTests
+{
+    private ProBuilderMesh m_Mesh;
+    private Camera m_Camera;
+    private ScenePickerPreferences m_PickerPreferences;
+
+    // Helper to calculate the world-space center of a face
+    private Vector3 GetFaceCenterWorld(ProBuilderMesh mesh, Face face)
+    {
+        Vector3 centerLocal = Vector3.zero;
+        if (face.indexesInternal == null || face.indexesInternal.Length == 0)
+            return Vector3.zero; // Should not happen for valid ProBuilder faces
+
+        Vector3[] positions = mesh.positionsInternal;
+        foreach (int index in face.indexesInternal)
+        {
+            if (index >= 0 && index < positions.Length)
+            {
+                centerLocal += positions[index];
+            }
+            else
+            {
+                Debug.LogError($"Invalid vertex index {index} found in face indexes.");
+                return Vector3.zero; // Or handle error appropriately
+            }
+        }
+        centerLocal /= face.indexesInternal.Length;
+
+        return mesh.transform.TransformPoint(centerLocal);
+    }
+
+    // Helper to create a non-ProBuilder GameObject with a MeshCollider
+    private GameObject CreateNonProBuilderPlane(Vector3 position, float sizeX, float sizeZ)
+    {
+        GameObject go = GameObject.CreatePrimitive(PrimitiveType.Plane);
+        go.name = "NonProBuilderPlane";
+        go.transform.position = position;
+        go.transform.localScale = new Vector3(sizeX, 1, sizeZ);
+        // Ensure it has a collider for picking
+        MeshCollider collider = go.GetComponent<MeshCollider>();
+        if (collider == null)
+            collider = go.AddComponent<MeshCollider>();
+        collider.enabled = true;
+        return go;
+    }
+
+    [SetUp]
+    public void Setup()
+    {
+        // Ensure SceneView is open and focused for HandleUtility to work correctly
+        var window = EditorWindow.GetWindow<SceneView>();
+        window.Show(false);
+        window.Repaint();
+        window.Focus();
+
+        m_Camera = new GameObject("TestCamera", typeof(Camera)).GetComponent<Camera>();
+        m_Camera.transform.position = new Vector3(0, 10, 0);
+        m_Camera.transform.LookAt(Vector3.zero);
+        m_Camera.orthographic = false;
+        m_Camera.cullingMask = ~0; // Render everything
+
+        m_Mesh = ShapeFactory.Instantiate<UnityEngine.ProBuilder.Shapes.Plane>();
+        m_Mesh.name = "TestPlane";
+        m_Mesh.transform.position = Vector3.zero;
+        m_Mesh.transform.rotation = Quaternion.identity;
+        m_Mesh.Refresh(); // Ensure mesh data is up-to-date
+
+        // Add MeshCollider for picking
+        var meshCollider = m_Mesh.gameObject.GetComponent<MeshCollider>();
+        if (meshCollider == null)
+            meshCollider = m_Mesh.gameObject.AddComponent<MeshCollider>();
+        meshCollider.sharedMesh = m_Mesh.mesh;
+        meshCollider.enabled = true;
+
+        Camera.SetupCurrent(m_Camera); // Set this camera as the active SceneView camera
+
+        m_PickerPreferences = new ScenePickerPreferences()
+        {
+            cullMode = CullingMode.Back, // Default culling mode
+            rectSelectMode = RectSelectMode.Partial // Default rect select mode
+        };
+
+        MeshSelection.ClearElementSelection();
+        MeshSelection.AddToSelection(m_Mesh.gameObject); // Add ProBuilder mesh to current selection context
+
+        ActiveEditorTracker.sharedTracker.ForceRebuild();
+        ToolManager.SetActiveContext<PositionToolContext>(); // Set to a tool that uses picking
+    }
+
+    [TearDown]
+    public void Cleanup()
+    {
+        MeshSelection.ClearElementSelection();
+        EditorSceneViewPicker.selection.Clear();
+
+        if (m_Mesh != null)
+            UObject.DestroyImmediate(m_Mesh.gameObject);
+        if (m_Camera != null)
+            UObject.DestroyImmediate(m_Camera.gameObject);
+
+        // Destroy any other GameObjects created specifically for tests
+        // Using FindObjectsOfType is generally slow, but acceptable in editor tests cleanup.
+        foreach (var go in UObject.FindObjectsOfType<GameObject>())
+        {
+            if (go.name.Contains("TestPlane2") || go.name.Contains("NonProBuilderPlane"))
+                UObject.DestroyImmediate(go);
+        }
+
+        Camera.SetupCurrent(null); // Clear active camera
+        LogAssert.NoUnexpectedReceived(); // Ensure no unexpected Unity errors/warnings occurred
+    }
+
+    // Helper to create a mouse event
+    private Event CreateMouseEvent(Vector3 mousePosition, EventType type = EventType.MouseDown, EventModifiers modifiers = EventModifiers.None)
+    {
+        Event evt = new Event
+        {
+            type = type,
+            mousePosition = mousePosition,
+            modifiers = modifiers
+        };
+        return evt;
+    }
+
+    [Test]
+    public void FacePicker_PicksVisibleFace()
+    {
+        // Get the first face of the plane (assuming a single-face plane)
+        Face faceToPick = m_Mesh.facesInternal[0];
+
+        // Get the world center of the face using the new helper
+        Vector3 centerOfFace_world = GetFaceCenterWorld(m_Mesh, faceToPick);
+        Vector2 mousePos = UnityEditor.HandleUtility.WorldToGUIPoint(centerOfFace_world);
+
+        UnityEngine.TestTools.LogAssert.ignoreFailingMessages = true; // Ignore logs due to not executing OnGUI loop
+        EditorSceneViewPicker.DoMouseClick(
+            CreateMouseEvent(mousePos, EventType.MouseDown, EventModifiers.None),
+            SelectMode.Face, // Select faces
+            m_PickerPreferences);
+
+        SceneSelection currentSelection = EditorSceneViewPicker.selection;
+
+        Assert.IsNotNull(currentSelection.mesh, "A mesh should be selected.");
+        Assert.AreEqual(m_Mesh, currentSelection.mesh, "The correct mesh should be selected.");
+        Assert.IsNotNull(currentSelection.faces, "Faces collection should not be null.");
+        Assert.AreEqual(1, currentSelection.faces.Count, "Exactly one face should be selected.");
+        Assert.AreEqual(faceToPick, currentSelection.faces.First(), "The expected face should be picked.");
+    }
+
+    [Test]
+    public void FacePicker_DoesNotPickWhenNotHovering()
+    {
+        // Click far away from any objects
+        Vector2 mousePos = new Vector2(Screen.width / 2f, Screen.height / 2f + 500f);
+
+        UnityEngine.TestTools.LogAssert.ignoreFailingMessages = true;
+        EditorSceneViewPicker.DoMouseClick(
+            CreateMouseEvent(mousePos, EventType.MouseDown, EventModifiers.None),
+            SelectMode.Face,
+            m_PickerPreferences);
+
+        SceneSelection currentSelection = EditorSceneViewPicker.selection;
+
+        Assert.IsNull(currentSelection.mesh, "No mesh should be selected.");
+        Assert.IsEmpty(currentSelection.faces, "No faces should be selected.");
+        Assert.IsNull(currentSelection.gameObject, "No GameObject should be selected.");
+    }
+
+    [Test]
+    public void FacePicker_PicksClosestFaceWithMultipleOverlappingProBuilderMeshes()
+    {
+        // Adjust camera to see both planes
+        m_Camera.transform.position = new Vector3(0.5f, 0.5f, -10);
+        m_Camera.transform.LookAt(Vector3.zero);
+
+        // Create a second ProBuilder mesh, slightly behind the first (m_Mesh is at Z=0)
+        ProBuilderMesh mesh2 = ShapeFactory.Instantiate<UnityEngine.ProBuilder.Shapes.Plane>();
+        mesh2.name = "TestPlane2";
+        mesh2.transform.position = new Vector3(0.0f, 0.0f, 0.5f); // mesh2 is further from camera
+        mesh2.Refresh();
+
+        var meshCollider2 = mesh2.gameObject.GetComponent<MeshCollider>();
+        if (meshCollider2 == null) meshCollider2 = mesh2.gameObject.AddComponent<MeshCollider>();
+        meshCollider2.sharedMesh = mesh2.mesh;
+        meshCollider2.enabled = true;
+
+        MeshSelection.AddToSelection(mesh2.gameObject); // Add to current selection for picker to consider
+
+        Face face1 = m_Mesh.facesInternal[0]; // Face on the front mesh (m_Mesh)
+        Vector3 center1_world = GetFaceCenterWorld(m_Mesh, face1); // Use helper
+
+        Vector2 mousePos = UnityEditor.HandleUtility.WorldToGUIPoint(center1_world);
+
+        UnityEngine.TestTools.LogAssert.ignoreFailingMessages = true;
+        EditorSceneViewPicker.DoMouseClick(
+            CreateMouseEvent(mousePos, EventType.MouseDown, EventModifiers.None),
+            SelectMode.Face,
+            m_PickerPreferences);
+
+        SceneSelection currentSelection = EditorSceneViewPicker.selection;
+
+        Assert.IsNotNull(currentSelection.mesh, "A face should be picked.");
+        Assert.AreEqual(m_Mesh, currentSelection.mesh, "The closer ProBuilder mesh (m_Mesh) should be picked.");
+        Assert.IsNotNull(currentSelection.faces, "Faces collection should not be null.");
+        Assert.AreEqual(1, currentSelection.faces.Count, "Exactly one face should be selected.");
+        Assert.AreEqual(face1, currentSelection.faces.First(), "The expected face (from m_Mesh) should be picked.");
+
+        UObject.DestroyImmediate(mesh2.gameObject);
+    }
+
+    [Test]
+    public void FacePicker_PicksProBuilderFaceOverlappingNonProBuilderGameObject()
+    {
+        // Place a non-ProBuilder plane in front of the ProBuilder mesh
+        // nonPbGo at y=1.0, m_Mesh at y=0.0. Camera at y=10. nonPbGo is CLOSER.
+        GameObject nonPbGo = CreateNonProBuilderPlane(new Vector3(0, 1.0f, 0), 1f, 1f);
+
+        Face pbFace = m_Mesh.facesInternal[0];
+        Vector3 centerPbFace_world = GetFaceCenterWorld(m_Mesh, pbFace); // Use helper
+        Vector2 mousePos = UnityEditor.HandleUtility.WorldToGUIPoint(centerPbFace_world);
+
+        UnityEngine.TestTools.LogAssert.ignoreFailingMessages = true;
+
+        // As per the provided EditorSceneViewPicker.cs (second version),
+        // ProBuilder faces are prioritized if any are hit.
+        EditorSceneViewPicker.DoMouseClick(
+            CreateMouseEvent(mousePos, EventType.MouseDown, EventModifiers.None),
+            SelectMode.Face,
+            m_PickerPreferences);
+
+        SceneSelection currentSelection = EditorSceneViewPicker.selection;
+
+        Assert.IsNotNull(currentSelection.mesh, "A ProBuilder mesh should be selected.");
+        Assert.AreEqual(m_Mesh, currentSelection.mesh, "The ProBuilder mesh should be picked despite the closer non-ProBuilder GameObject.");
+        Assert.IsNotNull(currentSelection.faces, "Faces collection should not be null.");
+        Assert.AreEqual(1, currentSelection.faces.Count, "Exactly one face should be selected.");
+        Assert.AreEqual(pbFace, currentSelection.faces.First(), "The expected ProBuilder face should be picked.");
+
+        // Explicitly assert that the non-ProBuilder object was NOT selected as the main GameObject.
+        Assert.AreNotEqual(nonPbGo, currentSelection.gameObject, "The non-ProBuilder GameObject should not be the selected object.");
+
+        UObject.DestroyImmediate(nonPbGo);
+    }
+
+    [Test]
+    public void FacePicker_PicksNonProBuilderGameObjectWhenNoProBuilderFaceIsPresent()
+    {
+        // Disable the ProBuilder mesh so no PB faces can be hit by the raycast
+        m_Mesh.gameObject.SetActive(false);
+
+        // Create a non-ProBuilder plane at the origin
+        GameObject nonPbGo = CreateNonProBuilderPlane(new Vector3(5, 0, 0), 1f, 1f);
+
+        // Adjust camera to look at it
+        m_Camera.transform.position = new Vector3(5, 10, 0);
+        m_Camera.transform.LookAt(new Vector3(5, 0, 0));
+
+        Vector2 mousePos = UnityEditor.HandleUtility.WorldToGUIPoint(nonPbGo.transform.position);
+
+        UnityEngine.TestTools.LogAssert.ignoreFailingMessages = true;
+        EditorSceneViewPicker.DoMouseClick(
+            CreateMouseEvent(mousePos, EventType.MouseDown, EventModifiers.None),
+            SelectMode.Face, // Still in Face select mode, but will fallback to GameObject picking
+            m_PickerPreferences);
+
+        SceneSelection currentSelection = EditorSceneViewPicker.selection;
+
+        Assert.IsNull(currentSelection.mesh, "No ProBuilder mesh should be selected.");
+        Assert.IsEmpty(currentSelection.faces, "No faces should be selected.");
+        Assert.IsNotNull(currentSelection.gameObject, "A GameObject should be selected.");
+        Assert.AreEqual(nonPbGo, currentSelection.gameObject, "The non-ProBuilder GameObject should be picked as a fallback.");
+
+        UObject.DestroyImmediate(nonPbGo);
+    }
+
+    [Test]
+    public void FacePicker_CyclesThroughOverlappingProBuilderFacesOnRepeatedClick()
+    {
+        // Create a second ProBuilder mesh, slightly in back of the first
+        // m_Mesh at y=0, mesh2 at y=-0.5. Camera at y=10.
+        ProBuilderMesh mesh2 = ShapeFactory.Instantiate<UnityEngine.ProBuilder.Shapes.Plane>();
+        mesh2.name = "TestPlane2";
+        mesh2.transform.position = new Vector3(0.0f, -0.5f, 0.0f);
+        mesh2.Refresh();
+
+        var meshCollider2 = mesh2.gameObject.GetComponent<MeshCollider>();
+        if (meshCollider2 == null) meshCollider2 = mesh2.gameObject.AddComponent<MeshCollider>();
+        meshCollider2.sharedMesh = mesh2.mesh;
+        meshCollider2.enabled = true;
+
+        // Add both to selection for picker to consider
+        MeshSelection.AddToSelection(m_Mesh.gameObject);
+        MeshSelection.AddToSelection(mesh2.gameObject);
+
+        Face face1 = m_Mesh.facesInternal[0];   // Face on the front mesh (m_Mesh)
+        Face face2 = mesh2.facesInternal[0];    // Face on the back mesh (mesh2)
+
+        // Calculate an overlapping point for clicking
+        Vector3 overlapCenter_world_face1 = GetFaceCenterWorld(m_Mesh, face1); // Use helper
+        Vector3 overlapCenter_world_face2 = GetFaceCenterWorld(mesh2, face2); // Use helper
+        Vector3 overlapCenter_world = (overlapCenter_world_face1 + overlapCenter_world_face2) / 2f;
+
+        Vector2 mousePos = UnityEditor.HandleUtility.WorldToGUIPoint(overlapCenter_world);
+
+        UnityEngine.TestTools.LogAssert.ignoreFailingMessages = true;
+
+        // --- First click: Should pick the front mesh (m_Mesh)
+        EditorSceneViewPicker.DoMouseClick(
+            CreateMouseEvent(mousePos, EventType.MouseDown, EventModifiers.None),
+            SelectMode.Face,
+            m_PickerPreferences);
+
+        SceneSelection currentSelection = EditorSceneViewPicker.selection;
+        Assert.AreEqual(m_Mesh, currentSelection.mesh, "First click: Front ProBuilder mesh should be picked.");
+        Assert.AreEqual(1, currentSelection.faces.Count, "First click: Exactly one face should be selected.");
+        Assert.AreEqual(face1, currentSelection.faces.First(), "First click: The front face should be picked.");
+
+        // --- Second click: Should pick the back mesh (mesh2) due to deep cycling
+        // Simulate releasing and pressing mouse again at the same spot
+        EditorSceneViewPicker.DoMouseClick(
+            CreateMouseEvent(mousePos, EventType.MouseDown, EventModifiers.None),
+            SelectMode.Face,
+            m_PickerPreferences);
+
+        currentSelection = EditorSceneViewPicker.selection;
+        Assert.AreEqual(mesh2, currentSelection.mesh, "Second click: Back ProBuilder mesh should be picked (cycled).");
+        Assert.AreEqual(1, currentSelection.faces.Count, "Second click: Exactly one face should be selected.");
+        Assert.AreEqual(face2, currentSelection.faces.First(), "Second click: The back face should be picked.");
+
+        // --- Third click: Should cycle back to the front mesh (m_Mesh)
+        EditorSceneViewPicker.DoMouseClick(
+            CreateMouseEvent(mousePos, EventType.MouseDown, EventModifiers.None),
+            SelectMode.Face,
+            m_PickerPreferences);
+
+        currentSelection = EditorSceneViewPicker.selection;
+        Assert.AreEqual(m_Mesh, currentSelection.mesh, "Third click: Front ProBuilder mesh should be picked again (cycled).");
+        Assert.AreEqual(1, currentSelection.faces.Count, "Third click: Exactly one face should be selected.");
+        Assert.AreEqual(face1, currentSelection.faces.First(), "Third click: The front face should be picked again.");
+
+        UObject.DestroyImmediate(mesh2.gameObject);
+    }
+
+    [Test]
+    public void FacePicker_DoesNotPickFace_BehindCamera()
+    {
+        // Move the entire mesh behind the camera's near clip plane
+        // m_Mesh at y=11
+        m_Mesh.transform.position = new Vector3(0, 11, 0);
+        m_Mesh.Refresh();
+
+        m_Mesh.GetComponent<MeshCollider>().sharedMesh = m_Mesh.mesh;
+        m_Mesh.GetComponent<MeshCollider>().enabled = true;
+
+        Face faceToTest = m_Mesh.facesInternal[0];
+        Vector3 centerOfFace_world = GetFaceCenterWorld(m_Mesh, faceToTest); // Use helper
+        Vector2 mousePos = UnityEditor.HandleUtility.WorldToGUIPoint(centerOfFace_world);
+
+        UnityEngine.TestTools.LogAssert.ignoreFailingMessages = true;
+        EditorSceneViewPicker.DoMouseClick(
+            CreateMouseEvent(mousePos, EventType.MouseDown, EventModifiers.None),
+            SelectMode.Face,
+            m_PickerPreferences);
+
+        SceneSelection currentSelection = EditorSceneViewPicker.selection;
+
+        Assert.IsNull(currentSelection.mesh, "No mesh should be selected.");
+        Assert.IsEmpty(currentSelection.faces, "No faces should be selected.");
+        Assert.IsNull(currentSelection.gameObject, "No GameObject should be selected.");
+    }
+}

--- a/Tests/Editor/Picking/FacePickerTests.cs.meta
+++ b/Tests/Editor/Picking/FacePickerTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b0ce4e28478b8094f9b1ccdb30f88742


### PR DESCRIPTION
### Purpose of this PR

This PR resolves a bug where single-click face picking on ProBuilder meshes failed if they were obscured by another GameObject, even when "Select Hidden" was enabled. The previous FaceRaycast implementation's internal next variable and looping logic caused it to often only consider the very first GameObject returned by the scene picker for a standard single click. This was problematic because if that initial GameObject was not a ProBuilder mesh, the ProBuilder picking routine would prematurely exit, preventing selection of the obscured ProBuilder face. The corrected approach now first collects all intersecting ProBuilder meshes and their hit faces under the mouse cursor. These ProBuilder hits are then internally sorted by distance, and the deep-click cycling logic is correctly applied exclusively to this filtered list of ProBuilder elements, ensuring reliable selection and improved interaction with obscured geometry.

### Links

[**Jira:**](https://jira.unity3d.com/browse/PBLD-226)

### Comments to Reviewers

Added unit tests