### PR TITLE
[UUM-136930] Fix Arch field not readable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changes
 
+- [UUM-136930] Fixed Arch circumference field not being fully readable in the editor.
 - [UUM-131032] Added a reset of static variables when entering playmode to allow fast enter playmode compatibility.
 - [UUM-138539] Removed the pb_ObjectArray file that was deprecated 8 years ago and is not used amymore.
 - [UUM-138960] Removed a large utility dictionary to reduce binary size and runtime memory overhead. 

--- a/Editor/EditorCore/ProBuilderShapeEditor.cs
+++ b/Editor/EditorCore/ProBuilderShapeEditor.cs
@@ -1,8 +1,12 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
 using UnityEditor.EditorTools;
 using UnityEngine;
 using UnityEngine.ProBuilder;
 using UnityEngine.ProBuilder.Shapes;
+using Debug = UnityEngine.Debug;
 using ToolManager = UnityEditor.EditorTools.ToolManager;
 
 namespace UnityEditor.ProBuilder
@@ -133,7 +137,7 @@ namespace UnityEditor.ProBuilder
             if(foldoutEnabled)
             {
                 EditorGUI.indentLevel++;
-                EditorGUIUtility.labelWidth = 90;
+                EditorGUIUtility.labelWidth = 120;
 
                 if (tool)
                     tool.pivotLocation = (PivotLocation)EditorGUILayout.EnumPopup(k_ShapePivotLabel, tool.pivotLocation);
@@ -179,14 +183,31 @@ namespace UnityEditor.ProBuilder
                 {
                     if(comp is ProBuilderShape shapeComponent && shapeComponent.isEditable)
                     {
-                        UndoUtility.RecordComponents<Transform, ProBuilderMesh, ProBuilderShape>(shapeComponent.GetComponents(typeof(Component)),"Resize Shape");
+                        Stopwatch stopWatch = new Stopwatch();
+                        stopWatch.Start();
+                        //UndoUtility.RecordComponents<Transform, ProBuilderMesh, ProBuilderShape>(shapeComponent.GetComponents(typeof(Component)),"Resize Shape");
+                        // Undo.RecordObject(shapeComponent, "Edit Shape");
+
+                        //Undo.RecordObject(shapeComponent.transform, "Edit Shape");
+                        //Undo.RecordObject(shapeComponent, "Edit Shape");
+
+                        Undo.RegisterCompleteObjectUndo(shapeComponent.mesh, "Edit Shape");
+
+                        TimeSpan ts1 = stopWatch.Elapsed;
                         shapeComponent.UpdateShape();
+
+                        TimeSpan ts2 = stopWatch.Elapsed;
                         if(tool != null)
                         {
                             tool.SetBounds(shapeComponent.size);
                             tool.SaveShapeParams(shapeComponent);
                         }
                         ProBuilderEditor.Refresh();
+
+                        stopWatch.Stop();
+                        // Get the elapsed time as a TimeSpan value.
+                        TimeSpan ts3 = stopWatch.Elapsed;
+                        Debug.Log($"Time spend = ({ts1.TotalMilliseconds}, {ts2.TotalMilliseconds}, {ts3.TotalMilliseconds}) ms");
                     }
                 }
             }

--- a/Editor/EditorCore/ProBuilderShapeEditor.cs
+++ b/Editor/EditorCore/ProBuilderShapeEditor.cs
@@ -1,12 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Threading;
 using UnityEditor.EditorTools;
 using UnityEngine;
 using UnityEngine.ProBuilder;
 using UnityEngine.ProBuilder.Shapes;
-using Debug = UnityEngine.Debug;
 using ToolManager = UnityEditor.EditorTools.ToolManager;
 
 namespace UnityEditor.ProBuilder
@@ -183,31 +179,14 @@ namespace UnityEditor.ProBuilder
                 {
                     if(comp is ProBuilderShape shapeComponent && shapeComponent.isEditable)
                     {
-                        Stopwatch stopWatch = new Stopwatch();
-                        stopWatch.Start();
-                        //UndoUtility.RecordComponents<Transform, ProBuilderMesh, ProBuilderShape>(shapeComponent.GetComponents(typeof(Component)),"Resize Shape");
-                        // Undo.RecordObject(shapeComponent, "Edit Shape");
-
-                        //Undo.RecordObject(shapeComponent.transform, "Edit Shape");
-                        //Undo.RecordObject(shapeComponent, "Edit Shape");
-
-                        Undo.RegisterCompleteObjectUndo(shapeComponent.mesh, "Edit Shape");
-
-                        TimeSpan ts1 = stopWatch.Elapsed;
+                        UndoUtility.RecordComponents<Transform, ProBuilderMesh, ProBuilderShape>(shapeComponent.GetComponents(typeof(Component)),"Resize Shape");
                         shapeComponent.UpdateShape();
-
-                        TimeSpan ts2 = stopWatch.Elapsed;
                         if(tool != null)
                         {
                             tool.SetBounds(shapeComponent.size);
                             tool.SaveShapeParams(shapeComponent);
                         }
                         ProBuilderEditor.Refresh();
-
-                        stopWatch.Stop();
-                        // Get the elapsed time as a TimeSpan value.
-                        TimeSpan ts3 = stopWatch.Elapsed;
-                        Debug.Log($"Time spend = ({ts1.TotalMilliseconds}, {ts2.TotalMilliseconds}, {ts3.TotalMilliseconds}) ms");
                     }
                 }
             }

--- a/Runtime/Shapes/Arch.cs
+++ b/Runtime/Shapes/Arch.cs
@@ -218,7 +218,7 @@ namespace UnityEngine.ProBuilder.Shapes
 
         static readonly GUIContent k_ThicknessContent = new GUIContent("Thickness", L10n.Tr("Thickness of the arch borders. Larger value creates a smaller opening."));
         static readonly GUIContent k_SidesContent = new GUIContent("Sides Count", L10n.Tr("Number of sides of the arch."));
-        static readonly GUIContent k_CircumferenceContent = new GUIContent("Arch Circumference", L10n.Tr("Circumference of the arch in degrees."));
+        static readonly GUIContent k_CircumferenceContent = new GUIContent("Arch Circ.", L10n.Tr("Circumference of the arch in degrees."));
         static readonly GUIContent k_EndCapsContent = new GUIContent("End Caps", L10n.Tr("Whether to generate faces for the ends of the arch."));
         static readonly GUIContent k_SmoothContent = new GUIContent("Smooth", L10n.Tr("Whether to smooth the edges of the arch."));
 


### PR DESCRIPTION
### Purpose of this PR

This PR shorten the label "Arch circumference" to "Arch circ." to avoid a cut in the Editor UIs.
This choice has been done to align with the Torus shape that is already doing this. 

### Links

**Jira:** https://jira.unity3d.com/browse/UUM-136930

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]