### PR TITLE
[UUM-132698] Fixing the movetool snapping when using the Slider1D

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changes
 
+- [UUM-132698] Fixed incorrect snapping of the UV Editor MoveTool in the scene. 
 - [UUM-131032] Added a reset of static variables when entering playmode to allow fast enter playmode compatibility.
 - [UUM-138539] Removed the pb_ObjectArray file that was deprecated 8 years ago and is not used amymore.
 - [UUM-138960] Removed a large utility dictionary to reduce binary size and runtime memory overhead. 

--- a/Editor/EditorCore/TextureMoveTool.cs
+++ b/Editor/EditorCore/TextureMoveTool.cs
@@ -59,11 +59,11 @@ namespace UnityEditor.ProBuilder
 
             Handles.color = Color.green;
 
-            m_Position = Handles.Slider(m_Position, Vector3.up);
+            m_Position = Handles.Slider(m_Position, Vector3.up, HandleUtility.GetHandleSize(m_Position), Handles.ArrowHandleCap, 0f);
 
             Handles.color = Color.red;
 
-            m_Position = Handles.Slider(m_Position, Vector3.right);
+            m_Position = Handles.Slider(m_Position, Vector3.right, HandleUtility.GetHandleSize(m_Position), Handles.ArrowHandleCap, 0f);
 
             Handles.color = Color.white;
 


### PR DESCRIPTION
### Purpose of this PR

The move tool of the UV Editor in the scene view was working incorrectly. 
Not setting the snap parameter to `0f` explicitly would use a snapping of 1f under the hood.

This has to be corrected in the Unity Editor API directly, but using this other API works as expected and will still be valid after the fix as well.

### Links

**Jira:** https://jira.unity3d.com/browse/UUM-132698

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]