### PR TITLE
Bring in trunk's CoreCLR compatibility changes (shadow-package sync)

### DIFF
--- a/Content/Shader/EdgePicker.shader
+++ b/Content/Shader/EdgePicker.shader
@@ -49,7 +49,7 @@ CGPROGRAM
                 return o;
             }
 
-            float4 frag (v2f i) : COLOR
+            float4 frag (v2f i) : SV_Target
             {
                 return i.color;
             }

--- a/Content/Shader/FaceHighlight.shader
+++ b/Content/Shader/FaceHighlight.shader
@@ -45,7 +45,7 @@ Shader "Hidden/ProBuilder/FaceHighlight"
                 return o;
             }
 
-            half4 frag (v2f i) : COLOR
+            half4 frag (v2f i) : SV_Target
             {
                 i.pos.xy = floor(i.pos.xy * 1) * .5;
                 float checker = -frac(i.pos.x + i.pos.y);

--- a/Content/Shader/FacePicker.shader
+++ b/Content/Shader/FacePicker.shader
@@ -41,7 +41,7 @@ Shader "Hidden/ProBuilder/FacePicker"
                 return o;
             }
 
-            float4 frag (v2f i) : COLOR
+            float4 frag (v2f i) : SV_Target
             {
                 return i.color;
             }

--- a/Content/Shader/HideVertices.shader
+++ b/Content/Shader/HideVertices.shader
@@ -33,7 +33,7 @@ Shader "Hidden/ProBuilder/HideVertices"
                 return o;
             }
 
-            half4 frag (v2f i) : COLOR
+            half4 frag (v2f i) : SV_Target
             {
                 return fixed4(0,0,0,0);
             }

--- a/Content/Shader/LineBillboard.shader
+++ b/Content/Shader/LineBillboard.shader
@@ -94,7 +94,7 @@ Shader "Hidden/ProBuilder/LineBillboard"
                 triStream.Append(geo_out);
             }
 
-            fixed4 frag (v2f i) : COLOR
+            fixed4 frag (v2f i) : SV_Target
             {
                 return i.color * _Color;
             }

--- a/Content/Shader/LineBillboardMetal.shader
+++ b/Content/Shader/LineBillboardMetal.shader
@@ -67,7 +67,7 @@ Shader "Hidden/ProBuilder/LineBillboardMetal"
                 return o;
             }
 
-            half4 frag (v2f i) : COLOR
+            half4 frag (v2f i) : SV_Target
             {
                 return _Color;
             }

--- a/Content/Shader/NormalPreview.shader
+++ b/Content/Shader/NormalPreview.shader
@@ -44,7 +44,7 @@ Shader "Hidden/ProBuilder/NormalPreview"
                 return o;
             }
 
-            half4 frag (v2f i) : COLOR
+            half4 frag (v2f i) : SV_Target
             {
                 return i.color;
             }

--- a/Content/Shader/PointBillboard.shader
+++ b/Content/Shader/PointBillboard.shader
@@ -118,7 +118,7 @@ Shader "Hidden/ProBuilder/PointBillboard"
                     triStream.Append(geo_out);
                 }
 
-                float4 frag(FS_INPUT input) : COLOR
+                float4 frag(FS_INPUT input) : SV_Target
                 {
                     return _Color * input.color;
                 }

--- a/Content/Shader/ReferenceUnlit.shader
+++ b/Content/Shader/ReferenceUnlit.shader
@@ -56,7 +56,7 @@ Shader "ProBuilder/Reference Unlit"
                 return o;
             }
 
-            half4 frag (v2f i) : COLOR
+            half4 frag (v2f i) : SV_Target
             {
                 return tex2D(_MainTex, i.uv);
             }

--- a/Content/Shader/ScrollHighlight.shader
+++ b/Content/Shader/ScrollHighlight.shader
@@ -54,7 +54,7 @@ Shader "Hidden/ProBuilder/ScrollHighlight" {
                 o.pos = UnityObjectToClipPos(v.vertex );
                 return o;
             }
-            float4 frag(VertexOutput i, float facing : VFACE) : COLOR {
+            float4 frag(VertexOutput i, float facing : VFACE) : SV_Target {
                 float isFrontFace = ( facing >= 0 ? 1 : 0 );
                 float faceSign = ( facing >= 0 ? 1 : -1 );
 ////// Lighting:

--- a/Content/Shader/SmoothingPreview.shader
+++ b/Content/Shader/SmoothingPreview.shader
@@ -47,7 +47,7 @@ Shader "Hidden/ProBuilder/SmoothingPreview"
                 return o;
             }
 
-            half4 frag (v2f i) : COLOR
+            half4 frag (v2f i) : SV_Target
             {
                 i.pos.xy = floor(i.pos.xy * 1) * .5;
                 float checker = -frac(i.pos.x + i.pos.y);

--- a/Content/Shader/TransparentOverlay.shader
+++ b/Content/Shader/TransparentOverlay.shader
@@ -50,7 +50,7 @@ Shader "Hidden/ProBuilder/TransparentOverlay"
                 return o;
             }
 
-            half4 frag (v2f i) : COLOR
+            half4 frag (v2f i) : SV_Target
             {
                 return tex2D(_MainTex, i.uv) * i.color;
             }

--- a/Content/Shader/UnlitSolidColor.shader
+++ b/Content/Shader/UnlitSolidColor.shader
@@ -44,7 +44,7 @@ Shader "ProBuilder/Unlit Solid Color"
                 return o;
             }
 
-            half4 frag (v2f i) : COLOR
+            half4 frag (v2f i) : SV_Target
             {
                 return _Color;
             }

--- a/Content/Shader/UnlitVertexColor.shader
+++ b/Content/Shader/UnlitVertexColor.shader
@@ -40,7 +40,7 @@ Shader "ProBuilder/UnlitVertexColor"
                 return o;
             }
 
-            half4 frag (v2f i) : COLOR
+            half4 frag (v2f i) : SV_Target
             {
                 return i.color;
             }

--- a/Content/Shader/VertexPicker.shader
+++ b/Content/Shader/VertexPicker.shader
@@ -65,7 +65,7 @@ CGPROGRAM
                 return o;
             }
 
-            float4 frag (v2f i) : COLOR
+            float4 frag (v2f i) : SV_Target
             {
                 return i.color;
             }

--- a/Content/Shader/VertexShader.shader
+++ b/Content/Shader/VertexShader.shader
@@ -71,7 +71,7 @@ Shader "Hidden/ProBuilder/VertexShader"
                 return o;
             }
 
-            half4 frag (v2f i) : COLOR
+            half4 frag (v2f i) : SV_Target
             {
                 return _Color;
             }

--- a/Tests/Runtime/MeshOps/BridgeEdgesTests.cs
+++ b/Tests/Runtime/MeshOps/BridgeEdgesTests.cs
@@ -6,9 +6,13 @@ using UnityEngine.ProBuilder.MeshOperations;
 using UnityEngine.ProBuilder.Shapes;
 using UnityEngine.ProBuilder.Tests;
 using UnityEngine.ProBuilder.Tests.Framework;
+#if UNITY_6000_7_OR_NEWER
 using UnityEngine.TestTools;
+#endif
 
+#if UNITY_6000_7_OR_NEWER
 [UnityCoreClrExplicitDisabled("https://jira.unity3d.com/browse/UUM-148933", "ProBuilder test mesh templates resolve their asset path from StackTrace calling-method info, which fails on CoreCLR")]
+#endif
 static class BridgeEdgesTests
 {
     [Test]

--- a/Tests/Runtime/MeshOps/BridgeEdgesTests.cs
+++ b/Tests/Runtime/MeshOps/BridgeEdgesTests.cs
@@ -6,7 +6,9 @@ using UnityEngine.ProBuilder.MeshOperations;
 using UnityEngine.ProBuilder.Shapes;
 using UnityEngine.ProBuilder.Tests;
 using UnityEngine.ProBuilder.Tests.Framework;
+using UnityEngine.TestTools;
 
+[UnityCoreClrExplicitDisabled("https://jira.unity3d.com/browse/UUM-148933", "ProBuilder test mesh templates resolve their asset path from StackTrace calling-method info, which fails on CoreCLR")]
 static class BridgeEdgesTests
 {
     [Test]

--- a/Tests/Runtime/MeshOps/CollapseVerticesTests.cs
+++ b/Tests/Runtime/MeshOps/CollapseVerticesTests.cs
@@ -5,9 +5,13 @@ using UnityEngine.ProBuilder.MeshOperations;
 using UnityEngine.ProBuilder.Shapes;
 using UnityEngine.ProBuilder.Tests;
 using UnityEngine.ProBuilder.Tests.Framework;
+#if UNITY_6000_7_OR_NEWER
 using UnityEngine.TestTools;
+#endif
 
+#if UNITY_6000_7_OR_NEWER
 [UnityCoreClrExplicitDisabled("https://jira.unity3d.com/browse/UUM-148933", "ProBuilder test mesh templates resolve their asset path from StackTrace calling-method info, which fails on CoreCLR")]
+#endif
 static class CollapseVerticesTests
 {
     [Test]

--- a/Tests/Runtime/MeshOps/CollapseVerticesTests.cs
+++ b/Tests/Runtime/MeshOps/CollapseVerticesTests.cs
@@ -5,7 +5,9 @@ using UnityEngine.ProBuilder.MeshOperations;
 using UnityEngine.ProBuilder.Shapes;
 using UnityEngine.ProBuilder.Tests;
 using UnityEngine.ProBuilder.Tests.Framework;
+using UnityEngine.TestTools;
 
+[UnityCoreClrExplicitDisabled("https://jira.unity3d.com/browse/UUM-148933", "ProBuilder test mesh templates resolve their asset path from StackTrace calling-method info, which fails on CoreCLR")]
 static class CollapseVerticesTests
 {
     [Test]

--- a/Tests/Runtime/MeshOps/DeleteElementsTests.cs
+++ b/Tests/Runtime/MeshOps/DeleteElementsTests.cs
@@ -8,7 +8,9 @@ using System.Collections.Generic;
 using UnityEngine.ProBuilder.Shapes;
 using UnityEngine.ProBuilder.Tests;
 using UnityEngine.ProBuilder.Tests.Framework;
+#if UNITY_6000_7_OR_NEWER
 using UnityEngine.TestTools;
+#endif
 
 static class DeleteElementsTests
 {
@@ -90,7 +92,9 @@ static class DeleteElementsTests
     }
 
     [Test]
+#if UNITY_6000_7_OR_NEWER
     [UnityCoreClrExplicitDisabled("https://jira.unity3d.com/browse/UUM-148933", "ProBuilder test mesh templates resolve their asset path from StackTrace calling-method info, which fails on CoreCLR")]
+#endif
     public static void DeleteFirstFace_CreatesValidMesh([ValueSource("shapeTypes")] Type shape)
     {
         var mesh = ShapeFactory.Instantiate(shape);

--- a/Tests/Runtime/MeshOps/DeleteElementsTests.cs
+++ b/Tests/Runtime/MeshOps/DeleteElementsTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using UnityEngine.ProBuilder.Shapes;
 using UnityEngine.ProBuilder.Tests;
 using UnityEngine.ProBuilder.Tests.Framework;
+using UnityEngine.TestTools;
 
 static class DeleteElementsTests
 {
@@ -89,6 +90,7 @@ static class DeleteElementsTests
     }
 
     [Test]
+    [UnityCoreClrExplicitDisabled("https://jira.unity3d.com/browse/UUM-148933", "ProBuilder test mesh templates resolve their asset path from StackTrace calling-method info, which fails on CoreCLR")]
     public static void DeleteFirstFace_CreatesValidMesh([ValueSource("shapeTypes")] Type shape)
     {
         var mesh = ShapeFactory.Instantiate(shape);

--- a/Tests/Runtime/MeshOps/ExtrudeTests.cs
+++ b/Tests/Runtime/MeshOps/ExtrudeTests.cs
@@ -81,7 +81,9 @@ class ExtrudeTests
     }
 
     [Test]
+#if UNITY_6000_7_OR_NEWER
     [UnityCoreClrExplicitDisabled("https://jira.unity3d.com/browse/UUM-148933", "ProBuilder test mesh templates resolve their asset path from StackTrace calling-method info, which fails on CoreCLR")]
+#endif
     public static void ExtrudeAllFaces_FaceNormal([ValueSource("m_AvailableShapeTypes")] Type shape)
     {
         var mesh = ShapeFactory.Instantiate(shape);
@@ -108,7 +110,9 @@ class ExtrudeTests
     }
 
     [Test]
+#if UNITY_6000_7_OR_NEWER
     [UnityCoreClrExplicitDisabled("https://jira.unity3d.com/browse/UUM-148933", "ProBuilder test mesh templates resolve their asset path from StackTrace calling-method info, which fails on CoreCLR")]
+#endif
     public static void ExtrudeAllFaces_IndividualFaces([ValueSource("m_AvailableShapeTypes")] Type shape)
     {
         var mesh = ShapeFactory.Instantiate(shape);
@@ -137,7 +141,9 @@ class ExtrudeTests
     }
 
     [Test]
+#if UNITY_6000_7_OR_NEWER
     [UnityCoreClrExplicitDisabled("https://jira.unity3d.com/browse/UUM-148933", "ProBuilder test mesh templates resolve their asset path from StackTrace calling-method info, which fails on CoreCLR")]
+#endif
     public static void ExtrudeAllFaces_VertexNormal([ValueSource("m_AvailableShapeTypes")] Type shape)
     {
         var mesh = ShapeFactory.Instantiate(shape);

--- a/Tests/Runtime/MeshOps/ExtrudeTests.cs
+++ b/Tests/Runtime/MeshOps/ExtrudeTests.cs
@@ -81,6 +81,7 @@ class ExtrudeTests
     }
 
     [Test]
+    [UnityCoreClrExplicitDisabled("https://jira.unity3d.com/browse/UUM-148933", "ProBuilder test mesh templates resolve their asset path from StackTrace calling-method info, which fails on CoreCLR")]
     public static void ExtrudeAllFaces_FaceNormal([ValueSource("m_AvailableShapeTypes")] Type shape)
     {
         var mesh = ShapeFactory.Instantiate(shape);
@@ -107,6 +108,7 @@ class ExtrudeTests
     }
 
     [Test]
+    [UnityCoreClrExplicitDisabled("https://jira.unity3d.com/browse/UUM-148933", "ProBuilder test mesh templates resolve their asset path from StackTrace calling-method info, which fails on CoreCLR")]
     public static void ExtrudeAllFaces_IndividualFaces([ValueSource("m_AvailableShapeTypes")] Type shape)
     {
         var mesh = ShapeFactory.Instantiate(shape);
@@ -135,6 +137,7 @@ class ExtrudeTests
     }
 
     [Test]
+    [UnityCoreClrExplicitDisabled("https://jira.unity3d.com/browse/UUM-148933", "ProBuilder test mesh templates resolve their asset path from StackTrace calling-method info, which fails on CoreCLR")]
     public static void ExtrudeAllFaces_VertexNormal([ValueSource("m_AvailableShapeTypes")] Type shape)
     {
         var mesh = ShapeFactory.Instantiate(shape);

--- a/Tests/Runtime/MeshOps/TextureUnwrapTests.cs
+++ b/Tests/Runtime/MeshOps/TextureUnwrapTests.cs
@@ -6,7 +6,9 @@ using UnityEngine.ProBuilder;
 using UnityEngine.ProBuilder.Shapes;
 using UnityEngine.ProBuilder.Tests;
 using UnityEngine.ProBuilder.Tests.Framework;
+using UnityEngine.TestTools;
 
+[UnityCoreClrExplicitDisabled("https://jira.unity3d.com/browse/UUM-148933", "ProBuilder test mesh templates resolve their asset path from StackTrace calling-method info, which fails on CoreCLR")]
 static class TextureUnwrapTests
 {
     static readonly Type[] offsetRotationShapes = new Type[]

--- a/Tests/Runtime/MeshOps/TextureUnwrapTests.cs
+++ b/Tests/Runtime/MeshOps/TextureUnwrapTests.cs
@@ -6,9 +6,13 @@ using UnityEngine.ProBuilder;
 using UnityEngine.ProBuilder.Shapes;
 using UnityEngine.ProBuilder.Tests;
 using UnityEngine.ProBuilder.Tests.Framework;
+#if UNITY_6000_7_OR_NEWER
 using UnityEngine.TestTools;
+#endif
 
+#if UNITY_6000_7_OR_NEWER
 [UnityCoreClrExplicitDisabled("https://jira.unity3d.com/browse/UUM-148933", "ProBuilder test mesh templates resolve their asset path from StackTrace calling-method info, which fails on CoreCLR")]
+#endif
 static class TextureUnwrapTests
 {
     static readonly Type[] offsetRotationShapes = new Type[]

--- a/Tests/Runtime/MeshOps/VertexColorTests.cs
+++ b/Tests/Runtime/MeshOps/VertexColorTests.cs
@@ -5,7 +5,9 @@ using UnityEngine.ProBuilder;
 using UnityEngine.ProBuilder.Shapes;
 using UnityEngine.ProBuilder.Tests;
 using UnityEngine.ProBuilder.Tests.Framework;
+using UnityEngine.TestTools;
 
+[UnityCoreClrExplicitDisabled("https://jira.unity3d.com/browse/UUM-148933", "ProBuilder test mesh templates resolve their asset path from StackTrace calling-method info, which fails on CoreCLR")]
 static class VertexColorTests
 {
     [Test]

--- a/Tests/Runtime/MeshOps/VertexColorTests.cs
+++ b/Tests/Runtime/MeshOps/VertexColorTests.cs
@@ -5,9 +5,13 @@ using UnityEngine.ProBuilder;
 using UnityEngine.ProBuilder.Shapes;
 using UnityEngine.ProBuilder.Tests;
 using UnityEngine.ProBuilder.Tests.Framework;
+#if UNITY_6000_7_OR_NEWER
 using UnityEngine.TestTools;
+#endif
 
+#if UNITY_6000_7_OR_NEWER
 [UnityCoreClrExplicitDisabled("https://jira.unity3d.com/browse/UUM-148933", "ProBuilder test mesh templates resolve their asset path from StackTrace calling-method info, which fails on CoreCLR")]
+#endif
 static class VertexColorTests
 {
     [Test]

--- a/Tests/Runtime/Shape/ShapeGeneratorTests.cs
+++ b/Tests/Runtime/Shape/ShapeGeneratorTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System;
 using UnityEngine.ProBuilder.Shapes;
 using UnityEngine.ProBuilder.Tests.Framework;
+using UnityEngine.TestTools;
 
 class ShapeGeneratorTests
 {
@@ -25,6 +26,7 @@ class ShapeGeneratorTests
     }
 
     [Test]
+    [UnityCoreClrExplicitDisabled("https://jira.unity3d.com/browse/UUM-148933", "ProBuilder test mesh templates resolve their asset path from StackTrace calling-method info, which fails on CoreCLR")]
     public void ShapeGenerator_MatchesTemplate([ValueSource("shapeTypes")] Type type)
     {
         ProBuilderMesh pb = ShapeFactory.Instantiate(type);

--- a/Tests/Runtime/Shape/ShapeGeneratorTests.cs
+++ b/Tests/Runtime/Shape/ShapeGeneratorTests.cs
@@ -6,7 +6,9 @@ using System.Collections.Generic;
 using System;
 using UnityEngine.ProBuilder.Shapes;
 using UnityEngine.ProBuilder.Tests.Framework;
+#if UNITY_6000_7_OR_NEWER
 using UnityEngine.TestTools;
+#endif
 
 class ShapeGeneratorTests
 {
@@ -26,7 +28,9 @@ class ShapeGeneratorTests
     }
 
     [Test]
+#if UNITY_6000_7_OR_NEWER
     [UnityCoreClrExplicitDisabled("https://jira.unity3d.com/browse/UUM-148933", "ProBuilder test mesh templates resolve their asset path from StackTrace calling-method info, which fails on CoreCLR")]
+#endif
     public void ShapeGenerator_MatchesTemplate([ValueSource("shapeTypes")] Type type)
     {
         ProBuilderMesh pb = ShapeFactory.Instantiate(type);

--- a/Tests/Runtime/Type/VertexTests.cs
+++ b/Tests/Runtime/Type/VertexTests.cs
@@ -4,7 +4,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System;
 using UnityEngine.ProBuilder;
+#if UNITY_6000_7_OR_NEWER
 using UnityEngine.TestTools;
+#endif
 
 static class TestHashUtility
 {
@@ -57,7 +59,9 @@ static class IntVectorTests
     }
 
     [Test]
+#if UNITY_6000_7_OR_NEWER
     [UnityCoreClrExplicitDisabled("https://jira.unity3d.com/browse/UUM-148935", "ProBuilder IntVec3/VectorHash float hashing produces different values on CoreCLR")]
+#endif
     public static void TestHashCollisions_IVEC3()
     {
 #if UNITY_EDITOR_OSX
@@ -70,7 +74,9 @@ static class IntVectorTests
     }
 
     [Test]
+#if UNITY_6000_7_OR_NEWER
     [UnityCoreClrExplicitDisabled("https://jira.unity3d.com/browse/UUM-148935", "ProBuilder IntVec3/VectorHash float hashing produces different values on CoreCLR")]
+#endif
     public static void TestVectorHashOverflow()
     {
 #if UNITY_EDITOR_OSX
@@ -91,7 +97,9 @@ static class IntVectorTests
     }
 
     [Test]
+#if UNITY_6000_7_OR_NEWER
     [UnityCoreClrExplicitDisabled("https://jira.unity3d.com/browse/UUM-148935", "ProBuilder IntVec3/VectorHash float hashing produces different values on CoreCLR")]
+#endif
     public static void TestComparison_IVEC3()
     {
 #if UNITY_EDITOR_OSX

--- a/Tests/Runtime/Type/VertexTests.cs
+++ b/Tests/Runtime/Type/VertexTests.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System;
 using UnityEngine.ProBuilder;
+using UnityEngine.TestTools;
 
 static class TestHashUtility
 {
@@ -56,6 +57,7 @@ static class IntVectorTests
     }
 
     [Test]
+    [UnityCoreClrExplicitDisabled("https://jira.unity3d.com/browse/UUM-148935", "ProBuilder IntVec3/VectorHash float hashing produces different values on CoreCLR")]
     public static void TestHashCollisions_IVEC3()
     {
 #if UNITY_EDITOR_OSX
@@ -68,6 +70,7 @@ static class IntVectorTests
     }
 
     [Test]
+    [UnityCoreClrExplicitDisabled("https://jira.unity3d.com/browse/UUM-148935", "ProBuilder IntVec3/VectorHash float hashing produces different values on CoreCLR")]
     public static void TestVectorHashOverflow()
     {
 #if UNITY_EDITOR_OSX
@@ -88,6 +91,7 @@ static class IntVectorTests
     }
 
     [Test]
+    [UnityCoreClrExplicitDisabled("https://jira.unity3d.com/browse/UUM-148935", "ProBuilder IntVec3/VectorHash float hashing produces different values on CoreCLR")]
     public static void TestComparison_IVEC3()
     {
 #if UNITY_EDITOR_OSX


### PR DESCRIPTION
## What this does

Trunk made some changes to keep ProBuilder working with Unity's new CoreCLR editor, and those changes got mirrored into this repo automatically by the shadow-package bot (see PR #695). This PR brings those changes into `master`, since that bot PR landed on `release/6.1` instead, which isn't where we actually do ongoing development anymore.

Two kinds of changes came from trunk:

1. **Shader fix**: 16 shader files had their fragment output changed from the old `COLOR` semantic to the modern `SV_Target` semantic. Purely a naming/compatibility fix, no visual or behavioral change.
2. **Disabling some tests under CoreCLR**: 8 test files got a new attribute (`UnityCoreClrExplicitDisabled`) added to tests that currently fail when Unity runs on CoreCLR instead of Mono. This doesn't fix the underlying issues, it just stops those specific tests from running in CoreCLR test passes until someone fixes the real problem (tracked in UUM-148933 and UUM-148935).

## What I changed on top of the raw trunk changes

The attribute used to disable those tests (`UnityCoreClrExplicitDisabled`) is brand new and only exists starting in Unity 6000.7. This package still supports Unity all the way back to 6000.0, so using that attribute unconditionally would have broken compilation of our whole test suite on any older, currently-supported Unity version.

I wrapped every use of that attribute in a `#if UNITY_6000_7_OR_NEWER` check, so:
- On Unity 6000.7 and newer, it behaves exactly as trunk intended (skips those tests under CoreCLR).
- On older Unity versions, the attribute is simply left out. That's fine, since CoreCLR isn't even an option on those older versions, so there's nothing to disable there.

## Why master and not release/6.1

The shadow-package bot's PR (#695) targets `release/6.1`, but that branch diverged from `master` a while back and isn't where new package work lands. Posted a question in #devs-pets about whether the bot's sync target should change, or if this manual "catch it and move it to master" step is expected going forward.

## Testing

No functional behavior changes for supported use cases — this only affects shader semantics (cosmetic naming fix) and test execution under CoreCLR specifically. Recommend a normal CI run to confirm the test assembly still compiles cleanly on the oldest supported Editor version as well as on 6000.7+.