### PR TITLE
Fixed issue with edge selection.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - [PBLD-240] Fixed a bug where buttons for "Create Cube" and "Create PolyShape" appeared incorrectly on Light theme.
+- [PBLD-258] Fixed an bug where clicking a highlighted edge might select a hidden edge instead.
 
 ## [6.0.7] - 2025-08-28
 

--- a/Tests/Editor/Picking/EdgePickerTests.cs
+++ b/Tests/Editor/Picking/EdgePickerTests.cs
@@ -184,8 +184,6 @@ public class EdgePickerTests
 
         yield return null;
 
-        //MeshSelection.AddToSelection(mesh2.gameObject);
-
         Edge edge1 = m_Mesh.facesInternal[0].edgesInternal[3];
         Vector3 pA1_world = m_Mesh.transform.TransformPoint(m_Mesh.positionsInternal[edge1.a]);
         Vector3 pB1_world = m_Mesh.transform.TransformPoint(m_Mesh.positionsInternal[edge1.b]);


### PR DESCRIPTION
**DO NOT FORGET TO INCLUDE A CHANGELOG ENTRY**

### Purpose of this PR

An issue was found with edge selection where even if a specific edge was visually highlighted by the hover system, a different edge might be selected once you left-clicked. This was pretty confusing for users because what they saw highlighted wasn't always what they got when they clicked, making the tool feel a bit unpredictable.

The root of this problem was how the `EdgeRaycast ` function worked. When you clicked, it first cleared any existing selection information. Then, there was a part of the code that checked if an edge was already highlighted. If it was highlighted, the code would skip trying to figure out which game object you were hovering over with `HandleUtility.PickGameObject`. This meant that `selection.gameObject` would stay `null`, causing the system to completely miss the mesh that was actually highlighted. So, it couldn't properly check for the nearest edge on that specific highlighted mesh. Instead, it would fall back to a more general search, finding the edge closest to your mouse in 2D screen space from currently selected meshes, which often picked something behind or not the intended edge.

The fix for this problem makes sure the system properly prioritizes. Now, right at the start of `EdgeRaycast`, if an edge is already highlighted by ProBuilder's hover state, the code grabs that specific highlighted edge and its mesh. It then quickly checks if this highlighted edge is still close enough to your mouse cursor. If it is, the system immediately selects this highlighted edge and returns early. This guarantees that the edge you see highlighted is the one that gets selected. If for some reason the highlighted edge isn't valid or too far, then the function continues with its usual picking logic, finding the closest edge from selected meshes like before.

Unit tests were updated to use cubes instead of planes, because planes couldn't really show this hidden edge issue well. A new unit test was also added specifically to confirm that the highlighted edge is the one that gets picked.

Before :

![edgePickerbug](https://github.com/user-attachments/assets/f9642f51-20e7-47c3-9495-e1cff9cf49ca)

After :

![edgePickerbug2](https://github.com/user-attachments/assets/feff2049-3c76-438f-b136-149907f3e4ff)

### Links

[PBLD-258](https://jira.unity3d.com/browse/PBLD-258)

### Comments to Reviewers

N/A