### PR TITLE
Bugfix/uum 141074 fix create shape gridsnap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- [UUM-141074] Fixed an issue where the CreateShape and CreatePolyshape tools would not properly snap to the grid.
 - [UUM-133861] Fixed "Look rotation viewing vector is zero" log being spammed when holding shift while using a create tool such as Create Sprite.
 - [UUM-133859] Fixed an issue in URP projects where the Editor would recompile scripts when after a rectangle selection in ProBuilder. 
 - [UUM-133530] Fixed the `Set Double Sided` custom action in the Editor Sample, which was previously remaining disabled.

--- a/Editor/EditorCore/DrawShapeTool.cs
+++ b/Editor/EditorCore/DrawShapeTool.cs
@@ -564,7 +564,7 @@ namespace UnityEditor.ProBuilder
             ProBuilderEditor.selectModeChanged -= OnSelectModeChanged;
             EditorApplication.playModeStateChanged -= OnPlayModeStateChanged;
 
-            if (m_ProBuilderShape != null && !( m_CurrentState is ShapeState_InitShape ))
+            if (m_ProBuilderShape != null)
                 m_CurrentState = ShapeState.ResetState();
 
             if (m_DuplicateGO != null)

--- a/Editor/EditorCore/PolyShapeTool.cs
+++ b/Editor/EditorCore/PolyShapeTool.cs
@@ -236,6 +236,8 @@ namespace UnityEditor.ProBuilder
     [EditorTool("Edit PolyShape", typeof(PolyShape))]
     public class PolyShapeTool : EditorTool
     {
+        public override bool gridSnapEnabled => true;
+
         [MenuItem("Tools/ProBuilder/Edit/Edit PolyShape", true, PreferenceKeys.menuEditor + 10)]
         static bool ValidateEditShapeTool()
         {

--- a/Editor/StateMachines/ShapeState_InitShape.cs
+++ b/Editor/StateMachines/ShapeState_InitShape.cs
@@ -47,59 +47,54 @@ namespace UnityEditor.ProBuilder
 
             if(evt.isMouse && HandleUtility.nearestControl == tool.controlID)
             {
-                if (evt.type != EventType.MouseDown)
-                {
-                    HandleUtility.PlaceObject(evt.mousePosition, out m_HitPosition, out _);
-                    m_HitPosition = tool.GetPoint(m_HitPosition);
-                }
-                else
-                {
-                    var res = EditorHandleUtility.FindBestPlaneAndBitangent(evt.mousePosition, tool.m_DuplicateGO);
-                    Ray ray = HandleUtility.GUIPointToWorldRay(evt.mousePosition);
-                    float hit;
+                var res = EditorHandleUtility.FindBestPlaneAndBitangent(evt.mousePosition, tool.m_DuplicateGO);
+                Ray ray = HandleUtility.GUIPointToWorldRay(evt.mousePosition);
+                float hit;
 
-                    if (evt.button == 0 && res.item1.Raycast(ray, out hit))
+                if (res.item1.Raycast(ray, out hit))
+                {
+                    var planeNormal = res.item1.normal;
+                    var planeCenter = res.item1.normal * -res.item1.distance;
+
+                    // if hit point on plane is cardinal axis and on grid, snap to grid.
+                    if (Math.IsCardinalAxis(planeNormal))
                     {
-                        //Plane init
+                        const float epsilon = .00001f;
+                        bool offGrid = false;
+                        Vector3 snapVal = EditorSnapping.activeMoveSnapValue;
+                        Vector3 center =
+                            Vector3.Scale(ProBuilderSnapping.GetSnappingMaskBasedOnNormalVector(planeNormal),
+                                planeCenter);
+                        for (int i = 0; i < 3; i++)
+                            offGrid |= Mathf.Abs(snapVal[i] % center[i]) > epsilon;
+                        tool.m_IsOnGrid = !offGrid;
+                    }
+                    else
+                    {
+                        tool.m_IsOnGrid = false;
+                    }
+
+                    m_HitPosition = tool.GetPoint(ray.GetPoint(hit));
+
+                    //Click has been done => Define a plane for the tool
+                    if (evt.type == EventType.MouseDown && evt.button == 0)
+                    {
+                        //Plane init (persist for subsequent states)
                         tool.m_Plane = res.item1;
                         tool.m_PlaneForward = res.item2;
                         tool.m_PlaneRight = Vector3.Cross(tool.m_Plane.normal, tool.m_PlaneForward);
 
-                        var planeNormal = tool.m_Plane.normal;
-                        var planeCenter = tool.m_Plane.normal * -tool.m_Plane.distance;
-                        // if hit point on plane is cardinal axis and on grid, snap to grid.
-                        if (Math.IsCardinalAxis(planeNormal))
-                        {
-                            const float epsilon = .00001f;
-                            bool offGrid = false;
-                            Vector3 snapVal = EditorSnapping.activeMoveSnapValue;
-                            Vector3 center =
-                                Vector3.Scale(ProBuilderSnapping.GetSnappingMaskBasedOnNormalVector(planeNormal),
-                                    planeCenter);
-                            for (int i = 0; i < 3; i++)
-                                offGrid |= Mathf.Abs(snapVal[i] % center[i]) > epsilon;
-                            tool.m_IsOnGrid = !offGrid;
-                        }
-                        else
-                        {
-                            tool.m_IsOnGrid = false;
-                        }
+                        //BB init
+                        tool.m_BB_Origin = m_HitPosition;
+                        tool.m_BB_HeightCorner = tool.m_BB_Origin;
+                        tool.m_BB_OppositeCorner = tool.m_BB_Origin;
 
-                        m_HitPosition = tool.GetPoint(ray.GetPoint(hit));
-
-                        //Click has been done => Define a plane for the tool
-                        if (evt.type == EventType.MouseDown && evt.button == 0)
-                        {
-                            //BB init
-                            tool.m_BB_Origin = m_HitPosition;
-                            tool.m_BB_HeightCorner = tool.m_BB_Origin;
-                            tool.m_BB_OppositeCorner = tool.m_BB_Origin;
-
-                            return NextState();
-                        }
+                        return NextState();
                     }
-                    else
-                        m_HitPosition = Vector3.positiveInfinity;
+                }
+                else
+                {
+                    m_HitPosition = Vector3.positiveInfinity;
                 }
             }
 

--- a/Tests/Editor/Editor/ShapeToolGridSnapTests.cs
+++ b/Tests/Editor/Editor/ShapeToolGridSnapTests.cs
@@ -1,0 +1,151 @@
+using NUnit.Framework;
+using UnityEditor;
+using UnityEditor.EditorTools;
+using UnityEditor.ProBuilder;
+using UnityEngine;
+using UnityEngine.ProBuilder;
+using ToolManager = UnityEditor.EditorTools.ToolManager;
+
+public class ShapeToolGridSnapTests
+{
+    [SetUp]
+    public void SetUp()
+    {
+        ToolManager.SetActiveContext<GameObjectToolContext>();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        ToolManager.RestorePreviousPersistentTool();
+    }
+
+    [Test]
+    public void CreateCubeTool_HasGridSnapEnabled()
+    {
+        ToolManager.SetActiveTool<CreateCubeTool>();
+        var toolType = ToolManager.activeToolType;
+
+        Assert.That(toolType, Is.EqualTo(typeof(CreateCubeTool)));
+
+        // Verify the tool has gridSnapEnabled property set to true
+        var tool = DrawShapeTool.instance;
+        Assert.That(tool, Is.Not.Null);
+        Assert.That(tool.gridSnapEnabled, Is.True);
+    }
+
+    [Test]
+    public void DrawShapeTool_GetPoint_SnapsWhenOnGridAndGridSnapActive()
+    {
+        ToolManager.SetActiveTool<CreateCubeTool>();
+        var tool = DrawShapeTool.instance;
+        Assume.That(tool, Is.Not.Null);
+
+        // Enable grid mode (this is set by ShapeState_InitShape during hover)
+        tool.m_IsOnGrid = true;
+
+        // Only test if grid snapping is currently active in the editor
+        if (EditorSnapSettings.gridSnapActive)
+        {
+            // Test position that should snap to grid
+            Vector3 unsnapedPosition = new Vector3(1.23f, 2.34f, 3.45f);
+            Vector3 snappedPosition = tool.GetPoint(unsnapedPosition);
+
+            // Position should be snapped (not equal to original)
+            Assert.That(snappedPosition, Is.Not.EqualTo(unsnapedPosition));
+        }
+        else
+        {
+            // Skip test if grid snap is not active
+            Assert.Ignore("Grid snapping is not active in the editor, skipping snap verification");
+        }
+    }
+
+    [Test]
+    public void DrawShapeTool_GetPoint_DoesNotSnapWhenOffGrid()
+    {
+        ToolManager.SetActiveTool<CreateCubeTool>();
+        var tool = DrawShapeTool.instance;
+        Assume.That(tool, Is.Not.Null);
+
+        // Disable grid mode
+        tool.m_IsOnGrid = false;
+
+        // Test position should NOT snap regardless of editor snap settings
+        Vector3 position = new Vector3(1.23f, 2.34f, 3.45f);
+        Vector3 result = tool.GetPoint(position);
+
+        // Position should remain unchanged when m_IsOnGrid is false
+        Assert.That(result, Is.EqualTo(position));
+    }
+
+    [Test]
+    public void PolyShapeTool_HasGridSnapEnabled()
+    {
+        // Test that PolyShapeTool also has gridSnapEnabled (fix from commit 1e25f10d7)
+        ToolManager.SetActiveTool<DrawPolyShapeTool>();
+
+        // PolyShapeTool doesn't have a static instance like DrawShapeTool,
+        // so we just verify it was activated successfully
+        Assert.That(ToolManager.activeToolType, Is.EqualTo(typeof(DrawPolyShapeTool)));
+    }
+
+    [Test]
+    public void DrawShapeTool_GetPoint_RespectsIncrementalSnap()
+    {
+        ToolManager.SetActiveTool<CreateCubeTool>();
+        var tool = DrawShapeTool.instance;
+        Assume.That(tool, Is.Not.Null);
+
+        // Get current incremental snap value
+        Vector3 snapValue = EditorSnapping.incrementalSnapMoveValue;
+
+        // Test with incremental snap enabled
+        Vector3 unsnappedPosition = new Vector3(1.23f, 2.34f, 3.45f);
+        Vector3 snappedPosition = tool.GetPoint(unsnappedPosition, useIncrementSnap: true);
+
+        // Position should be snapped to incremental snap value
+        Assert.That(snappedPosition, Is.Not.EqualTo(unsnappedPosition));
+
+        // Verify each component is a multiple of snap value (within tolerance)
+        Assert.That(snappedPosition.x % snapValue.x, Is.EqualTo(0).Within(0.001f));
+        Assert.That(snappedPosition.y % snapValue.y, Is.EqualTo(0).Within(0.001f));
+        Assert.That(snappedPosition.z % snapValue.z, Is.EqualTo(0).Within(0.001f));
+    }
+
+    /// Test for UUM-141074:
+    [Test]
+    public void ShapeState_InitShape_CalculatesGridStateBeforeMouseDown()
+    {
+        // This test verifies the fix for UUM-141074
+        // Before the fix, m_IsOnGrid was only calculated on MouseDown
+        // After the fix, it's calculated during hover (before MouseDown)
+
+        ToolManager.SetActiveTool<CreateCubeTool>();
+        var tool = DrawShapeTool.instance;
+        Assume.That(tool, Is.Not.Null);
+
+        // The fix ensures that GetPoint can snap correctly during hover
+        // because m_IsOnGrid is set before GetPoint is called
+        // We can't directly test the state machine, but we can verify
+        // that the tool's GetPoint method respects the m_IsOnGrid flag
+
+        // Test 1: When m_IsOnGrid is true, GetPoint should snap (if grid is active)
+        tool.m_IsOnGrid = true;
+        Vector3 pos1 = new Vector3(1.23f, 2.34f, 3.45f);
+        Vector3 result1 = tool.GetPoint(pos1);
+
+        if (EditorSnapSettings.gridSnapActive)
+        {
+            Assert.That(result1, Is.Not.EqualTo(pos1),
+                "GetPoint should snap when m_IsOnGrid is true and grid snap is active");
+        }
+
+        // Test 2: When m_IsOnGrid is false, GetPoint should NOT snap
+        tool.m_IsOnGrid = false;
+        Vector3 pos2 = new Vector3(1.23f, 2.34f, 3.45f);
+        Vector3 result2 = tool.GetPoint(pos2);
+        Assert.That(result2, Is.EqualTo(pos2),
+            "GetPoint should not snap when m_IsOnGrid is false");
+    }
+}

--- a/Tests/Editor/Editor/ShapeToolGridSnapTests.cs
+++ b/Tests/Editor/Editor/ShapeToolGridSnapTests.cs
@@ -41,6 +41,12 @@ public class ShapeToolGridSnapTests
         var tool = DrawShapeTool.instance;
         Assume.That(tool, Is.Not.Null);
 
+        EditorSnapSettings.gridSnapEnabled = true;
+        EditorSnapSettings.snapEnabled = true;
+
+        var previousPivotRotation = Tools.pivotRotation;
+        Tools.pivotRotation = PivotRotation.Global;
+
         // Enable grid mode (this is set by ShapeState_InitShape during hover)
         tool.m_IsOnGrid = true;
 
@@ -48,17 +54,19 @@ public class ShapeToolGridSnapTests
         if (EditorSnapSettings.gridSnapActive)
         {
             // Test position that should snap to grid
-            Vector3 unsnapedPosition = new Vector3(1.23f, 2.34f, 3.45f);
-            Vector3 snappedPosition = tool.GetPoint(unsnapedPosition);
+            Vector3 unsnappedPosition = new Vector3(1.23f, 2.34f, 3.45f);
+            Vector3 snappedPosition = tool.GetPoint(unsnappedPosition);
 
             // Position should be snapped (not equal to original)
-            Assert.That(snappedPosition, Is.Not.EqualTo(unsnapedPosition));
+            Assert.That(snappedPosition, Is.Not.EqualTo(unsnappedPosition));
         }
         else
         {
             // Skip test if grid snap is not active
             Assert.Ignore("Grid snapping is not active in the editor, skipping snap verification");
         }
+
+        Tools.pivotRotation = previousPivotRotation;
     }
 
     [Test]
@@ -77,17 +85,6 @@ public class ShapeToolGridSnapTests
 
         // Position should remain unchanged when m_IsOnGrid is false
         Assert.That(result, Is.EqualTo(position));
-    }
-
-    [Test]
-    public void PolyShapeTool_HasGridSnapEnabled()
-    {
-        // Test that PolyShapeTool also has gridSnapEnabled (fix from commit 1e25f10d7)
-        ToolManager.SetActiveTool<DrawPolyShapeTool>();
-
-        // PolyShapeTool doesn't have a static instance like DrawShapeTool,
-        // so we just verify it was activated successfully
-        Assert.That(ToolManager.activeToolType, Is.EqualTo(typeof(DrawPolyShapeTool)));
     }
 
     [Test]
@@ -111,41 +108,5 @@ public class ShapeToolGridSnapTests
         Assert.That(snappedPosition.x % snapValue.x, Is.EqualTo(0).Within(0.001f));
         Assert.That(snappedPosition.y % snapValue.y, Is.EqualTo(0).Within(0.001f));
         Assert.That(snappedPosition.z % snapValue.z, Is.EqualTo(0).Within(0.001f));
-    }
-
-    /// Test for UUM-141074:
-    [Test]
-    public void ShapeState_InitShape_CalculatesGridStateBeforeMouseDown()
-    {
-        // This test verifies the fix for UUM-141074
-        // Before the fix, m_IsOnGrid was only calculated on MouseDown
-        // After the fix, it's calculated during hover (before MouseDown)
-
-        ToolManager.SetActiveTool<CreateCubeTool>();
-        var tool = DrawShapeTool.instance;
-        Assume.That(tool, Is.Not.Null);
-
-        // The fix ensures that GetPoint can snap correctly during hover
-        // because m_IsOnGrid is set before GetPoint is called
-        // We can't directly test the state machine, but we can verify
-        // that the tool's GetPoint method respects the m_IsOnGrid flag
-
-        // Test 1: When m_IsOnGrid is true, GetPoint should snap (if grid is active)
-        tool.m_IsOnGrid = true;
-        Vector3 pos1 = new Vector3(1.23f, 2.34f, 3.45f);
-        Vector3 result1 = tool.GetPoint(pos1);
-
-        if (EditorSnapSettings.gridSnapActive)
-        {
-            Assert.That(result1, Is.Not.EqualTo(pos1),
-                "GetPoint should snap when m_IsOnGrid is true and grid snap is active");
-        }
-
-        // Test 2: When m_IsOnGrid is false, GetPoint should NOT snap
-        tool.m_IsOnGrid = false;
-        Vector3 pos2 = new Vector3(1.23f, 2.34f, 3.45f);
-        Vector3 result2 = tool.GetPoint(pos2);
-        Assert.That(result2, Is.EqualTo(pos2),
-            "GetPoint should not snap when m_IsOnGrid is false");
     }
 }

--- a/Tests/Editor/Editor/ShapeToolGridSnapTests.cs.meta
+++ b/Tests/Editor/Editor/ShapeToolGridSnapTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 41c2a001abcc39e439cbf0c7a5d4df2b


### PR DESCRIPTION
#Purpose of this PR

  ##Problem

  The Create Shape tool (Cube, Sphere, Plane, etc.) was ignoring grid snapping when hovering the cursor over the scene view before starting to create a shape. Grid snapping would only activate after the first mouse click (MouseDown event). This inconsistent behavior differed from the Create PolyShape tool, which correctly snapped to the grid during hover.

  Additionally, the Create PolyShape tool had gridSnapEnabled not set to true, preventing the tool from properly integrating with Unity's grid snapping system.

  ##Root Cause

  In ShapeState_InitShape.cs, the m_IsOnGrid flag was only calculated during the MouseDown event (when clicking to start shape creation), not during hover/mouse move events. Since DrawShapeTool.GetPoint() requires both m_IsOnGrid && EditorSnapSettings.gridSnapActive to be true for snapping to work, the  cursor position remained unsnapped during hover.

##Solutions

  ###Create Shape Tool Fix

  Refactored ShapeState_InitShape.DoState() to calculate the plane and grid snapping state for ALL mouse events (hover + click), not just on MouseDown:

  Key Changes:
  - Moved plane calculation and m_IsOnGrid determination outside the MouseDown-specific branch
  - Grid alignment check now happens during hover, before GetPoint() is called
  - On MouseDown, the plane is persisted to tool members for subsequent states
  - Eliminated code duplication by unifying hover and click logic

  Result: m_IsOnGrid is correctly set before GetPoint() is called during hover, enabling grid snapping throughout the shape creation workflow.

  ###Create PolyShape Tool Fix

  Added gridSnapEnabled override to PolyShapeTool class:
`  public override bool gridSnapEnabled => true;`

  This ensures the tool properly integrates with Unity's grid snapping system.

### Links

**Jira:** https://jira.unity3d.com/browse/UUM-141074

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]