### PR TITLE
[UUM-148243] Fixing dimensionseditor refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Fixed the Dimensions Overlay not updating when resizing a PolyShape or primitive Shape in the Scene View.
+- [UUM-148243] Fixed the Dimensions Overlay not updating when resizing a PolyShape or primitive Shape in the Scene View.
 
 ## [6.1.2] - 2026-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Made the ProBuilder Editor actions available in GameObject context in the action overlay.
 
+### Fixed
+
+- Fixed the Dimensions Overlay not updating when resizing a PolyShape or primitive Shape in the Scene View.
+
 ## [6.1.2] - 2026-06-11
 
 ### Fixed

--- a/Content/Resources/Materials/ProBuilderDefault.mat
+++ b/Content/Resources/Materials/ProBuilderDefault.mat
@@ -50,7 +50,7 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: ProBuilderDefault
-  m_Shader: {fileID: -6465566751694194690, guid: 8547ec39534635c4289065e5c5033f43, type: 3}
+  m_Shader: {fileID: 4800000, guid: 8547ec39534635c4289065e5c5033f43, type: 3}
   m_Parent: {fileID: 0}
   m_ModifiedSerializedProperties: 0
   m_ValidKeywords: []

--- a/Content/Resources/Materials/ProBuilderDefault.mat
+++ b/Content/Resources/Materials/ProBuilderDefault.mat
@@ -50,7 +50,7 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: ProBuilderDefault
-  m_Shader: {fileID: 4800000, guid: 8547ec39534635c4289065e5c5033f43, type: 3}
+  m_Shader: {fileID: -6465566751694194690, guid: 8547ec39534635c4289065e5c5033f43, type: 3}
   m_Parent: {fileID: 0}
   m_ModifiedSerializedProperties: 0
   m_ValidKeywords: []

--- a/Debug/Editor/MeshViewer.cs
+++ b/Debug/Editor/MeshViewer.cs
@@ -21,11 +21,13 @@ namespace UnityEditor.ProBuilder.Debug
         protected MeshDebugView()
         {
             ProBuilderMesh.elementSelectionChanged += SelectionChanged;
+            ProBuilderMesh.versionChanged += VersionChanged;
         }
 
         ~MeshDebugView()
         {
             ProBuilderMesh.elementSelectionChanged -= SelectionChanged;
+            ProBuilderMesh.versionChanged -= VersionChanged;
         }
 
         public ProBuilderMesh mesh
@@ -61,6 +63,12 @@ namespace UnityEditor.ProBuilder.Debug
                 SelectionChanged();
                 AnythingChanged();
             }
+        }
+
+        void VersionChanged(ProBuilderMesh mesh)
+        {
+            if (mesh == m_Mesh)
+                AnythingChanged();
         }
 
         protected virtual void MeshAssigned() {}
@@ -171,6 +179,7 @@ namespace UnityEditor.ProBuilder.Debug
             SceneView.duringSceneGui += OnSceneGUI;
             MeshSelection.objectSelectionChanged += SelectionChanged;
             ProBuilderMesh.elementSelectionChanged += SelectionChanged;
+            ProBuilderMesh.versionChanged += MeshVersionChanged;
             EditorMeshUtility.meshOptimized += MeshOptimized;
             SelectionChanged();
         }
@@ -178,6 +187,7 @@ namespace UnityEditor.ProBuilder.Debug
         void OnDisable()
         {
             EditorMeshUtility.meshOptimized -= MeshOptimized;
+            ProBuilderMesh.versionChanged -= MeshVersionChanged;
             ProBuilderMesh.elementSelectionChanged -= SelectionChanged;
             MeshSelection.objectSelectionChanged -= SelectionChanged;
             SceneView.duringSceneGui -= OnSceneGUI;
@@ -241,6 +251,12 @@ namespace UnityEditor.ProBuilder.Debug
         void SelectionChanged(ProBuilderMesh mesh)
         {
             SelectionChanged();
+        }
+
+        void MeshVersionChanged(ProBuilderMesh mesh)
+        {
+            Repaint();
+            SceneView.RepaintAll();
         }
 
         void MeshOptimized(ProBuilderMesh pmesh, Mesh umesh)

--- a/Editor/EditorCore/DimensionsEditor.cs
+++ b/Editor/EditorCore/DimensionsEditor.cs
@@ -172,6 +172,7 @@ namespace UnityEditor.ProBuilder
             SceneView.duringSceneGui += OnSceneGUI;
             MeshSelection.objectSelectionChanged += OnObjectSelectionChanged;
             ProBuilderMesh.elementSelectionChanged += OnElementSelectionChanged;
+            ProBuilderMesh.versionChanged += OnMeshVersionChanged;
             ProBuilderEditor.selectionUpdated += OnEditingMeshSelection;
             VertexManipulationTool.beforeMeshModification += OnBeginMeshModification;
             VertexManipulationTool.afterMeshModification += OnFinishMeshModification;
@@ -183,6 +184,7 @@ namespace UnityEditor.ProBuilder
         {
             MeshSelection.objectSelectionChanged -= OnObjectSelectionChanged;
             ProBuilderMesh.elementSelectionChanged -= OnElementSelectionChanged;
+            ProBuilderMesh.versionChanged -= OnMeshVersionChanged;
             ProBuilderEditor.selectionUpdated -= OnEditingMeshSelection;
             VertexManipulationTool.beforeMeshModification -= OnBeginMeshModification;
             VertexManipulationTool.afterMeshModification -= OnFinishMeshModification;
@@ -332,6 +334,11 @@ namespace UnityEditor.ProBuilder
         }
 
         void OnElementSelectionChanged(ProBuilderMesh mesh)
+        {
+            RebuildBounds();
+        }
+
+        void OnMeshVersionChanged(ProBuilderMesh mesh)
         {
             RebuildBounds();
         }

--- a/Editor/EditorCore/MeshSelection.cs
+++ b/Editor/EditorCore/MeshSelection.cs
@@ -127,6 +127,7 @@ namespace UnityEditor.ProBuilder
             Selection.selectionChanged += OnObjectSelectionChanged;
             Undo.undoRedoPerformed += UndoRedoPerformed;
             ProBuilderMesh.elementSelectionChanged += ElementSelectionChanged;
+            ProBuilderMesh.versionChanged += MeshVersionChanged;
             PrefabUtility.prefabInstanceReverted += PrefabInstanceReverted;
             EditorMeshUtility.meshOptimized += (x, y) => { s_ElementCountsDirty = true; };
             ProBuilderMesh.componentWillBeDestroyed += RemoveMeshFromSelectionInternal;
@@ -289,6 +290,11 @@ namespace UnityEditor.ProBuilder
         }
 
         static void ElementSelectionChanged(ProBuilderMesh mesh)
+        {
+            InvalidateCaches();
+        }
+
+        static void MeshVersionChanged(ProBuilderMesh mesh)
         {
             InvalidateCaches();
         }

--- a/Editor/Overlays/SceneInformationOverlay.cs
+++ b/Editor/Overlays/SceneInformationOverlay.cs
@@ -1,5 +1,6 @@
 ﻿using UnityEditor.Overlays;
 using UnityEngine;
+using UnityEngine.ProBuilder;
 using UnityEngine.UIElements;
 
 namespace UnityEditor.ProBuilder.Overlays
@@ -18,6 +19,7 @@ namespace UnityEditor.ProBuilder.Overlays
         {
             ProBuilderEditor.selectionUpdated += _ => UpdateSceneInfo();
             MeshSelection.objectSelectionChanged += UpdateSceneInfo;
+            ProBuilderMesh.versionChanged += _ => UpdateSceneInfo();
         }
 
         public override VisualElement CreatePanelContent()

--- a/Editor/Overlays/SceneInformationOverlay.cs
+++ b/Editor/Overlays/SceneInformationOverlay.cs
@@ -1,4 +1,5 @@
-﻿using UnityEditor.Overlays;
+﻿using System.Collections.Generic;
+using UnityEditor.Overlays;
 using UnityEngine;
 using UnityEngine.ProBuilder;
 using UnityEngine.UIElements;
@@ -17,10 +18,27 @@ namespace UnityEditor.ProBuilder.Overlays
 
         public SceneInformationOverlay()
         {
-            ProBuilderEditor.selectionUpdated += _ => UpdateSceneInfo();
-            MeshSelection.objectSelectionChanged += UpdateSceneInfo;
-            ProBuilderMesh.versionChanged += _ => UpdateSceneInfo();
+            rootVisualElement.RegisterCallback<AttachToPanelEvent>(OnAttachedToPanel);
+            rootVisualElement.RegisterCallback<DetachFromPanelEvent>(OnDetachFromPanel);
         }
+
+        void OnAttachedToPanel(AttachToPanelEvent evt)
+        {
+            ProBuilderEditor.selectionUpdated += OnSelectionUpdated;
+            MeshSelection.objectSelectionChanged += UpdateSceneInfo;
+            ProBuilderMesh.versionChanged += OnMeshVersionChanged;
+        }
+
+        void OnDetachFromPanel(DetachFromPanelEvent evt)
+        {
+            ProBuilderEditor.selectionUpdated -= OnSelectionUpdated;
+            MeshSelection.objectSelectionChanged -= UpdateSceneInfo;
+            ProBuilderMesh.versionChanged -= OnMeshVersionChanged;
+        }
+
+        void OnSelectionUpdated(IEnumerable<ProBuilderMesh> meshes) => UpdateSceneInfo();
+
+        void OnMeshVersionChanged(ProBuilderMesh mesh) => UpdateSceneInfo();
 
         public override VisualElement CreatePanelContent()
         {

--- a/Runtime/Core/ProBuilderMesh.cs
+++ b/Runtime/Core/ProBuilderMesh.cs
@@ -960,6 +960,11 @@ namespace UnityEngine.ProBuilder
         /// <seealso cref="SetSelectedEdges"/>
         public static event Action<ProBuilderMesh> elementSelectionChanged;
 
+        /// <summary>
+        /// Invoked from IncrementVersionIndex whenever this mesh's geometry is modified.
+        /// </summary>
+        internal static event Action<ProBuilderMesh> versionChanged;
+
         internal Mesh mesh
         {
             get

--- a/Runtime/Core/ProBuilderMeshFunction.cs
+++ b/Runtime/Core/ProBuilderMeshFunction.cs
@@ -168,8 +168,8 @@ namespace UnityEngine.ProBuilder
             InvalidateSharedTextureLookup();
             m_Colors = null;
             m_MeshFormatVersion = k_MeshFormatVersion;
-            IncrementVersionIndex();
             ClearSelection();
+            IncrementVersionIndex();
         }
 
         internal void EnsureMeshFilterIsAssigned()

--- a/Runtime/Core/ProBuilderMeshFunction.cs
+++ b/Runtime/Core/ProBuilderMeshFunction.cs
@@ -143,6 +143,8 @@ namespace UnityEngine.ProBuilder
                     m_VersionIndex = 1;
                 m_InstanceVersionIndex = m_VersionIndex;
             }
+
+            versionChanged?.Invoke(this);
         }
 
         /// <summary>

--- a/Tests/Editor/Object/ProBuilderMeshEventsTests.cs
+++ b/Tests/Editor/Object/ProBuilderMeshEventsTests.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine.ProBuilder;
+using UnityEngine.ProBuilder.Shapes;
+using UObject = UnityEngine.Object;
+
+static class ProBuilderMeshEventsTests
+{
+    static void CallToMesh(ProBuilderMesh mesh) => mesh.ToMesh();
+    static void CallRefresh(ProBuilderMesh mesh) => mesh.Refresh();
+    static void CallClear(ProBuilderMesh mesh) => mesh.Clear();
+
+    static IEnumerable<TestCaseData> MeshMutatingOperations()
+    {
+        yield return new TestCaseData((Action<ProBuilderMesh>)CallToMesh).SetName("ToMesh");
+        yield return new TestCaseData((Action<ProBuilderMesh>)CallRefresh).SetName("Refresh");
+        yield return new TestCaseData((Action<ProBuilderMesh>)CallClear).SetName("Clear");
+    }
+
+    [TestCaseSource(nameof(MeshMutatingOperations))]
+    public static void VersionChanged_IsInvokedWithMesh_WhenMeshVersionIsIncremented(Action<ProBuilderMesh> mutate)
+    {
+        var pb = ShapeFactory.Instantiate<Cube>();
+
+        try
+        {
+            ProBuilderMesh received = null;
+            int invokeCount = 0;
+            void Handler(ProBuilderMesh m)
+            {
+                received = m;
+                invokeCount++;
+            }
+
+            ProBuilderMesh.versionChanged += Handler;
+            try
+            {
+                mutate(pb);
+            }
+            finally
+            {
+                ProBuilderMesh.versionChanged -= Handler;
+            }
+
+            Assert.That(invokeCount, Is.GreaterThan(0));
+            Assert.That(received, Is.SameAs(pb));
+        }
+        finally
+        {
+            UObject.DestroyImmediate(pb.gameObject);
+        }
+    }
+
+    [Test]
+    public static void VersionChanged_IsNotInvoked_AfterUnsubscribing()
+    {
+        var pb = ShapeFactory.Instantiate<Cube>();
+
+        try
+        {
+            int invokeCount = 0;
+            void Handler(ProBuilderMesh m) => invokeCount++;
+
+            ProBuilderMesh.versionChanged += Handler;
+            ProBuilderMesh.versionChanged -= Handler;
+
+            pb.ToMesh();
+            pb.Refresh();
+
+            Assert.That(invokeCount, Is.EqualTo(0));
+        }
+        finally
+        {
+            UObject.DestroyImmediate(pb.gameObject);
+        }
+    }
+
+    [Test]
+    public static void VersionChanged_PassesTheModifiedMesh_WhenMultipleMeshesExist()
+    {
+        var pbA = ShapeFactory.Instantiate<Cube>();
+        var pbB = ShapeFactory.Instantiate<Cube>();
+
+        try
+        {
+            ProBuilderMesh received = null;
+            void Handler(ProBuilderMesh m) => received = m;
+
+            ProBuilderMesh.versionChanged += Handler;
+            try
+            {
+                pbB.ToMesh();
+            }
+            finally
+            {
+                ProBuilderMesh.versionChanged -= Handler;
+            }
+
+            Assert.That(received, Is.SameAs(pbB));
+            Assert.That(received, Is.Not.SameAs(pbA));
+        }
+        finally
+        {
+            UObject.DestroyImmediate(pbA.gameObject);
+            UObject.DestroyImmediate(pbB.gameObject);
+        }
+    }
+}

--- a/Tests/Editor/Object/ProBuilderMeshEventsTests.cs.meta
+++ b/Tests/Editor/Object/ProBuilderMeshEventsTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 293fd3f99fb37ef4d86e3885c970853d


### PR DESCRIPTION
### Purpose of this PR

Fixes the Dimensions Overlay not updating when resizing a PolyShape (or other shape/spline tools) in the Scene View.

**Root cause:** The Dimensions Overlay only recomputes its bounds on Unity selection change, element selection change, or ProBuilderEditor.selectionUpdated. That last event is only raised through ProBuilderEditor.instance, which is owned by the PositionToolContext and is null whenever editing happens through a component EditorTool (PolyShapeTool, EditShapeTool, etc.) without switching into that context — which is the normal flow for editing a PolyShape or primitive Shape. Since resizing doesn't move the object's Transform either, none of the overlay's existing refresh triggers fire, so its cached bounds go stale.

**Fix:** Added a new internal **static event Action<ProBuilderMesh> versionChanged** on ProBuilderMesh, raised from IncrementVersionIndex() — the single choke point every mesh-mutating operation (ToMesh, Refresh, Clear, Extrude, etc.) already runs through. This decouples "something changed this mesh's geometry" from ProBuilderEditor's tool-context state entirely, so it fires regardless of which tool/context is active.

DimensionsEditor now subscribes to it to rebuild its bounds. While auditing other places with the same "stale cache, no refresh outside PositionToolContext" pattern, also wired it up in:
- MeshSelection — invalidates its cached face/vertex/triangle counts.
- SceneInformationOverlay — refreshes its displayed counts (currently disabled via commented-out [Overlay] attribute, but fixed for if/when it's re-enabled).
- Debug/Editor/MeshViewer.cs (MeshDebugView + MeshViewer) — refreshes the debug mesh viewer's cached per-mesh data and repaints.

Added **Tests/Editor/Object/ProBuilderMeshEventsTests.cs** covering the event itself in isolation (fires with the correct mesh across several mutating operations, stops firing after unsubscribing, reports the right mesh when multiple meshes exist) — not the individual consumers above.

### Links

**Jira:** https://jira.unity3d.com/browse/UUM-148243

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]