### PR TITLE
Fixed an issue where faces being extruded using the shift+click were invisible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [PBLD-164] Fixed a bug with UV autostitching where the position offset would not take into account the face rotation center offset.
 - [PBLD-251] Fixed a bug which would cause out of bounds exceptions when exporting meshes with quad topology
 - [PBLD-253] Removes call to internal API that is being removed.
+- [PBLD-255] Fixed an issue where faces being extruded using the shift+click were invisible
 
 ## [6.0.6] - 2025-07-01
 

--- a/Editor/EditorCore/VertexManipulationTool.cs
+++ b/Editor/EditorCore/VertexManipulationTool.cs
@@ -320,6 +320,9 @@ namespace UnityEditor.ProBuilder
             var selection = MeshSelection.topInternal;
             var selectMode = ProBuilderEditor.selectMode;
 
+            // A small epsilon is added to avoid the created face being detected as a degenerate triangle
+            const float epsilon = .00001f;
+
             foreach (var mesh in selection)
             {
                 switch (selectMode)
@@ -329,7 +332,7 @@ namespace UnityEditor.ProBuilder
                             goto default;
 
                         Edge[] newEdges = mesh.Extrude(mesh.selectedEdges,
-                                0f,
+                                epsilon,
                                 s_ExtrudeEdgesAsGroup,
                                 ProBuilderEditor.s_AllowNonManifoldActions);
 
@@ -345,7 +348,7 @@ namespace UnityEditor.ProBuilder
 
                         if (len > 0)
                         {
-                            mesh.Extrude(mesh.selectedFacesInternal, s_ExtrudeMethod, 0f);
+                            mesh.Extrude(mesh.selectedFacesInternal, s_ExtrudeMethod, epsilon);
                             mesh.SetSelectedFaces(mesh.selectedFacesInternal);
                             ef += len;
                         }


### PR DESCRIPTION
### Purpose of this PR

**Regression**
The problematic [PR](https://github.com/Unity-Technologies/com.unity.probuilder/pull/606) removed degenerate triangles from meshes, meaning a triangle where all three vertices lie on the same straight line, effectively making it a line segment. 

The problem is that the existing Extrude feature, specifically when using the shift+click feature to extrude from a face or an edge, would create a new face, with the two new vertices being exactly the same as the origin edge :
`mesh.Extrude(mesh.selectedFacesInternal, s_ExtrudeMethod, 0f);`

The 0f represents the distance from the origin face/edge, meaning that the created face would result in a degenerate triangle.

**Fix**
The fix was simply to add an epsilon when calling mesh.Extrude from the shift+click, so that while extruding, the face would not be removed automatically while it was looking for degenerate triangles

**Tests**
Because the API of Extrude is in itself correct, simply the call from the editor action had to be retouched, no unit tests were added.

### Links

https://jira.unity3d.com/browse/PBLD-255

### Comments to Reviewers

N/A