### PR TITLE
Remove call to SetAlpha as the internal method is being removed (UUM-…

### DIFF
--- a/Editor/EditorCore/TooltipEditor.cs
+++ b/Editor/EditorCore/TooltipEditor.cs
@@ -24,7 +24,6 @@ namespace UnityEditor.ProBuilder
                 s_Instance.maxSize = Vector2.zero;
                 s_Instance.hideFlags = HideFlags.HideAndDontSave;
                 s_Instance.ShowTooltip();
-                s_Instance.m_Parent.window.SetAlpha(1f);
             }
 
             return s_Instance;


### PR DESCRIPTION
**DO NOT FORGET TO INCLUDE A CHANGELOG ENTRY**

### Purpose of this PR

The ContainerWindow.SetAlpha() method is obsolete functionality that's being removed from the Editor. This is the only call, which is already non-functional, so there's no risk for breaking behavior.

### Links

**Jira:**

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]