### PR TITLE
[UUM-133528] Fixing autolightmap UV not rebuilding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- [UUM-133528] Fixed an issue where using some UV Editor actions would clear a mesh's Lightmap UVs without regenerating them.
+
 ## [6.1.2] - 2026-06-11
 
 ### Fixed

--- a/Editor/EditorCore/AutoUVEditor.cs
+++ b/Editor/EditorCore/AutoUVEditor.cs
@@ -214,26 +214,12 @@ namespace UnityEditor.ProBuilder
             {
                 for (int i = 0; i < selection.Length; i++)
                     TextureGroupSelectedFaces(selection[i]);
-
-                ProBuilderEditor.Refresh();
             }
 
             if (GUILayout.Button(gc_BreakSelected))
             {
                 SetTextureGroup(selection, -1);
-
-                foreach (var kvp in MeshSelection.selectedFacesInEditZone)
-                {
-                    kvp.Key.ToMesh();
-                    kvp.Key.Refresh();
-                    kvp.Key.Optimize();
-                }
-
-                SceneView.RepaintAll();
-
                 s_AutoUVSettingsDiff["textureGroup"] = false;
-
-                ProBuilderEditor.Refresh();
             }
 
             /* Select all in current texture group */
@@ -241,8 +227,6 @@ namespace UnityEditor.ProBuilder
             {
                 for (int i = 0; i < selection.Length; i++)
                     selection[i].SetSelectedFaces(System.Array.FindAll(selection[i].facesInternal, x => x.textureGroup == textureGroup));
-
-                ProBuilderEditor.Refresh();
             }
 
             if (GUILayout.Button(gc_Reset))
@@ -260,8 +244,6 @@ namespace UnityEditor.ProBuilder
 
                     UVEditing.SplitUVs(selection[i], selection[i].GetSelectedFaces());
                 }
-
-                ProBuilderEditor.Refresh();
             }
 
             GUI.backgroundColor = PreferenceKeys.proBuilderLightGray;

--- a/Editor/EditorCore/UVEditor.cs
+++ b/Editor/EditorCore/UVEditor.cs
@@ -2617,7 +2617,10 @@ namespace UnityEditor.ProBuilder
                     {
                         pb.ToMesh();
                         pb.Refresh();
+                        pb.Optimize();
                     }
+                    ProBuilderEditor.Refresh();
+                    SceneView.RepaintAll();
                 }
 
                 foreach (var kvp in MeshSelection.selectedFacesInEditZone)


### PR DESCRIPTION
### Purpose of this PR

Problem: Using any Auto UV panel action in the UV Editor (e.g. "Group Selected Faces") cleared the mesh's Lightmap UVs (UV2/TexCoord1) without regenerating them, even though these actions don't necessarily touch geometry.

Root cause: AutoUVEditor.OnGUI wraps its whole panel in a single EditorGUI.BeginChangeCheck()/EndChangeCheck(), so any interaction — including a button click that only sets face metadata — registers as a change. The caller, UVEditor.DrawAutoModeUI, responded to that by calling pb.ToMesh(); pb.Refresh(); on every mesh in the selection, which **_unconditionally clears mesh.uv2_**. Unlike the Planar/Box/Spherical Project actions, this path never followed up with pb.Optimize(), so the lightmap UVs were never rebuilt.

Fix:
- UVEditor.cs: added pb.Optimize() to the same guarded ToMesh/Refresh block in DrawAutoModeUI, plus centralized ProBuilderEditor.Refresh() calls there.
- AutoUVEditor.cs: removed the now-redundant per-button ProBuilderEditor.Refresh() / ToMesh()/Refresh()/Optimize() calls from "Group Selected Faces," "Break Selected Groups," "Select Texture Group," and "Reset UVs" — that responsibility now lives solely in the one caller (UVEditor.DrawAutoModeUI).

### Links

**Jira:** https://jira.unity3d.com/browse/UUM-133528

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]