### PR TITLE
Fix ProBuilderDefault and Checker materials incorrectly referencing the PB vertex color shader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- [UUM-150702] Fixed the ProBuilderDefault and Checker materials referencing a stale shader ID, causing ProBuilder meshes to render magenta when a scene was opened.
 - [UUM-148237] Fixed the "Lightmap UVs Settings" foldout in ProBuilder Preferences not opening when clicking its title.
 - [UUM-133528] Fixed an issue where using some UV Editor actions would clear a mesh's Lightmap UVs without regenerating them.
 - Fixed the Select Hidden (Select Back Faces) toggle icon missing from the Tool Settings overlay due to a filename casing mismatch.

--- a/Content/Material/Checker.mat
+++ b/Content/Material/Checker.mat
@@ -21,7 +21,7 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: Checker
-  m_Shader: {fileID: 4800000, guid: 8547ec39534635c4289065e5c5033f43, type: 3}
+  m_Shader: {fileID: -6465566751694194690, guid: 8547ec39534635c4289065e5c5033f43, type: 3}
   m_Parent: {fileID: 0}
   m_ModifiedSerializedProperties: 0
   m_ValidKeywords: []

--- a/Content/Resources/Materials/ProBuilderDefault.mat
+++ b/Content/Resources/Materials/ProBuilderDefault.mat
@@ -50,7 +50,7 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: ProBuilderDefault
-  m_Shader: {fileID: 4800000, guid: 8547ec39534635c4289065e5c5033f43, type: 3}
+  m_Shader: {fileID: -6465566751694194690, guid: 8547ec39534635c4289065e5c5033f43, type: 3}
   m_Parent: {fileID: 0}
   m_ModifiedSerializedProperties: 0
   m_ValidKeywords: []

--- a/Tests/Editor/Editor/BuiltinMaterialShaderReferenceTests.cs
+++ b/Tests/Editor/Editor/BuiltinMaterialShaderReferenceTests.cs
@@ -1,0 +1,67 @@
+using System.IO;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using PackageInfo = UnityEditor.PackageManager.PackageInfo;
+
+class BuiltinMaterialShaderReferenceTests
+{
+    const string k_ShaderGraphAssetPath = "Packages/com.unity.probuilder/Content/Shader/Standard Vertex Color.shadergraph";
+
+    static readonly Regex k_ShaderReference = new Regex(@"m_Shader: \{fileID: (-?\d+), guid: ([0-9a-f]{32})");
+
+    static readonly string[] k_MaterialAssetPaths =
+    {
+        "Packages/com.unity.probuilder/Content/Resources/Materials/ProBuilderDefault.mat",
+        "Packages/com.unity.probuilder/Content/Material/Checker.mat"
+    };
+
+    static string ResolveDiskPath(string assetPath)
+    {
+        var package = PackageInfo.FindForAssetPath(assetPath);
+
+        if (package == null)
+            return assetPath;
+
+        return package.resolvedPath + assetPath.Substring(package.assetPath.Length);
+    }
+
+    // UUM-150702
+    [Test]
+    [TestCaseSource(nameof(k_MaterialAssetPaths))]
+    public void SerializedShaderReferenceResolvesToShaderGraphShader(string materialAssetPath)
+    {
+        var shader = AssetDatabase.LoadAssetAtPath<Shader>(k_ShaderGraphAssetPath);
+        Assert.That(shader, Is.Not.Null, k_ShaderGraphAssetPath);
+
+        Assert.That(
+            AssetDatabase.TryGetGUIDAndLocalFileIdentifier(shader, out var shaderGuid, out long shaderLocalId),
+            Is.True,
+            k_ShaderGraphAssetPath);
+
+        var diskPath = ResolveDiskPath(materialAssetPath);
+        Assert.That(File.Exists(diskPath), Is.True, diskPath);
+
+        // Matches the material's serialized shader reference, for example:
+        // m_Shader: {fileID: -6465566751694194690, guid: 8547ec39534635c4289065e5c5033f43, type: 3}
+        var match = k_ShaderReference.Match(File.ReadAllText(diskPath));
+        Assert.That(match.Success, Is.True, materialAssetPath);
+
+        // Group 2 is guid, identifying the asset file itself.
+        Assert.That(match.Groups[2].Value, Is.EqualTo(shaderGuid), materialAssetPath);
+
+        // Group 1 is fileID, the shader's local identifier within the referenced asset.
+        Assert.That(long.Parse(match.Groups[1].Value), Is.EqualTo(shaderLocalId), materialAssetPath);
+    }
+
+    [Test]
+    [TestCaseSource(nameof(k_MaterialAssetPaths))]
+    public void LoadedMaterialHasSupportedShader(string materialAssetPath)
+    {
+        var material = AssetDatabase.LoadAssetAtPath<Material>(materialAssetPath);
+        Assert.That(material, Is.Not.Null, materialAssetPath);
+        Assert.That(material.shader, Is.Not.Null, materialAssetPath);
+        Assert.That(material.shader.name, Does.Not.StartWith("Hidden/InternalErrorShader"), materialAssetPath);
+    }
+}

--- a/Tests/Editor/Editor/BuiltinMaterialShaderReferenceTests.cs.meta
+++ b/Tests/Editor/Editor/BuiltinMaterialShaderReferenceTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 329300aa93144dbebcfd0ff3c8b5ae4f


### PR DESCRIPTION
### Purpose of this PR

PR fixes a regression (from https://github.com/Unity-Technologies/com.unity.probuilder/pull/686) where, after updating PB to 6.1.1 or above, meshes with materials that use the `PB6/Standard Vertex Color` shader (including the built-in `ProBuilderDefault.mat` and `Checker.mat`) would render in magenta. 

This happened because the breaking PR, after migrating large number of meta files, did not refresh the built-in materials, causing the link between the materials and the `Standard Vertex Color.shadergraph` asset to break. The migrated shgraph asset's meta file dropped: 
```
  fileIDToRecycleName:
    4800000: MainAsset
```
But the materials continued to point to 4800000: 
```
 m_Shader: {fileID: 4800000, guid: 8547ec39534635c4289065e5c5033f43, type: 3}
 ```
 

Various actions would indirectly fix the issue, for example, creating a new PB cube, due to it hitting codepath where the shared built-in material is assigned a newly loaded shader, fixing the broken reference, for example:

```
var material = (Material) Resources.Load("Materials/ProBuilderDefault", typeof(Material));
material.shader = Shader.Find("ProBuilder6/Standard Vertex Color");    <- overwrites the outdated reference
```

The fix updates the `ProBuilderDefault.mat` and `Checker.mat` assets to point to the correct fileID of the `PB6/Standard Vertex Color` shader.

### Links

**Jira:**. https://jira.unity3d.com/browse/UUM-150702

### Comments to Reviewers

[List known issues, planned work, provide any extra context for your code.]