### PR TITLE
Fix Material Warnings When Importing ProBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [PBLD-226] Fixed a bug where ProBuilder faces could not selected when obscured by another GameObject
 - [PBLD-164] Fixed a bug with UV autostitching where the position offset would not take into account the face rotation center offset.
 - [PBLD-251] Fixed a bug which would cause out of bounds exceptions when exporting meshes with quad topology
-- [PBLD-253] Removes call to internal API that is being removed.
+- [PBLD-253] Removed a call to internal API that is being removed.
 - [PBLD-255] Fixed an issue where faces being extruded using the shift+click were invisible
+- Fixed warnings about materials being altered when the package is imported in Unity 6.2.
 
 ## [6.0.6] - 2025-07-01
 

--- a/Content/Material/Checker.mat
+++ b/Content/Material/Checker.mat
@@ -24,10 +24,11 @@ Material:
   m_Shader: {fileID: 4800000, guid: 8547ec39534635c4289065e5c5033f43, type: 3}
   m_Parent: {fileID: 0}
   m_ModifiedSerializedProperties: 0
-  m_ValidKeywords:
+  m_ValidKeywords: []
+  m_InvalidKeywords:
   - _DISABLE_SSR_TRANSPARENT
-  m_InvalidKeywords: []
-  m_LightmapFlags: 1
+  - _EMISSION
+  m_LightmapFlags: 3
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: 2225
@@ -97,7 +98,7 @@ Material:
     - _AlphaCutoffEnable: 0
     - _AlphaDstBlend: 0
     - _AlphaSrcBlend: 1
-    - _BUILTIN_QueueControl: -1
+    - _BUILTIN_QueueControl: 1
     - _BUILTIN_QueueOffset: 0
     - _BlendMode: 0
     - _BumpScale: 1
@@ -200,4 +201,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  version: 9
+  version: 10

--- a/Content/Resources/Materials/ProBuilderDefault.mat
+++ b/Content/Resources/Materials/ProBuilderDefault.mat
@@ -41,7 +41,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  version: 9
+  version: 10
 --- !u!21 &2100000
 Material:
   serializedVersion: 8
@@ -56,7 +56,8 @@ Material:
   m_ValidKeywords: []
   m_InvalidKeywords:
   - _DISABLE_SSR_TRANSPARENT
-  m_LightmapFlags: 1
+  - _EMISSION
+  m_LightmapFlags: 3
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: 2000

--- a/Content/Resources/Materials/ProBuilderDefault.mat
+++ b/Content/Resources/Materials/ProBuilderDefault.mat
@@ -60,7 +60,7 @@ Material:
   m_LightmapFlags: 3
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
-  m_CustomRenderQueue: 2000
+  m_CustomRenderQueue: -1
   stringTagMap:
     MotionVector: User
   disabledShaderPasses:


### PR DESCRIPTION
### Purpose of this PR

Warnings pop up about materials being altered when one imports the ProBuilder package in Unity 6000.2 and above. This PR serves to update those materials to fix the warnings.

### Links

**Jira:**

### Comments to Reviewers

Tested by importing the local copy of ProBuilder with this fix on the latest versions of Unity 6000.2 and 6000.0