### PR TITLE
[UUM-141406] fixing action overlay behavior

### DIFF
--- a/Editor/MenuActions/Geometry/BevelEdges.cs
+++ b/Editor/MenuActions/Geometry/BevelEdges.cs
@@ -62,10 +62,15 @@ namespace UnityEditor.ProBuilder.Actions
                 }
             });
 
-            PreviewActionManager.delayedPreviewChanged += () =>
+            System.Action onDelayedPreviewChanged = () =>
             {
                 floatField.isDelayed = PreviewActionManager.delayedPreview;
             };
+            PreviewActionManager.delayedPreviewChanged += onDelayedPreviewChanged;
+            root.RegisterCallback<DetachFromPanelEvent>(evt =>
+            {
+                PreviewActionManager.delayedPreviewChanged -= onDelayedPreviewChanged;
+            });
             root.Add(floatField);
 
             return root;

--- a/Editor/MenuActions/Geometry/BevelEdges.cs
+++ b/Editor/MenuActions/Geometry/BevelEdges.cs
@@ -61,6 +61,11 @@ namespace UnityEditor.ProBuilder.Actions
                     PreviewActionManager.UpdatePreview();
                 }
             });
+
+            PreviewActionManager.delayedPreviewChanged += () =>
+            {
+                floatField.isDelayed = PreviewActionManager.delayedPreview;
+            };
             root.Add(floatField);
 
             return root;

--- a/Editor/MenuActions/Geometry/ExtrudeEdges.cs
+++ b/Editor/MenuActions/Geometry/ExtrudeEdges.cs
@@ -53,6 +53,10 @@ namespace UnityEditor.ProBuilder.Actions
             floatField.tooltip = "Extrude Amount determines how far an edge will be moved along it's normal when extruding. This value can be negative.";
             floatField.SetValueWithoutNotify(m_ExtrudeEdgeDistance);
             floatField.RegisterCallback<ChangeEvent<float>>(OnExtrudeChanged);
+            PreviewActionManager.delayedPreviewChanged += () =>
+            {
+                floatField.isDelayed = PreviewActionManager.delayedPreview;
+            };
             root.Add(floatField);
 
             return root;

--- a/Editor/MenuActions/Geometry/ExtrudeEdges.cs
+++ b/Editor/MenuActions/Geometry/ExtrudeEdges.cs
@@ -53,10 +53,16 @@ namespace UnityEditor.ProBuilder.Actions
             floatField.tooltip = "Extrude Amount determines how far an edge will be moved along it's normal when extruding. This value can be negative.";
             floatField.SetValueWithoutNotify(m_ExtrudeEdgeDistance);
             floatField.RegisterCallback<ChangeEvent<float>>(OnExtrudeChanged);
-            PreviewActionManager.delayedPreviewChanged += () =>
+
+            System.Action onDelayedPreviewChanged = () =>
             {
                 floatField.isDelayed = PreviewActionManager.delayedPreview;
             };
+            PreviewActionManager.delayedPreviewChanged += onDelayedPreviewChanged;
+            root.RegisterCallback<DetachFromPanelEvent>(evt =>
+            {
+                PreviewActionManager.delayedPreviewChanged -= onDelayedPreviewChanged;
+            });
             root.Add(floatField);
 
             return root;

--- a/Editor/MenuActions/Geometry/ExtrudeFaces.cs
+++ b/Editor/MenuActions/Geometry/ExtrudeFaces.cs
@@ -106,6 +106,11 @@ namespace UnityEditor.ProBuilder.Actions
             });
             root.Add(distanceField);
 
+            PreviewActionManager.delayedPreviewChanged += () =>
+            {
+                distanceField.isDelayed = PreviewActionManager.delayedPreview;
+            };
+
             return root;
         }
 

--- a/Editor/MenuActions/Geometry/ExtrudeFaces.cs
+++ b/Editor/MenuActions/Geometry/ExtrudeFaces.cs
@@ -106,10 +106,15 @@ namespace UnityEditor.ProBuilder.Actions
             });
             root.Add(distanceField);
 
-            PreviewActionManager.delayedPreviewChanged += () =>
+            System.Action onDelayedPreviewChanged = () =>
             {
                 distanceField.isDelayed = PreviewActionManager.delayedPreview;
             };
+            PreviewActionManager.delayedPreviewChanged += onDelayedPreviewChanged;
+            root.RegisterCallback<DetachFromPanelEvent>(evt =>
+            {
+                PreviewActionManager.delayedPreviewChanged -= onDelayedPreviewChanged;
+            });
 
             return root;
         }

--- a/Editor/MenuActions/Geometry/OffsetElements.cs
+++ b/Editor/MenuActions/Geometry/OffsetElements.cs
@@ -51,9 +51,9 @@ namespace UnityEditor.ProBuilder.Actions
 
             var spaceField = new EnumField("Coordinate Space", coord);
             root.Add(spaceField);
-            spaceField.RegisterCallback<ChangeEvent<string>>(evt =>
+            spaceField.RegisterCallback<ChangeEvent<Enum>>(evt =>
             {
-                Enum.TryParse(evt.newValue, out CoordinateSpace newValue);
+                CoordinateSpace newValue = (CoordinateSpace)evt.newValue;
                 if (s_CoordinateSpace.value == newValue)
                     return;
                 s_CoordinateSpace.SetValue(newValue);
@@ -70,10 +70,15 @@ namespace UnityEditor.ProBuilder.Actions
                 PreviewActionManager.UpdatePreview();
             });
 
-            PreviewActionManager.delayedPreviewChanged += () =>
+            Action onDelayedPreviewChanged = () =>
             {
                 distField.Query<FloatField>().ForEach(ff => ff.isDelayed = PreviewActionManager.delayedPreview);
             };
+            PreviewActionManager.delayedPreviewChanged += onDelayedPreviewChanged;
+            root.RegisterCallback<DetachFromPanelEvent>(evt =>
+            {
+                PreviewActionManager.delayedPreviewChanged -= onDelayedPreviewChanged;
+            });
 
             return root;
         }

--- a/Editor/MenuActions/Geometry/OffsetElements.cs
+++ b/Editor/MenuActions/Geometry/OffsetElements.cs
@@ -62,14 +62,18 @@ namespace UnityEditor.ProBuilder.Actions
 
             var distField = new Vector3Field("Translate");
             distField.SetValueWithoutNotify(dist);
-            if(PreviewActionManager.delayedPreview)
-                distField.Query<FloatField>().ForEach(ff => ff.isDelayed = true);
+            distField.Query<FloatField>().ForEach(ff => ff.isDelayed = PreviewActionManager.delayedPreview);
             root.Add(distField);
             distField.RegisterCallback<ChangeEvent<Vector3>>(evt =>
             {
                 s_Translation.SetValue(evt.newValue, true);
                 PreviewActionManager.UpdatePreview();
             });
+
+            PreviewActionManager.delayedPreviewChanged += () =>
+            {
+                distField.Query<FloatField>().ForEach(ff => ff.isDelayed = PreviewActionManager.delayedPreview);
+            };
 
             return root;
         }

--- a/Editor/MenuActions/Geometry/SubdivideEdges.cs
+++ b/Editor/MenuActions/Geometry/SubdivideEdges.cs
@@ -83,6 +83,10 @@ namespace UnityEditor.ProBuilder.Actions
             m_SubdivCount.tooltip = tooltip;
             m_SubdivCount.RegisterCallback<ChangeEvent<int>>(OnCountChanged);
             m_SubdivCount.style.width = 40;
+            PreviewActionManager.delayedPreviewChanged += () =>
+            {
+                m_SubdivCount.isDelayed = PreviewActionManager.delayedPreview;
+            };
             line.Add(foldout);
             line.Add(m_Slider);
             line.Add(m_SubdivCount);

--- a/Editor/MenuActions/Geometry/SubdivideEdges.cs
+++ b/Editor/MenuActions/Geometry/SubdivideEdges.cs
@@ -83,10 +83,15 @@ namespace UnityEditor.ProBuilder.Actions
             m_SubdivCount.tooltip = tooltip;
             m_SubdivCount.RegisterCallback<ChangeEvent<int>>(OnCountChanged);
             m_SubdivCount.style.width = 40;
-            PreviewActionManager.delayedPreviewChanged += () =>
+            Action onDelayedPreviewChanged = () =>
             {
                 m_SubdivCount.isDelayed = PreviewActionManager.delayedPreview;
             };
+            PreviewActionManager.delayedPreviewChanged += onDelayedPreviewChanged;
+            root.RegisterCallback<DetachFromPanelEvent>(evt =>
+            {
+                PreviewActionManager.delayedPreviewChanged -= onDelayedPreviewChanged;
+            });
             line.Add(foldout);
             line.Add(m_Slider);
             line.Add(m_SubdivCount);

--- a/Editor/MenuActions/Geometry/WeldVertices.cs
+++ b/Editor/MenuActions/Geometry/WeldVertices.cs
@@ -69,6 +69,10 @@ namespace UnityEditor.ProBuilder.Actions
                     m_WeldDistance.SetValue(evt.newValue);
                 PreviewActionManager.UpdatePreview();
             });
+            PreviewActionManager.delayedPreviewChanged += () =>
+            {
+                floatField.isDelayed = PreviewActionManager.delayedPreview;
+            };
             root.Add(floatField);
             return root;
         }

--- a/Editor/MenuActions/Geometry/WeldVertices.cs
+++ b/Editor/MenuActions/Geometry/WeldVertices.cs
@@ -69,10 +69,15 @@ namespace UnityEditor.ProBuilder.Actions
                     m_WeldDistance.SetValue(evt.newValue);
                 PreviewActionManager.UpdatePreview();
             });
-            PreviewActionManager.delayedPreviewChanged += () =>
+            Action onDelayedPreviewChanged = () =>
             {
                 floatField.isDelayed = PreviewActionManager.delayedPreview;
             };
+            PreviewActionManager.delayedPreviewChanged += onDelayedPreviewChanged;
+            root.RegisterCallback<DetachFromPanelEvent>(evt =>
+            {
+                PreviewActionManager.delayedPreviewChanged -= onDelayedPreviewChanged;
+            });
             root.Add(floatField);
             return root;
         }

--- a/Editor/MenuActions/Selection/GrowSelection.cs
+++ b/Editor/MenuActions/Selection/GrowSelection.cs
@@ -85,7 +85,10 @@ Grow by angle is enabled by Option + Clicking the <b>Grow Selection</b> button."
                 m_GrowSelectionAngleIterative.SetValue(evt.newValue);
                 PreviewActionManager.UpdatePreview();
             });
-
+            PreviewActionManager.delayedPreviewChanged += () =>
+            {
+                floatField.isDelayed = PreviewActionManager.delayedPreview;
+            };
             return root;
         }
 

--- a/Editor/MenuActions/Selection/GrowSelection.cs
+++ b/Editor/MenuActions/Selection/GrowSelection.cs
@@ -85,10 +85,15 @@ Grow by angle is enabled by Option + Clicking the <b>Grow Selection</b> button."
                 m_GrowSelectionAngleIterative.SetValue(evt.newValue);
                 PreviewActionManager.UpdatePreview();
             });
-            PreviewActionManager.delayedPreviewChanged += () =>
+            System.Action onDelayedPreviewChanged = () =>
             {
                 floatField.isDelayed = PreviewActionManager.delayedPreview;
             };
+            PreviewActionManager.delayedPreviewChanged += onDelayedPreviewChanged;
+            root.RegisterCallback<DetachFromPanelEvent>(evt =>
+            {
+                PreviewActionManager.delayedPreviewChanged -= onDelayedPreviewChanged;
+            });
             return root;
         }
 

--- a/Editor/Overlays/ActionSettings.cs
+++ b/Editor/Overlays/ActionSettings.cs
@@ -18,6 +18,7 @@ namespace UnityEditor.ProBuilder
         [UserSetting("Mesh Editing", "Auto Update Action Preview", "Automatically update the action preview, without delay. This operation is costly and can cause lag when working with large selections.")]
         static Pref<bool> s_AutoUpdatePreview = new Pref<bool>("editor.autoUpdatePreview", false, SettingsScope.Project);
         internal static bool delayedPreview => !s_AutoUpdatePreview.value;
+        public static event Action delayedPreviewChanged;
 
         MenuAction m_CurrentAction;
 
@@ -59,8 +60,10 @@ namespace UnityEditor.ProBuilder
             ProBuilderEditor.selectModeChanged += SelectModeChanged;
 
             SceneView.AddOverlayToActiveView(m_Overlay = new MenuActionSettingsOverlay());
+            // Hack to ensure that the overlay is displayed in the sceneview even when the overlay was already displayed before
+            // Doing only displayed = true is not adding the overlay as it should in the view, only changing the display status is
+            m_Overlay.displayed = false;
             m_Overlay.displayed = true;
-            SceneView.RepaintAll();
         }
 
         public void Dispose()
@@ -104,12 +107,7 @@ namespace UnityEditor.ProBuilder
 
             s_AutoUpdatePreview.value = value;
 
-            if (s_Instance == null)
-                return;
-
-            SceneView.RemoveOverlayFromActiveView(s_Instance.m_Overlay);
-            SceneView.AddOverlayToActiveView(s_Instance.m_Overlay = new MenuActionSettingsOverlay());
-            s_Instance.m_Overlay.displayed = true;
+            delayedPreviewChanged?.Invoke();
         }
 
         internal static void EndPreview()


### PR DESCRIPTION
##Purpose of this PR

  Jira: UUM-141406 (https://jira.unity3d.com/browse/UUM-141406)

  This PR fixes two related issues with ProBuilder action overlays:

  1. Overlay Display Issue: When an action overlay was already displayed in the SceneView and a new action was
  triggered, the overlay would not properly refresh or display. The fix adds a workaround that toggles displayed from
  false to true to ensure the overlay is properly added/refreshed in the view.
  2. Live Preview Toggle Not Updating Fields: When users toggled the "Live Preview" setting during an action, input
  fields (FloatField, IntegerField, Vector3Field) would not dynamically update their isDelayed property. Users had to
  restart the action for the setting to take effect.

  ###Solution:
  - Introduced a delayedPreviewChanged event in PreviewActionManager that fires when the live preview setting changes
  - Updated all affected geometry actions (BevelEdges, ExtrudeEdges, ExtrudeFaces, OffsetElements, SubdivideEdges,
  WeldVertices, GrowSelection) to subscribe to this event and update their field properties dynamically
  - Fixed the overlay display issue with a toggle workaround in ActionSettings.cs
  - Removed the previous inefficient approach of destroying and recreating the entire overlay UI

 ##Release Notes

  Fixed: UUM-141406 - Action overlays now display correctly when triggering a new action while an overlay is already shown in the SceneView. 

  ##Functional Testing status

  Manual Testing:
  - Tested all seven modified geometry actions (Bevel Edges, Extrude Edges, Extrude Faces, Offset Elements, Subdivide
  Edges, Weld Vertices, Grow Selection)
  - Verified toggling "Live Preview" immediately updates field behavior (delayed vs immediate input)
  - Verified starting actions when overlays are already displayed properly shows the new action overlay
  - Tested both delayed and immediate preview modes with each action
  - Confirmed field input behavior matches the live preview setting in all cases

  Existing Automation:
  ProBuilder has existing editor tests for action functionality. The overlay display and UI field behavior changes are
  UI-specific and covered by manual testing.

 ##Performance Testing Status

  Performance Impact: Minimal positive impact

  The change replaces an inefficient approach (destroying and recreating the entire overlay UI hierarchy) with an
  event-based approach that only updates the isDelayed property on existing fields. This reduces allocations and UI
  rebuilds when toggling the live preview setting.

  No performance testing required - this is a UI behavior fix with a minor efficiency improvement.

  ##Overall Product Risks

  Technical Risk: 1
  Isolated UI behavior changes in ProBuilder action overlays. The event-based approach is straightforward, and the
  overlay display workaround is localized. Low risk of regression.

  Halo Effect: 1
  Changes are isolated to ProBuilder's action overlay system and the seven modified geometry actions. Does not affect
  other ProBuilder functionality, other packages, or Unity Editor core systems.