### PR TITLE
 Enable Renovate and Renovate Validation Github Actions

### DIFF
--- a/.github/workflows/renovate-validation.yml
+++ b/.github/workflows/renovate-validation.yml
@@ -1,0 +1,40 @@
+# Refer to https://internaldocs.unity.com/renovate/ for more documentation
+
+# This workflow is for validating the Renovate configuration and docker image
+# updates for it.
+name: Renovate Validation
+on:
+  workflow_dispatch:
+    inputs:
+      log-level:
+        type: choice
+        description: Select log level for Renovate
+        options:
+          - trace
+          - debug
+          - info
+          - warn
+          - error
+        default: info
+        required: false
+  pull_request:
+    paths:
+      # we trigger validation on any changes to the renovate workflow files
+      - .github/workflows/renovate*.yml
+      # as well as for any possible location for the renovate config file
+      - .github/renovate.json?
+
+
+jobs:
+  renovate-validation:
+    # The reusable workflow will be updated by renovate if there's a new version
+    uses: unity/renovate-workflows/.github/workflows/run.yml@v4.0.0
+    with:
+      # This is the image that contains our custom renovate and will be auto
+      # updated by Renovate itself.
+      image: europe-docker.pkg.dev/unity-cds-services-prd/ds-docker/renovate:10.1.3@sha256:fdeed7bb524bd67611eb91ee1a5e990c8c73ed62c84a0cd5ef66c87eb5fd0d70
+      dry-run: full
+      log-level: ${{ github.event.inputs.log-level }}
+    secrets:
+      renovate-auth-secret: ${{ secrets.RENOVATE_AUTH_SECRET }}
+      github-com-token: ${{ secrets.GH_COM_TOKEN }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,36 @@
+# Refer to https://internaldocs.unity.com/renovate/ for more documentation
+
+# This workflow runs Renovate against the current repo and will create PRs with outdated dependencies.
+name: Renovate
+
+on:
+  workflow_dispatch:
+    inputs:
+      log-level:
+        type: choice
+        description: Select log level for Renovate
+        options:
+          - trace
+          - debug
+          - info
+          - warn
+          - error
+        default: info
+        required: false
+  schedule:
+    # Default daily scheduled run. Feel free to change this to run when you want it to.
+    - cron: '15 14 * * *'
+
+jobs:
+  renovate:
+    # The reusable workflow will be updated by renovate if there's a new version
+    uses: unity/renovate-workflows/.github/workflows/run.yml@v4.0.0
+    with:
+      # This is the image that contains our custom renovate and will be auto
+      # updated by Renovate itself.
+      image: europe-docker.pkg.dev/unity-cds-services-prd/ds-docker/renovate:10.1.3@sha256:fdeed7bb524bd67611eb91ee1a5e990c8c73ed62c84a0cd5ef66c87eb5fd0d70
+      log-level: ${{ github.event.inputs.log-level }}
+    secrets:
+      renovate-auth-secret: ${{ secrets.RENOVATE_AUTH_SECRET }}
+      github-com-token: ${{ secrets.GH_COM_TOKEN }}
+


### PR DESCRIPTION
**DO NOT FORGET TO INCLUDE A CHANGELOG ENTRY**

### Purpose of this PR

This PR adds a workflow that runs Renovate against the current repo and will create PRs with outdated dependencies. It also adds another workflow for validating the Renovate configuration and docker image updates for it.

Refer to https://internaldocs.unity.com/renovate/ for more documentation

> Yamato jobs: adding Renovate to the repository with your Yamato jobs is [recommended best practice](https://internaldocs.unity.com/yamato_continuous_integration/usage/best-practices/) to keep dependencies in your Yamato jobs up to date, including the pinned version of the Bokken image you’re using for your job.

It's also useful for keeping Wrench up to date

### Links

**Jira:** [WBTR-1367](https://jira.unity3d.com/browse/WBTR-1367)

### Comments to Reviewers