### PR TITLE
fix issue where probuilder with quad topology instead of triangle would trigger out of bounds exception when being exported

### DIFF
--- a/Tests/Editor/Geometry/ProbuilderMeshDegenerateTriangleTest.cs
+++ b/Tests/Editor/Geometry/ProbuilderMeshDegenerateTriangleTest.cs
@@ -7,42 +7,57 @@ using System.Linq;
 
 public class ProbuilderMeshDegenerateTriangleTest
 {
-    private ProBuilderMesh m_Mesh;
-
-    [SetUp]
-    public void SetUp()
-    {
-        // Create a Probuilder cube
-        m_Mesh = ShapeFactory.Instantiate(typeof(Cube));
-    }
-
-    [TearDown]
-    public void TearDown()
-    {
-        // Clean up the created GameObject
-        GameObject.DestroyImmediate(m_Mesh.gameObject);
-    }
-
     [Test]
     public void TestNormalsWithDegenerateTriangles()
     {
-        // Collapse two of the shared vertices together.
-        var positions = new List<Vector3>(m_Mesh.positions);
-        Vector3 svPosition = positions[m_Mesh.sharedVertices[0][0]];
-        for (int v = 0; v < m_Mesh.sharedVertices[1].Count; ++v)
+        // Create a Probuilder cube
+        var mesh = ShapeFactory.Instantiate(typeof(Cube));
+        try
         {
-            positions[m_Mesh.sharedVertices[1][v]] = svPosition;
-        }
-        m_Mesh.positions = positions.ToList();
-        m_Mesh.Rebuild();
+            // Collapse two of the shared vertices together.
+            var positions = new List<Vector3>(mesh.positions);
+            Vector3 svPosition = positions[mesh.sharedVertices[0][0]];
+            for (int v = 0; v < mesh.sharedVertices[1].Count; ++v)
+            {
+                positions[mesh.sharedVertices[1][v]] = svPosition;
+            }
 
-        // Check all the normals in use by faces to ensure none have invalid values.
-        foreach (int index in m_Mesh.mesh.triangles)
+            mesh.positions = positions.ToList();
+            mesh.Rebuild();
+
+            // Check all the normals in use by faces to ensure none have invalid values.
+            foreach (int index in mesh.mesh.triangles)
+            {
+                var normal = mesh.normals[index];
+                Assert.IsFalse(float.IsNaN(normal.x) || float.IsNaN(normal.y) || float.IsNaN(normal.z), "Normals should not contain NaN values.");
+                Assert.IsFalse(float.IsInfinity(normal.x) || float.IsInfinity(normal.y) || float.IsInfinity(normal.z), "Normals should not contain Infinite values.");
+                Assert.IsFalse(normal == Vector3.zero, "Normals should not be zero vectors.");
+            }
+        }
+        finally
         {
-            var normal = m_Mesh.normals[index];
-            Assert.IsFalse(float.IsNaN(normal.x) || float.IsNaN(normal.y) || float.IsNaN(normal.z), "Normals should not contain NaN values.");
-            Assert.IsFalse(float.IsInfinity(normal.x) || float.IsInfinity(normal.y) || float.IsInfinity(normal.z), "Normals should not contain Infinite values.");
-            Assert.IsFalse(normal == Vector3.zero, "Normals should not be zero vectors.");
+            // Clean up the created GameObject
+            GameObject.DestroyImmediate(mesh.gameObject);
+        }
+    }
+
+    [Test]
+    [Description("PBLD-251 : IndexOutOfRangeException appears in the Console when exporting certain ProBuilder meshes")]
+    public void TestOriginalDoorBugScenario()
+    {
+        // Recreate the specific Door shape bug scenario
+        var door = ShapeFactory.Instantiate(typeof(Door));
+
+        try
+        {
+            Assert.DoesNotThrow(() => door.ToMesh(MeshTopology.Quads));
+
+            Assert.IsNotNull(door.mesh);
+            Assert.Greater(door.mesh.vertexCount, 0);
+        }
+        finally
+        {
+            GameObject.DestroyImmediate(door.gameObject);
         }
     }
 }


### PR DESCRIPTION
### Purpose of this PR

The degenerate triangle removal code introduced in [v6.0.6](https://github.com/Unity-Technologies/com.unity.probuilder/pull/606) assumed all submeshes used triangular topology, 
but ProBuilder meshes can contain mixed topologies (triangles, quads, etc.). The code incremented through indices 
by 3 and accessed `indexes[tri + 2]`, causing IndexOutOfRangeException when processing non-triangular submeshes 
like quads with indices arrays not divisible by 3. This specifically affected shapes like Door that use quad topology.

**Fix**: Added a topology check `if (submeshes[i].m_Topology == MeshTopology.Triangles)` before applying the 
degenerate triangle removal logic. This ensures the triangle-specific degenerate detection only runs on actual 
triangular submeshes, preventing the index bounds violation on quad/other topologies.

**Preserves Original Fix**: The degenerate triangle removal functionality remains completely intact for triangular 
submeshes - it still detects and removes zero-area triangles using cross-product magnitude checks. Non-triangular 
submeshes bypass this processing entirely, which is appropriate since the concept of "degenerate triangles" doesn't 
apply to quads or other topologies. The fix maintains backward compatibility while eliminating the crash.

**Result**: Door shapes and other mixed-topology meshes can now be exported without IndexOutOfRangeException, 
while triangular meshes continue to benefit from degenerate triangle cleanup and improved rendering quality.

### Links

https://jira.unity3d.com/browse/PBLD-251

### Comments to Reviewers

I did not check for degenerate quads in this PR, because I could not repro the issue the user was having with degenerate triangles (making the bloom flash weirdly)