### PR TITLE
Fixed a bug with UV autostitching where the position offset would not take into account the face rotation center offset.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - [PBLD-242] Fixed a bug where edges were being incorrectly selected when one or both vertices were behind the camera's near plane, causing flipped lines and inconsistent selection behavior.
 - [PBLD-226] Fixed a bug where ProBuilder faces could not selected when obscured by another GameObject
+- [PBLD-164] Fixed a bug with UV autostitching where the position offset would not take into account the face rotation center offset.
 
 ## [6.0.6] - 2025-07-01
 

--- a/Runtime/Core/UvAutoManualConversion.cs
+++ b/Runtime/Core/UvAutoManualConversion.cs
@@ -140,11 +140,29 @@ namespace UnityEngine.ProBuilder
 	        Vector2 dstSize = GetRotatedSize(dst, dstIndices, dstCenter, -rotation);
 	        Bounds2D srcBounds = srcIndices == null ? new Bounds2D(src) : new Bounds2D(src, srcIndices);
             Vector2 scale = dstSize.DivideBy(srcBounds.size);
-            Vector2 srcCenter = srcBounds.center * scale;
+
+            // Calculate new bounds after rotation
+            Vector2 min = new Vector2(float.MaxValue, float.MaxValue);
+            Vector2 max = new Vector2(float.MinValue, float.MinValue);
+
+            int count = srcIndices?.Count ?? src.Count;
+            for (int i = 0; i < count; i++)
+            {
+                int index = GetIndex(srcIndices, i);
+                Vector2 rotated = Math.RotateAroundPoint(src[index], srcBounds.center, rotation);
+                min.x = Mathf.Min(min.x, rotated.x);
+                min.y = Mathf.Min(min.y, rotated.y);
+                max.x = Mathf.Max(max.x, rotated.x);
+                max.y = Mathf.Max(max.y, rotated.y);
+            }
+
+            // Calculate center of rotated bounds, and apply the calculated scale afterwards
+            Vector2 rotatedCenter = (min + max) * 0.5f;
+            Vector2 srcTransformedCenter = rotatedCenter * scale;
 
 			return new UVTransform()
 			{
-				translation = dstCenter - srcCenter,
+				translation =  dstCenter - srcTransformedCenter,
 				rotation = rotation,
 				scale = dstSize.DivideBy(srcBounds.size)
 			};

--- a/Runtime/MeshOperations/UV/TextureStitching.cs
+++ b/Runtime/MeshOperations/UV/TextureStitching.cs
@@ -8,11 +8,11 @@ namespace UnityEngine.ProBuilder.MeshOperations
         /// Provided two faces, this method will attempt to project @f2 and align its size, rotation, and position to match
         /// the shared edge on f1.  Returns true on success, false otherwise.
         /// </summary>
-        /// <param name="mesh"></param>
-        /// <param name="f1"></param>
-        /// <param name="f2"></param>
+        /// <param name="mesh">The mesh containing the faces</param>
+        /// <param name="f1">The anchor face</param>
+        /// <param name="f2">The face to align to the anchor</param>
         /// <param name="channel"></param>
-        /// <returns></returns>
+        /// <returns>true if the autostitching succeeded, else fase</returns>
         public static bool AutoStitch(ProBuilderMesh mesh, Face f1, Face f2, int channel)
         {
             var wings = WingedEdge.GetWingedEdges(mesh, new [] { f1, f2 });

--- a/Tests/Editor/UV/AutoStitchingTests.cs
+++ b/Tests/Editor/UV/AutoStitchingTests.cs
@@ -1,0 +1,122 @@
+using System.Linq;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.ProBuilder;
+using UnityEngine.ProBuilder.MeshOperations;
+using UnityEngine.ProBuilder.Shapes;
+
+[TestFixture]
+public class AutoStitchTests
+{
+    const float k_Tolerance = 0.0001f;
+    [Test]
+    public void AutoStitch_AlignsEdgesCorrectly()
+    {
+        // Step 1: Create a cube and deform one face
+        var cube = ShapeFactory.Instantiate<Cube>();
+        Assume.That(cube, Is.Not.Null);
+
+        var f0 = cube.faces[0]; // idx : 0,1,2,3
+        var f1 = cube.faces[1]; // idx : 4,5,6,7
+        var vertices = cube.positionsInternal;
+
+        // let's modify the non adjacent edge
+        vertices[5] += new Vector3(0, -0.5f, 0);
+        vertices[8] += new Vector3(0, -0.5f, 0);
+        vertices[7] += new Vector3(0, 0.5f, 0);
+        vertices[10] += new Vector3(0, 0.5f, 0);
+        cube.positionsInternal = vertices;
+
+        cube.ToMesh();
+        cube.Refresh();
+
+        // Step 2: Perform AutoStitch
+        bool succeeded = UVEditing.AutoStitch(cube, f0, f1, 0);
+        Assert.IsTrue(succeeded, "AutoStitch operation failed.");
+
+        // Step 3: Verify that the edge of one face UV is the same as the other face UV
+        var uvs = cube.texturesInternal;
+
+        // Get the shared edge between f0 and f1
+        var sharedEdge = WingedEdge.GetWingedEdges(cube, new[] { f0, f1 })
+            .FirstOrDefault(x => x.face == f0 && x.opposite != null && x.opposite.face == f1);
+
+        Assume.That(sharedEdge, Is.Not.Null, "No shared edge found between the two faces.");
+
+        // Check if UVs on the shared edge are aligned
+        var f0Edge = sharedEdge.opposite.edge.common;
+        var f1Edge = sharedEdge.opposite.edge.local;
+
+        // Compare UVs for each vertex in the shared edge
+        AssertUVsAlmostEqual(uvs[f0Edge.a], uvs[f1Edge.a], k_Tolerance, $"UV mismatch at vertex {f0Edge.a}.");
+        AssertUVsAlmostEqual(uvs[f0Edge.b], uvs[f1Edge.b], k_Tolerance, $"UV mismatch at vertex {f0Edge.b}.");
+
+        // Cleanup
+        Object.DestroyImmediate(cube.gameObject);
+    }
+
+    [Test]
+    public void AutoStitch_AlignsEdgesCorrectly_WhenRotated()
+    {
+        // Step 1: Create a cube
+        var cube = ShapeFactory.Instantiate<Cube>();
+        Assume.That(cube, Is.Not.Null);
+
+        // Step 2: Rotate all faces of the cube
+        var rotation = Quaternion.Euler(45, 45, 45);
+        var vertices = cube.positionsInternal;
+
+        for (int i = 0; i < vertices.Length; i++)
+        {
+            vertices[i] = rotation * vertices[i];
+        }
+
+        cube.positionsInternal = vertices;
+        cube.ToMesh();
+        cube.Refresh();
+
+        // Deform one face slightly to ensure edge misalignment
+        var f0 = cube.faces[0]; // idx : 0,1,2,3
+        var f1 = cube.faces[1]; // idx : 4,5,6,7
+
+        // let's modify the non adjacent edge
+        vertices[5] += new Vector3(0, -0.5f, 0);
+        vertices[8] += new Vector3(0, -0.5f, 0);
+        vertices[7] += new Vector3(0, 0.5f, 0);
+        vertices[10] += new Vector3(0, 0.5f, 0);
+        cube.positionsInternal = vertices;
+
+        cube.ToMesh();
+        cube.Refresh();
+
+        // Step 3: Perform AutoStitch
+        bool succeeded = UVEditing.AutoStitch(cube, f0, f1, 0);
+        Assert.IsTrue(succeeded, "AutoStitch operation failed.");
+
+        // Step 4: Verify that the edge of one face UV is the same as the other face UV
+        var uvs = cube.texturesInternal;
+
+        // Get the shared edge between f0 and f1
+        var sharedEdge = WingedEdge.GetWingedEdges(cube, new[] { f0, f1 })
+            .FirstOrDefault(x => x.face == f0 && x.opposite != null && x.opposite.face == f1);
+
+        Assume.That(sharedEdge, Is.Not.Null, "No shared edge found between the two faces.");
+
+        // Check if UVs on the shared edge are aligned
+        var f0Edge = sharedEdge.opposite.edge.common;
+        var f1Edge = sharedEdge.opposite.edge.local;
+
+        // Compare UVs for each vertex in the shared edge
+        AssertUVsAlmostEqual(uvs[f0Edge.a], uvs[f1Edge.a], k_Tolerance, $"UV mismatch at vertex {f0Edge.a}.");
+        AssertUVsAlmostEqual(uvs[f0Edge.b], uvs[f1Edge.b], k_Tolerance, $"UV mismatch at vertex {f0Edge.b}.");
+
+        // Cleanup
+        Object.DestroyImmediate(cube.gameObject);
+    }
+
+    private void AssertUVsAlmostEqual(Vector2 uv1, Vector2 uv2, float tolerance, string message)
+    {
+        Assert.That(uv1.x, Is.EqualTo(uv2.x).Within(tolerance), $"{message} on X coordinate.");
+        Assert.That(uv1.y, Is.EqualTo(uv2.y).Within(tolerance), $"{message} on Y coordinate.");
+    }
+}

--- a/Tests/Editor/UV/AutoStitchingTests.cs.meta
+++ b/Tests/Editor/UV/AutoStitchingTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a88be54f7c604c042b09eb11b8c5d690


### PR DESCRIPTION
### Purpose of this PR

The calculation of the auto stitching was based on the offset between the destination UV center, and the source UV center. This offset is then applied to a face UV. 

The problem with the old calculation, was that when a rotation was needed for a target face, the bounds center could be slightly offseted, when the face was not a rectangle or cube (eg. a trapezoid), since the bounds are calculated using the min,max x and y. This slight offset would result in a misposition of the target face relative to the anchor, which would visually result in an offsetted texture. 

This was solved by making sure we take into account the rotation of the face when calculating the offset.

In the image below, we see that the rotation of the trapezoid modifies its center bound, which is not taken into the account in the calculation
<img width="944" height="483" alt="image" src="https://github.com/user-attachments/assets/6d86d3de-a7d1-4236-922a-1d49a3a01dc7" />


The image below shows the old behaviour. notice the existing offset between the square and the trapezoid. It is the same offset as the image above:
<img width="1151" height="1173" alt="image" src="https://github.com/user-attachments/assets/9b1a6644-176d-4016-9342-29736d0bab14" />

After. We now take into account the rotation

![autostiching](https://github.com/user-attachments/assets/7fe86e0b-51a7-4ca5-a3ae-61a29cacca1e)


### Links

https://jira.unity3d.com/browse/PBLD-164

### Comments to Reviewers

N/A