### PR TITLE
[UUM-148237] Fixing uvlightmap pref foldout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- [UUM-148237] Fixed the "Lightmap UVs Settings" foldout in ProBuilder Preferences not opening when clicking its title.
 - [UUM-133528] Fixed an issue where using some UV Editor actions would clear a mesh's Lightmap UVs without regenerating them.
 
 ### Changes

--- a/Editor/EditorCore/Lightmapping.cs
+++ b/Editor/EditorCore/Lightmapping.cs
@@ -71,7 +71,7 @@ namespace UnityEditor.ProBuilder
             var isSearching = !string.IsNullOrEmpty(searchContext);
 
             if (!isSearching)
-                Styles.unwrapSettingsFoldout = EditorGUILayout.Foldout(Styles.unwrapSettingsFoldout, "Lightmap UVs Settings");
+                Styles.unwrapSettingsFoldout = EditorGUILayout.Foldout(Styles.unwrapSettingsFoldout, "Lightmap UVs Settings", true);
 
             if (isSearching || Styles.unwrapSettingsFoldout)
             {


### PR DESCRIPTION
### Purpose of this PR

Fixed the "Lightmap UVs Settings" foldout in ProBuilder Preferences not opening when clicking its title.

Just adding the interactable = true to the foldout method.

### Links

**Jira:** https://jira.unity3d.com/browse/UUM-148237

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]