### PR TITLE
[DOCATT-104141] Clarified where experimental settings are

### DIFF
--- a/Documentation~/experimental.md
+++ b/Documentation~/experimental.md
@@ -8,4 +8,8 @@ ProBuilder includes three experimental features:
 
 These features are still under development; they're not fully tested, and might reduce ProBuilder's stability. They are disabled by default; use them with caution.
 
-To enable experimental features, in the main menu, go to **Unity** > **Settings** > **ProBuilder** and enable **Experimental Features Enabled**.
+To enable experimental featuresL
+
+1. In the main menu, go to **Edit** > **Preferences** (macOS: **Unity** > **Settings**).
+1. Select the **ProBuilder** tab. 
+1. In the **ProBuilder** tab, enable **Experimental Features Enabled**.

--- a/Documentation~/experimental.md
+++ b/Documentation~/experimental.md
@@ -8,7 +8,7 @@ ProBuilder includes three experimental features:
 
 These features are still under development; they're not fully tested, and might reduce ProBuilder's stability. They are disabled by default; use them with caution.
 
-To enable experimental featuresL
+To enable experimental features:
 
 1. In the main menu, go to **Edit** > **Preferences** (macOS: **Unity** > **Settings**).
 1. Select the **ProBuilder** tab. 


### PR DESCRIPTION
**DO NOT FORGET TO INCLUDE A CHANGELOG ENTRY**

### Purpose of this PR

In response to user feedback, clarified where the ProBuilder preferences are located in the Editor. 

### Links

**Jira:** https://jira.unity3d.com/browse/DOCATT-10414

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]