### PR TITLE
[UUM-149791] Fix First Vertex pivot offset when resizing shapes or shift-duplicating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- [UUM-149791] Fixed the First Vertex pivot ending up offset from the shape after resizing an existing shape or shift-duplicating one with the Shape tool.
 - [UUM-148237] Fixed the "Lightmap UVs Settings" foldout in ProBuilder Preferences not opening when clicking its title.
 - [UUM-133528] Fixed an issue where using some UV Editor actions would clear a mesh's Lightmap UVs without regenerating them.
 - Fixed the Select Hidden (Select Back Faces) toggle icon missing from the Tool Settings overlay due to a filename casing mismatch.

--- a/Editor/EditorCore/DrawShapeTool.cs
+++ b/Editor/EditorCore/DrawShapeTool.cs
@@ -446,31 +446,16 @@ namespace UnityEditor.ProBuilder
             {
                 if (pivotLocation == PivotLocation.FirstVertex && instance != null)
                 {
-                    // Only the corner (sign per axis) of the last non-duplicate shape is reused here.
-                    // The offset magnitude must come from the size of the shape currently being
-                    // previewed/duplicated (m_Bounds.size), not from the size it was originally drawn at.
-                    var lastCenterToOrigin = instance.m_LastNonDuplicateCenterToOrigin;
-                    var cornerSign = new Vector3(
-                        SignOrZero(lastCenterToOrigin.x),
-                        SignOrZero(lastCenterToOrigin.y),
-                        SignOrZero(lastCenterToOrigin.z));
-
-                    var currentCenterToOrigin = Vector3.Scale(cornerSign, instance.m_Bounds.size * 0.5f);
-                    var pivotOffset = instance.m_PlaneRotation * currentCenterToOrigin;
+                    // A First Vertex pivot always sits at bounds.center - size/2: the sign of `size`
+                    // itself already encodes which side the shape extends toward, so the size (and
+                    // corner) of whatever shape was last drawn has no bearing on this - only the
+                    // shape currently being previewed/duplicated (instance.m_Bounds) does.
+                    var pivotOffset = instance.m_PlaneRotation * (instance.m_Bounds.size * -0.5f);
                     return pivotOffset + instance.m_Bounds.center;
                 }
 
                 return m_Bounds.center;
             }
-        }
-
-        static float SignOrZero(float value)
-        {
-            if (value > 0f)
-                return 1f;
-            if (value < 0f)
-                return -1f;
-            return 0f;
         }
 
         int m_ControlID;

--- a/Editor/EditorCore/DrawShapeTool.cs
+++ b/Editor/EditorCore/DrawShapeTool.cs
@@ -446,18 +446,31 @@ namespace UnityEditor.ProBuilder
             {
                 if (pivotLocation == PivotLocation.FirstVertex && instance != null)
                 {
+                    // Only the corner (sign per axis) of the last non-duplicate shape is reused here.
+                    // The offset magnitude must come from the size of the shape currently being
+                    // previewed/duplicated (m_Bounds.size), not from the size it was originally drawn at.
                     var lastCenterToOrigin = instance.m_LastNonDuplicateCenterToOrigin;
-                    var lastCenterToOriginNorm = lastCenterToOrigin.normalized;
+                    var cornerSign = new Vector3(
+                        SignOrZero(lastCenterToOrigin.x),
+                        SignOrZero(lastCenterToOrigin.y),
+                        SignOrZero(lastCenterToOrigin.z));
 
-                    var deltaRot = instance.m_PlaneRotation;
-                    lastCenterToOriginNorm = deltaRot * lastCenterToOriginNorm;
-
-                    var pivotOffset = lastCenterToOriginNorm * lastCenterToOrigin.magnitude;
+                    var currentCenterToOrigin = Vector3.Scale(cornerSign, instance.m_Bounds.size * 0.5f);
+                    var pivotOffset = instance.m_PlaneRotation * currentCenterToOrigin;
                     return pivotOffset + instance.m_Bounds.center;
                 }
 
                 return m_Bounds.center;
             }
+        }
+
+        static float SignOrZero(float value)
+        {
+            if (value > 0f)
+                return 1f;
+            if (value < 0f)
+                return -1f;
+            return 0f;
         }
 
         int m_ControlID;

--- a/Runtime/Shapes/ProBuilderShape.cs
+++ b/Runtime/Shapes/ProBuilderShape.cs
@@ -69,6 +69,14 @@ namespace UnityEngine.ProBuilder.Shapes
 
         [SerializeField]
         Vector3 m_LocalCenter;
+
+        // Per axis, how far the pivot sits from the center as a fraction of the half-size: 0 for a
+        // Center pivot, 1 for a First Vertex pivot. Captured whenever the shape is fully rebuilt so
+        // that resizing (which only knows the new size, not what it was built with) can re-derive the
+        // center from the current size instead of keeping the previous size's stale center fixed.
+        [SerializeField]
+        Vector3 m_PivotRatio;
+
         public Bounds shapeLocalBounds => new Bounds(m_LocalCenter, size);
         public Bounds shapeWorldBounds => new Bounds(shapeWorldCenter, size);
 
@@ -104,7 +112,10 @@ namespace UnityEngine.ProBuilder.Shapes
             if(gameObject == null || gameObject.hideFlags == HideFlags.HideAndDontSave)
                 return;
 
-            Rebuild(mesh.transform.position, mesh.transform.rotation, new Bounds(shapeWorldCenter, size));
+            var newLocalCenter = Vector3.Scale(m_PivotRatio, size * 0.5f);
+            var newWorldCenter = mesh.transform.TransformPoint(newLocalCenter);
+
+            Rebuild(mesh.transform.position, mesh.transform.rotation, new Bounds(newWorldCenter, size));
         }
 
         internal void UpdateBounds(Bounds bounds)
@@ -121,8 +132,19 @@ namespace UnityEngine.ProBuilder.Shapes
             Rebuild();
             mesh.SetPivot(pivotPosition);
             m_LocalCenter = mesh.transform.InverseTransformPoint(bounds.center);
+            m_PivotRatio = new Vector3(
+                RatioOrZero(m_LocalCenter.x, bounds.size.x),
+                RatioOrZero(m_LocalCenter.y, bounds.size.y),
+                RatioOrZero(m_LocalCenter.z, bounds.size.z));
 
             m_UnmodifiedMeshVersion = mesh.versionIndex;
+        }
+
+        static float RatioOrZero(float localCenterComponent, float sizeComponent)
+        {
+            if (Mathf.Abs(sizeComponent) < 0.0001f)
+                return 0f;
+            return Mathf.Clamp(localCenterComponent / (sizeComponent * 0.5f), -1f, 1f);
         }
 
         internal void Rebuild(Bounds bounds, Quaternion rotation)

--- a/Tests/Editor/Editor/DrawShapeToolPivotOffsetTests.cs
+++ b/Tests/Editor/Editor/DrawShapeToolPivotOffsetTests.cs
@@ -44,6 +44,13 @@ public class DrawShapeToolPivotOffsetTests
         // duplicating at 1x1x-1 (matching a Stairs-style shape with a negative Z size).
         yield return new TestCaseData(new Vector3(2f, 2f, 2f), new Vector3(1f, 1f, -1f), new Vector3(-0.5f, -0.5f, 0.5f))
             .SetName("PreviewPivotPosition_NegativeAxisInOldSize_DoesNotFlipCurrentAxis");
+
+        // Drawn toward negative X (size.x negative), then duplicated unchanged: this gives a
+        // *positive* m_LastNonDuplicateCenterToOrigin.x alongside a *negative* current size.x - the
+        // exact combination that reverses the pivot onto the wrong corner if that stale vector's sign
+        // is multiplied against the current (still negative) size instead of driving off size alone.
+        yield return new TestCaseData(new Vector3(1.5f, -0.5f, -0.5f), new Vector3(-3f, 1f, 1f), new Vector3(1.5f, -0.5f, -0.5f))
+            .SetName("PreviewPivotPosition_NegativeDragDirection_DoesNotReversePivotCorner");
     }
 
     [TestCaseSource(nameof(PivotOffsetCases))]

--- a/Tests/Editor/Editor/DrawShapeToolPivotOffsetTests.cs
+++ b/Tests/Editor/Editor/DrawShapeToolPivotOffsetTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using NUnit.Framework;
 using UnityEditor;
 using UnityEditor.EditorTools;
@@ -28,29 +29,38 @@ public class DrawShapeToolPivotOffsetTests
         ToolManager.RestorePreviousPersistentTool();
     }
 
-    // Reproduces: create a shape with Pivot = First Vertex at one size (e.g. drag out a 4x4x4 cube),
-    // then place a duplicate (shift-click) at a different, smaller size (e.g. 1x1x1 after editing
-    // Shape Settings). The duplicate's pivot offset from its own bounds center must scale with the
-    // size of the duplicate being placed, not the size of the shape it was copied from.
-    [Test]
-    public void PreviewPivotPosition_ScalesWithCurrentBoundsSize_NotStaleDragSize()
+    // For a First Vertex pivot, the pivot always sits at bounds.center - size/2: the sign of `size`
+    // itself already encodes which side the shape extends toward, so the previous drag's recorded
+    // corner-to-center vector should have no bearing on where a same-or-different-sized duplicate's
+    // pivot lands. Both cases below place a duplicate of the same currentSize/expectedOffset, only
+    // the stale drag data differs, to prove that stale data can't leak into the result.
+    static IEnumerable<TestCaseData> PivotOffsetCases()
+    {
+        // Drawn previously as a 4x4x4 cube, now duplicating at 1x1x1 (Shape Settings edited down).
+        yield return new TestCaseData(new Vector3(-2f, -2f, -2f), Vector3.one, new Vector3(-0.5f, -0.5f, -0.5f))
+            .SetName("PreviewPivotPosition_AllPositiveOldSize_ScalesToCurrentSize");
+
+        // Drawn previously as an all-negative-size shape (e.g. dragged backwards on every axis), now
+        // duplicating at 1x1x-1 (matching a Stairs-style shape with a negative Z size).
+        yield return new TestCaseData(new Vector3(2f, 2f, 2f), new Vector3(1f, 1f, -1f), new Vector3(-0.5f, -0.5f, 0.5f))
+            .SetName("PreviewPivotPosition_NegativeAxisInOldSize_DoesNotFlipCurrentAxis");
+    }
+
+    [TestCaseSource(nameof(PivotOffsetCases))]
+    public void PreviewPivotPosition_ScalesWithCurrentBoundsSize_NotStaleDragSize(Vector3 lastCenterToOrigin, Vector3 currentSize, Vector3 expectedOffset)
     {
         var tool = DrawShapeTool.instance;
         Assume.That(tool, Is.Not.Null);
 
         tool.m_PlaneRotation = Quaternion.identity;
-
-        // Corner-to-center offset captured from a previously drawn 4x4x4 shape.
-        tool.m_LastNonDuplicateCenterToOrigin = new Vector3(-2f, -2f, -2f);
-
-        // Bounds for the shape currently being previewed/duplicated: size has since been changed to 1x1x1.
-        tool.m_Bounds = new Bounds(new Vector3(5f, 0.5f, 5f), Vector3.one);
+        tool.m_LastNonDuplicateCenterToOrigin = lastCenterToOrigin;
+        tool.m_Bounds = new Bounds(new Vector3(5f, 0.5f, 5f), currentSize);
 
         var pivot = tool.previewPivotPosition;
         var offset = pivot - tool.m_Bounds.center;
 
-        Assert.That(offset.x, Is.EqualTo(-0.5f).Within(0.0001f));
-        Assert.That(offset.y, Is.EqualTo(-0.5f).Within(0.0001f));
-        Assert.That(offset.z, Is.EqualTo(-0.5f).Within(0.0001f));
+        Assert.That(offset.x, Is.EqualTo(expectedOffset.x).Within(0.0001f));
+        Assert.That(offset.y, Is.EqualTo(expectedOffset.y).Within(0.0001f));
+        Assert.That(offset.z, Is.EqualTo(expectedOffset.z).Within(0.0001f));
     }
 }

--- a/Tests/Editor/Editor/DrawShapeToolPivotOffsetTests.cs
+++ b/Tests/Editor/Editor/DrawShapeToolPivotOffsetTests.cs
@@ -3,6 +3,7 @@ using UnityEditor;
 using UnityEditor.EditorTools;
 using UnityEditor.ProBuilder;
 using UnityEngine;
+using UnityEngine.ProBuilder;
 using ToolManager = UnityEditor.EditorTools.ToolManager;
 
 public class DrawShapeToolPivotOffsetTests

--- a/Tests/Editor/Editor/DrawShapeToolPivotOffsetTests.cs
+++ b/Tests/Editor/Editor/DrawShapeToolPivotOffsetTests.cs
@@ -1,0 +1,55 @@
+using NUnit.Framework;
+using UnityEditor;
+using UnityEditor.EditorTools;
+using UnityEditor.ProBuilder;
+using UnityEngine;
+using ToolManager = UnityEditor.EditorTools.ToolManager;
+
+public class DrawShapeToolPivotOffsetTests
+{
+    Pref<PivotLocation> m_PivotPref = new Pref<PivotLocation>("ShapeBuilder.PivotLocation.Cube", PivotLocation.Center);
+    PivotLocation m_PreviousPivot;
+
+    [SetUp]
+    public void SetUp()
+    {
+        ToolManager.SetActiveContext<GameObjectToolContext>();
+        ToolManager.SetActiveTool<CreateCubeTool>();
+
+        m_PreviousPivot = m_PivotPref.value;
+        m_PivotPref.SetValue(PivotLocation.FirstVertex);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        m_PivotPref.SetValue(m_PreviousPivot);
+        ToolManager.RestorePreviousPersistentTool();
+    }
+
+    // Reproduces: create a shape with Pivot = First Vertex at one size (e.g. drag out a 4x4x4 cube),
+    // then place a duplicate (shift-click) at a different, smaller size (e.g. 1x1x1 after editing
+    // Shape Settings). The duplicate's pivot offset from its own bounds center must scale with the
+    // size of the duplicate being placed, not the size of the shape it was copied from.
+    [Test]
+    public void PreviewPivotPosition_ScalesWithCurrentBoundsSize_NotStaleDragSize()
+    {
+        var tool = DrawShapeTool.instance;
+        Assume.That(tool, Is.Not.Null);
+
+        tool.m_PlaneRotation = Quaternion.identity;
+
+        // Corner-to-center offset captured from a previously drawn 4x4x4 shape.
+        tool.m_LastNonDuplicateCenterToOrigin = new Vector3(-2f, -2f, -2f);
+
+        // Bounds for the shape currently being previewed/duplicated: size has since been changed to 1x1x1.
+        tool.m_Bounds = new Bounds(new Vector3(5f, 0.5f, 5f), Vector3.one);
+
+        var pivot = tool.previewPivotPosition;
+        var offset = pivot - tool.m_Bounds.center;
+
+        Assert.That(offset.x, Is.EqualTo(-0.5f).Within(0.0001f));
+        Assert.That(offset.y, Is.EqualTo(-0.5f).Within(0.0001f));
+        Assert.That(offset.z, Is.EqualTo(-0.5f).Within(0.0001f));
+    }
+}

--- a/Tests/Editor/Editor/DrawShapeToolPivotOffsetTests.cs.meta
+++ b/Tests/Editor/Editor/DrawShapeToolPivotOffsetTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8d737f6e725194841a350eb63842ae47

--- a/Tests/Editor/Editor/ProBuilderShapeResizePivotTests.cs
+++ b/Tests/Editor/Editor/ProBuilderShapeResizePivotTests.cs
@@ -1,0 +1,47 @@
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.ProBuilder;
+using UnityEngine.ProBuilder.Shapes;
+using UObject = UnityEngine.Object;
+
+public class ProBuilderShapeResizePivotTests
+{
+    ProBuilderMesh m_PBMesh;
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (m_PBMesh != null)
+            UObject.DestroyImmediate(m_PBMesh.gameObject);
+    }
+
+    // Reproduces: draw a shape with Pivot = First Vertex (pivot sits at a corner, not the center),
+    // then edit its size directly in Shape Settings (e.g. 2x2x2 -> 1x1x1). The pivot/gizmo must stay
+    // where it was, and the shape must be rebuilt against that same pivot corner at the new size -
+    // not left floating at the old size's center. Both cases resize to the same (1,1,1) target, so
+    // both must land on the exact same expected center - proving the old size's sign (e.g. a Stairs
+    // shape drawn with a negative Z size) can't leak into the new center's placement.
+    [TestCase(2f, 2f, 2f, TestName = "AllPositiveInitialSize")]
+    [TestCase(2f, 2f, -2f, TestName = "NegativeAxisInInitialSize")]
+    public void UpdateShape_AfterResizeWithFirstVertexPivot_KeepsShapeAnchoredAtPivot(float initialX, float initialY, float initialZ)
+    {
+        m_PBMesh = ShapeFactory.Instantiate<Stairs>();
+        var shapeComponent = m_PBMesh.GetComponent<ProBuilderShape>();
+
+        var pivotPosition = Vector3.zero;
+        var initialSize = new Vector3(initialX, initialY, initialZ);
+        var initialBounds = new Bounds(pivotPosition + initialSize * 0.5f, initialSize);
+        shapeComponent.Rebuild(pivotPosition, Quaternion.identity, initialBounds);
+
+        // Simulate editing the size field in the Shape Settings inspector down to 1x1x1.
+        shapeComponent.size = Vector3.one;
+        shapeComponent.UpdateShape();
+
+        Assert.That(shapeComponent.transform.position, Is.EqualTo(pivotPosition));
+
+        var expectedCenter = pivotPosition + Vector3.one * 0.5f;
+        Assert.That(shapeComponent.shapeWorldCenter.x, Is.EqualTo(expectedCenter.x).Within(0.0001f));
+        Assert.That(shapeComponent.shapeWorldCenter.y, Is.EqualTo(expectedCenter.y).Within(0.0001f));
+        Assert.That(shapeComponent.shapeWorldCenter.z, Is.EqualTo(expectedCenter.z).Within(0.0001f));
+    }
+}

--- a/Tests/Editor/Editor/ProBuilderShapeResizePivotTests.cs.meta
+++ b/Tests/Editor/Editor/ProBuilderShapeResizePivotTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1687fe7e7fdacaf4fb39640e9566a107


### PR DESCRIPTION
## Summary

[[UUM-149791](https://jira.unity3d.com/browse/UUM-149791)] Fixed the First Vertex pivot ending up offset from the shape after resizing an existing shape or shift-duplicating one with
the Shape tool.


Original bug:
- **Shift-duplicate offset**: `DrawShapeTool.previewPivotPosition` normalized the drag-captured corner offset (`m_LastNonDuplicateCenterToOrigin`) and rescaled it by that same vector's own magnitude - a no-op that always reconstructed the offset using the size of whatever shape was last *dragged* out, ignoring the size of the shape actually being placed. Repro: draw a shape with Pivot = First Vertex, change its size (e.g. via Shape Settings), then shift-duplicate it - the new shape's pivot was offset using the previous shape's dimensions instead of its own.
- **Resize offset**: `ProBuilderShape.UpdateShape()` had the same class of bug one level down - it rebuilt a resized shape around its *stale* center (valid only for the previous size) instead of its pivot corner, so resizing an already-placed First-Vertex-pivoted shape via Shape Settings left the mesh floating away from its pivot/gizmo.

Fix:
- Both are now fixed with the same insight: for a First Vertex pivot, `center = pivot + size/2` holds **exactly**, regardless of the sign of `size` - there's no independent "corner choice" to reconstruct. (An intermediate fix that re-derived a corner *sign* from the stale center was still wrong for shapes with a negative size axis, e.g. a Stairs shape dragged backwards - `ProBuilderShape` now instead records the pivot-to-center ratio, per axis, which is exactly `0` or `1` regardless of size's sign, once at rebuild time, and re-derives the center from that ratio and the current size on every resize.)

<img width="1079" height="711" alt="firstcorner-pivot-fixed" src="https://github.com/user-attachments/assets/70b86a76-73f6-4c87-b2a1-6cf25e3dd2ba" />

## Test plan

Executed by @lopezt-unity :
- [x] `Tests/Editor/Editor/DrawShapeToolPivotOffsetTests.cs` - `previewPivotPosition` against both an all-positive and a negative-size-axis "last drawn shape", proving stale drag data can't leak into the duplicate's placement.
- [x] `Tests/Editor/Editor/ProBuilderShapeResizePivotTests.cs` - `UpdateShape()` resizing a First-Vertex-pivoted Stairs shape down, with both an all-positive and a negative-Z initial size, proving the shape stays anchored at its pivot after resize regardless of the original size's sign.
- [x] All cases run via Unity Test Runner (EditMode) and pass.
- [x] Manually reproduced and verified fixed in-editor: shift-duplicate after a Shape Settings resize, and resizing an existing First-Vertex-pivoted Stairs shape (including the negative-size-axis case from the screenshot).