### PR TITLE
BugFix : Missing icons in toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - [UUM-133528] Fixed an issue where using some UV Editor actions would clear a mesh's Lightmap UVs without regenerating them.
+- Fixed the Select Hidden (Select Back Faces) toggle icon missing from the Tool Settings overlay due to a filename casing mismatch.
 
 ### Changes
 

--- a/Editor/MenuActions/Interaction/ToggleSelectBackFaces.cs
+++ b/Editor/MenuActions/Interaction/ToggleSelectBackFaces.cs
@@ -10,7 +10,7 @@ namespace UnityEditor.ProBuilder.Actions
             get { return ToolbarGroup.Selection; }
         }
 
-        public override string iconPath => "Toolbar/Selection_SelectHidden-Off";
+        public override string iconPath => "Toolbar/Selection_SelectHidden-OFF";
         public override Texture2D icon => ProBuilderEditor.backfaceSelectionEnabled ? m_Icons[1] : m_Icons[0];
 
         public override TooltipContent tooltip
@@ -48,8 +48,8 @@ namespace UnityEditor.ProBuilder.Actions
         {
             m_Icons = new Texture2D[]
             {
-                IconUtility.GetIcon("Toolbar/Selection_SelectHidden-Off"),
-                IconUtility.GetIcon("Toolbar/Selection_SelectHidden-On")
+                IconUtility.GetIcon("Toolbar/Selection_SelectHidden-OFF"),
+                IconUtility.GetIcon("Toolbar/Selection_SelectHidden-ON")
             };
         }
 

--- a/Editor/MenuActions/Interaction/ToggleXRay.cs
+++ b/Editor/MenuActions/Interaction/ToggleXRay.cs
@@ -10,7 +10,7 @@ namespace UnityEditor.ProBuilder.Actions
             get { return ToolbarGroup.Selection; }
         }
 
-        public override string iconPath => "Toolbar/Selection_SelectHidden-Off";
+        public override string iconPath => "Toolbar/Selection_SelectHidden-OFF";
         public override Texture2D icon => ProBuilderEditor.backfaceSelectionEnabled ? m_Icons[1] : m_Icons[0];
 
         public override TooltipContent tooltip
@@ -49,8 +49,8 @@ namespace UnityEditor.ProBuilder.Actions
         {
             m_Icons = new Texture2D[]
             {
-                IconUtility.GetIcon("Toolbar/Selection_SelectHidden-Off"),
-                IconUtility.GetIcon("Toolbar/Selection_SelectHidden-On")
+                IconUtility.GetIcon("Toolbar/Selection_SelectHidden-OFF"),
+                IconUtility.GetIcon("Toolbar/Selection_SelectHidden-ON")
             };
         }
 

--- a/Tests/Editor/Editor/IconUtilityTests.cs
+++ b/Tests/Editor/Editor/IconUtilityTests.cs
@@ -27,9 +27,9 @@ class IconUtilityTests
             // PolyShapeTool.cs
             "Toolbar/CreatePolyShape.png",
             "Toolbar/CreatePolyShape",
-            // ToggleXRay.cs
-            "Toolbar/Selection_SelectHidden-Off",
-            "Toolbar/Selection_SelectHidden-On",
+            // ToggleXRay.cs, ToggleSelectBackFaces.cs
+            "Toolbar/Selection_SelectHidden-OFF",
+            "Toolbar/Selection_SelectHidden-ON",
             // ProBuilderMeshEditor.cs
             "EditableMesh/EditMeshContext",
             // ExtrudeFaces.cs


### PR DESCRIPTION
### Purpose of this PR

Fixes 2 missing toolbar icons: ToggleSelectBackFaces.cs requested Selection_SelectHidden-Off/-On (icon lookup is case-sensitive) while the actual files are named -OFF/-ON, so both textures failed to load.

Updated the icon path strings to match the on-disk filenames; no asset changes needed.

Before:
<img width="291" height="224" alt="Screenshot 2026-08-06 163429" src="https://github.com/user-attachments/assets/2ae2f0f5-0a00-4389-9807-b9e04604f714" />

After:
<img width="277" height="125" alt="Screenshot 2026-08-06 164054" src="https://github.com/user-attachments/assets/88d9520d-8105-48dd-89b1-417f04995b10" />


### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]