### PR TITLE
[UUM-138261] Fix move handle exponentially moving the selected elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changes
 
+- [UUM-138261] Fixed an issue where the move handle could create an incorrect displacement of selected elements.
 - [UUM-132698] Fixed incorrect snapping of the UV Editor MoveTool in the scene. 
 - [UUM-131032] Added a reset of static variables when entering playmode to allow fast enter playmode compatibility.
 - [UUM-138539] Removed the pb_ObjectArray file that was deprecated 8 years ago and is not used amymore.

--- a/Editor/EditorCore/VertexManipulationTool.cs
+++ b/Editor/EditorCore/VertexManipulationTool.cs
@@ -117,9 +117,9 @@ namespace UnityEditor.ProBuilder
         {
             if (s_PivotRotation != Tools.pivotRotation)
             {
-                s_HandleOrientation.SetValue(Tools.pivotRotation == PivotRotation.Global
-                    ? HandleOrientation.World
-                    : HandleOrientation.ActiveObject);
+                s_HandleOrientation.SetValue(Tools.pivotRotation == PivotRotation.Local
+                    ? HandleOrientation.ActiveObject
+                    : HandleOrientation.World);
                 s_PivotRotation = Tools.pivotRotation;
                 MeshSelection.InvalidateCaches();
                 pivotRotationChanged?.Invoke();
@@ -127,15 +127,18 @@ namespace UnityEditor.ProBuilder
             }
 
             var value = s_HandleOrientation.value;
-            var unity = value == HandleOrientation.ActiveObject ? PivotRotation.Local : PivotRotation.Global;
-
-            if (value != HandleOrientation.ActiveElement)
+            var customUnityPivotRotation = Tools.pivotRotation != PivotRotation.Global && Tools.pivotRotation != PivotRotation.Local;
+            // We only sync pivot modes that are compatible with probuilder: Global and Local
+            if (!customUnityPivotRotation && value != HandleOrientation.ActiveElement)
             {
+                var unity = PivotRotation.Global;
+                if (value == HandleOrientation.ActiveObject)
+                    unity = PivotRotation.Local;
                 if (unity != Tools.pivotRotation)
                 {
-                    s_HandleOrientation.SetValue(Tools.pivotRotation == PivotRotation.Global
-                            ? HandleOrientation.World
-                            : HandleOrientation.ActiveObject,
+                    s_HandleOrientation.SetValue(Tools.pivotRotation == PivotRotation.Local
+                            ? HandleOrientation.ActiveObject
+                            : HandleOrientation.World,
                         true);
                     MeshSelection.InvalidateCaches();
                     pivotRotationChanged?.Invoke();

--- a/Tests/Editor/Geometry/VertexManipulationTests.cs
+++ b/Tests/Editor/Geometry/VertexManipulationTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;
@@ -12,6 +13,77 @@ using UObject = UnityEngine.Object;
 
 class VertexManipulationTests
 {
+    HandleOrientation m_OriginalOrientation;
+    PivotRotation m_OriginalPivotRotation;
+
+    [SetUp]
+    public void SetUp()
+    {
+        m_OriginalOrientation = VertexManipulationTool.handleOrientation;
+        m_OriginalPivotRotation = Tools.pivotRotation;
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        VertexManipulationTool.handleOrientation = m_OriginalOrientation;
+        Tools.pivotRotation = m_OriginalPivotRotation;
+    }
+
+#if UNITY_6000_4_OR_NEWER
+    [Test]
+    public void SyncPivotRotation_PivotRotationGrid_HandleOrientationIsWorld()
+    {
+        Tools.pivotRotation = PivotRotation.Grid;
+        _ = VertexManipulationTool.handleOrientation; // flush sync
+
+        Assert.That(VertexManipulationTool.handleOrientation, Is.EqualTo(HandleOrientation.World));
+    }
+#endif
+
+    [Test]
+    public void SyncPivotRotation_PivotChangesToLocal_HandleOrientationIsActiveObject()
+    {
+        Tools.pivotRotation = PivotRotation.Global;
+        _ = VertexManipulationTool.handleOrientation; // flush sync
+
+        Tools.pivotRotation = PivotRotation.Local;
+        Assert.That(VertexManipulationTool.handleOrientation, Is.EqualTo(HandleOrientation.ActiveObject));
+    }
+
+    [Test]
+    public void SyncPivotRotation_PivotChangesToGlobal_HandleOrientationIsWorld()
+    {
+        Tools.pivotRotation = PivotRotation.Local;
+        _ = VertexManipulationTool.handleOrientation; // flush sync
+
+        Tools.pivotRotation = PivotRotation.Global;
+        Assert.That(VertexManipulationTool.handleOrientation, Is.EqualTo(HandleOrientation.World));
+    }
+
+    [Test]
+    public void HandleOrientation_RepeatedAccessWhenInSync_DoesNotFirePivotRotationChangedEvent()
+    {
+        VertexManipulationTool.handleOrientation = HandleOrientation.ActiveObject;
+        Assume.That(Tools.pivotRotation, Is.EqualTo(PivotRotation.Local));
+
+        int syncCount = 0;
+        Action countSync = () => syncCount++;
+        VertexManipulationTool.pivotRotationChanged += countSync;
+        try
+        {
+            for (int i = 0; i < 20; i++)
+                _ = VertexManipulationTool.handleOrientation;
+        }
+        finally
+        {
+            VertexManipulationTool.pivotRotationChanged -= countSync;
+        }
+
+        Assert.That(syncCount, Is.EqualTo(0),
+            "Accessing handleOrientation in a consistent state must not fire pivotRotationChanged");
+    }
+
     [UnityTest, Ignore("LINUX_EDITOR")]
     public static IEnumerator ExtrudeOrthogonally_OneElementManyTimes_NoYOffsetAccumulates()
     {


### PR DESCRIPTION
### Purpose of this PR

This PR fixes an issue with the Move handle, creating a accumulation of the move deltas when using the handles. This was resulting in an exponential motion of the selected element.

This was caused by a wrong test in the rotation handle type, causing a cache invalidation in the middle of the process. This PR fixes that and focuses on getting PivotRotation.Local and World from unity as they are the only valid ones. This prevent that the use of new pivot types (such as grid or custom) messes up with ProBuilder state.

This PR also added tests to validate that PB pivot types are aligned with these changes.


### Links

**Jira:** https://jira.unity3d.com/browse/UUM-138261

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]